### PR TITLE
chore: enforce PR review-loop completion gate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,7 @@ A skill is a set of local instructions stored in a `SKILL.md` file.
 - For any Flutter UI or theming task, default to `flutter-ux-theming` unless the user explicitly asks for a different approach.
 - For any backend/API implementation or refactor task, default to `backend-ddd-vertical-slice` unless the user explicitly asks for a different approach.
 - If multiple skills apply, use the minimal set and apply them in sequence.
+- For implementation + PR tasks, prefer explicit completion prompts such as: `Implement issue #<n>, open PR, then continue review rounds until required checks pass and actionable comments are resolved (or I say stop).`
 - Read only the needed sections/files from each skill to keep context lean.
 - Prefer bundled `scripts/` and `references/` inside skills over rewriting the same workflow repeatedly.
 - If a skill path is missing or unreadable, continue with a direct fallback workflow and note the gap.

--- a/skills/github-pr/SKILL.md
+++ b/skills/github-pr/SKILL.md
@@ -19,6 +19,19 @@ Focus on behavior, risk, verification evidence, and deterministic comment resolu
 5. Produce PR title, PR body, and reviewer checklist.
 6. Open or update PR.
 7. Run review loop until merge readiness criteria are met.
+8. Do not stop at "PR opened"; continue polling and resolving reviews/checks unless the user explicitly asks to stop.
+
+## Completion Gate (Required)
+
+A PR task is not complete until one of these is true:
+
+1. Merge-ready state reached:
+- No pending required checks.
+- No unresolved actionable review comments (PR review comments or issue comments).
+- AI-reviewer quiet window reached (default 10 minutes with no new actionable comments).
+2. User explicitly asks to stop before merge-ready.
+
+If merge-ready is not reached in the current turn, report exact blocking state and continue the loop on next request.
 
 ## Review Loop Protocol
 


### PR DESCRIPTION
## Summary by Sourcery

Clarify and enforce that GitHub PR tasks must continue through the review loop until merge-ready conditions are met or the user explicitly stops them.

Enhancements:
- Document a required completion gate for PR tasks, defining merge-ready criteria and behavior when those criteria are not yet met.
- Update global agent guidance to prefer explicit implementation-plus-PR prompts that include continuing review rounds until checks pass and comments are resolved.