### PR TITLE
Codex/harden GitHub pr run gate

### DIFF
--- a/skills/github-pr/SKILL.md
+++ b/skills/github-pr/SKILL.md
@@ -20,38 +20,51 @@ Focus on behavior, risk, verification evidence, and deterministic comment resolu
 6. Open or update PR.
 7. Run review loop until merge readiness criteria are met.
 
+## Review Parameters
+
+1. Poll interval: `POLL_SECONDS` (default `300`).
+2. Quiet window interval count: `QUIET_POLL_INTERVALS` (default `2`).
+3. Quiet window duration is `POLL_SECONDS * QUIET_POLL_INTERVALS`.
+
+## Comment Classification (Canonical)
+
+1. Actionable comments:
+- Inline review comments and concrete issue comments requesting code or documentation changes.
+2. Non-actionable comments:
+- "review in progress", rate-limit notices, summaries/walkthroughs, ads/tips, and informational status updates.
+3. If a status-style comment includes a concrete requested change, treat it as actionable.
+
 ## Run Completion Gate
 
 Do not end the skill run while either condition is true:
 
-1. Any review/check is still in progress (for example CodeRabbit pending, Sourcery in progress, required checks pending).
+1. Any review/check is still in progress (for example, CodeRabbit pending, Sourcery in progress, required checks pending).
 2. Any actionable comment remains unresolved.
 
 Only end the run when all are true:
 
-1. No in-progress review/check statuses remain.
-2. No unresolved actionable comments remain.
-3. No new actionable comments have appeared during at least 2 poll intervals.
+1. All review and check statuses have completed.
+2. All actionable comments have been resolved.
+3. No new actionable comments have appeared for at least `QUIET_POLL_INTERVALS` poll intervals.
+
+Use the `Round Completion Heuristic` (from `references/review-loop-commands.md`) to determine when one review round has ended. Then apply this `Run Completion Gate` to decide whether to start another round or end the full skill run.
 
 ## Review Loop Protocol
 
-1. Poll PR state for new reviews/comments and check results every 5 minutes.
+1. Poll PR state for new reviews/comments and check results every `POLL_SECONDS` seconds.
 2. Detect end of current round with this heuristic:
 - All checks are complete (no pending required checks).
-- No new AI-reviewer comments for a quiet window of at least 2 poll intervals (10 minutes).
-- At least one signal from expected AI reviewers on current head commit when possible.
+- No new actionable comments (from any reviewer, human or AI) for at least `QUIET_POLL_INTERVALS` poll intervals.
+- At least one signal from expected reviewers (required human reviewers and/or configured AI reviewers) on current head commit when possible.
 3. Build unresolved comment queue from review comments and issue comments.
-4. Classify comments before acting:
-- Actionable: inline review comments and concrete issue comments that request code/documentation changes.
-- Non-actionable: "review in progress", rate-limit notices, summaries/walkthroughs, ads/tips, and informational status updates.
-- Do not treat non-actionable comments as blockers.
+4. Classify comments using `Comment Classification (Canonical)` before acting.
 5. For each unresolved actionable comment:
 - Add a thumbs-up reaction first.
 - Then either fix in code or reply with a technical rebuttal.
 6. Never use "push to later feature" as the reason to skip a valid fix.
 7. If rejecting a comment, provide specific evidence: incorrect assumption, constraint conflict, duplicate, or already addressed.
 8. Push updates, post round summary, and request re-review.
-9. Sleep 5 minutes and re-poll.
+9. Sleep `POLL_SECONDS` seconds and re-poll.
 10. Repeat until run completion gate is satisfied.
 
 Multiple rounds per PR are normal and expected.

--- a/skills/github-pr/references/review-loop-commands.md
+++ b/skills/github-pr/references/review-loop-commands.md
@@ -9,6 +9,7 @@ OWNER_REPO="<owner>/<repo>" # e.g. garethbaumgart/money-tracker
 PR_NUMBER="<pr-number>"
 AI_REVIEWERS_REGEX="copilot|coderabbit|sourcery"
 POLL_SECONDS=300
+QUIET_POLL_INTERVALS=2
 ```
 
 ## Poll PR State
@@ -82,14 +83,14 @@ If a reaction already exists, ignore duplicate-reaction errors and continue.
 Treat a review round as complete when all are true:
 
 1. No pending required checks.
-2. No new actionable AI reviewer comments for at least 2 poll intervals.
-3. No unresolved actionable comments remain in queue.
+2. No new actionable comments (human or AI) for at least `QUIET_POLL_INTERVALS` poll intervals.
+3. All actionable comments in the queue have been resolved.
 
 Then push next iteration summary or mark PR merge-ready.
 
 ## Non-Actionable Comment Patterns
 
-Do not block on comments matching these patterns unless they include a concrete requested change:
+Use `Comment Classification (Canonical)` from `skills/github-pr/SKILL.md` as the source of truth. Do not block on comments matching these patterns unless they include a concrete requested change:
 
 1. Review-in-progress status messages.
 2. Rate-limit notices.
@@ -99,6 +100,7 @@ Do not block on comments matching these patterns unless they include a concrete 
 ## Polling Loop Skeleton
 
 ```bash
+quiet_count=0
 while true; do
   # 1) Poll PR/check status
   gh pr view "$PR_NUMBER" --repo "$OWNER_REPO" \
@@ -108,9 +110,16 @@ while true; do
   gh api --paginate "repos/$OWNER_REPO/pulls/$PR_NUMBER/comments?per_page=100"
   gh api --paginate "repos/$OWNER_REPO/issues/$PR_NUMBER/comments?per_page=100"
 
-  # 3) If actionable comments exist: react + fix/rebut + push + reply
-  # 4) If no pending checks and no actionable comments for this interval: break
+  # 3) If actionable comments exist:
+  #    - react + fix/rebut + push + reply
+  #    - quiet_count=0
+  # 4) Else if pending checks exist:
+  #    - quiet_count=0
+  # 5) Else (no pending checks and no actionable comments):
+  #    - quiet_count=$((quiet_count + 1))
+  # 6) Break only when quiet_count >= QUIET_POLL_INTERVALS
 
+  [ "$quiet_count" -ge "$QUIET_POLL_INTERVALS" ] && break
   sleep "$POLL_SECONDS"
 done
 ```


### PR DESCRIPTION
## Summary by Sourcery

Clarify and harden the GitHub PR review loop by introducing an explicit completion gate and tightening polling and comment-classification rules.

Documentation:
- Document a run completion gate that requires all checks complete, no unresolved actionable comments, and a quiet period before ending the skill run.
- Clarify polling cadence, quiet-window definition, and the distinction between actionable and non-actionable comments in the review loop protocol.
- Add reference guidance and a shell polling-loop skeleton for repeatedly checking PR status and comments without blocking on non-actionable messages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated PR review workflow: added a Run Completion Gate that defines when a review may end (no in-progress reviews, no unresolved actionable comments, and a quiet-window).
  * Introduced comment classification (actionable vs non-actionable) and revised round-handling to reclassify unresolved comments before acting.
  * Specified configurable polling cadence and quiet-window logic, plus new sections for output contract, quality rules, required pre-PR checks, and multi-round expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->