### PR TITLE
Update github-pr skill to avoid @copilot review mentions

### DIFF
--- a/skills/github-pr/SKILL.md
+++ b/skills/github-pr/SKILL.md
@@ -20,7 +20,8 @@ Focus on behavior, risk, verification evidence, and deterministic comment resolu
 6. Open or update PR.
 7. Run review loop until merge readiness criteria are met.
 8. After each push in the review loop, explicitly trigger Copilot re-review for the new PR head.
-9. Do not stop at "PR opened"; continue polling and resolving reviews/checks unless the user explicitly asks to stop.
+9. Never post `@copilot review`; use reviewer-request APIs only to avoid triggering coding-agent PR creation.
+10. Do not stop at "PR opened"; continue polling and resolving reviews/checks unless the user explicitly asks to stop.
 
 ## Completion Gate (Required)
 
@@ -74,7 +75,7 @@ Rules:
 - If no such comments exist for current head, set value to `null` (this counts as present, not omitted) and treat the AI quiet-window condition as satisfied for this metric.
 
 4. `copilot_rerequested_on_head`
-- Set `true` only when a Copilot re-review trigger action is recorded for the current `headRefOid` (for example, reviewer-request API call accepted on current head, or `@copilot review` comment posted after the push that produced current `headRefOid`).
+- Set `true` only when a Copilot reviewer-request action is recorded for the current `headRefOid` (for example, reviewer-request API call accepted on current head).
 - Set `false` if no explicit trigger can be proven for current head.
 
 ### Freshness Rules (Repoll Required)
@@ -166,9 +167,10 @@ Use the `Round Completion Heuristic` (from `references/review-loop-commands.md`)
 7. If rejecting a comment, provide specific evidence: incorrect assumption, constraint conflict, duplicate, or already addressed.
 8. Push updates, post round summary, and request re-review.
 9. Explicitly trigger Copilot re-review on each pushed head using command patterns in `references/review-loop-commands.md`.
-10. Verify whether Copilot produced a review signal for current `headRefOid`; if not, keep polling through the quiet window and report the exact state.
-11. Sleep `POLL_SECONDS` seconds and re-poll.
-12. Repeat until run completion gate is satisfied.
+10. Do not trigger Copilot using PR/issue comment mentions.
+11. Verify whether Copilot produced a review signal for current `headRefOid`; if not, keep polling through the quiet window and report the exact state.
+12. Sleep `POLL_SECONDS` seconds and re-poll.
+13. Repeat until run completion gate is satisfied.
 
 Multiple rounds per PR are normal and expected.
 

--- a/skills/github-pr/references/review-loop-commands.md
+++ b/skills/github-pr/references/review-loop-commands.md
@@ -51,7 +51,7 @@ gh api --paginate "repos/$OWNER_REPO/issues/$PR_NUMBER/comments?per_page=100" \
 
 ## Trigger Copilot Re-Review After Each Push
 
-Try requesting Copilot as a reviewer first. If that is unsupported in the repository, fall back to mention-trigger:
+Request Copilot as a reviewer only. Do not fall back to PR comment mentions such as `@copilot review` because that can trigger coding-agent behavior in some repositories.
 
 ```bash
 triggered="false"
@@ -62,7 +62,7 @@ if gh api --method POST "repos/$OWNER_REPO/pulls/$PR_NUMBER/requested_reviewers"
 fi
 
 if [ "$triggered" != "true" ]; then
-  gh pr comment "$PR_NUMBER" --repo "$OWNER_REPO" --body "@copilot review"
+  echo "Copilot reviewer request unsupported; skipping Copilot re-review trigger for this head."
 fi
 ```
 
@@ -138,7 +138,7 @@ while true; do
   gh api --paginate "repos/$OWNER_REPO/issues/$PR_NUMBER/comments?per_page=100"
 
   # 3) If actionable comments exist:
-  #    - react + fix/rebut + push + reply + trigger Copilot re-review
+  #    - react + fix/rebut + push + reply + trigger Copilot re-review (reviewer-request API only)
   #    - quiet_count=0
   # 4) Else if pending checks or pending Copilot signal on current head exist:
   #    - quiet_count=0


### PR DESCRIPTION
## Summary
- Updates the `$github-pr` skill to explicitly prohibit posting `@copilot review`.
- Removes the fallback mention trigger from review-loop commands.
- Keeps Copilot re-review triggering limited to reviewer-request API only.

## Why
- In this repository, `@copilot review` invokes Copilot SWE agent behavior that opens draft fix PRs instead of review-only comments.
- The PR workflow should request review signals without spawning unsolicited implementation PRs.

## Behavior Changes
- `skills/github-pr/SKILL.md`
  - Adds a hard rule: never post `@copilot review`.
  - Tightens `copilot_rerequested_on_head` derivation to reviewer-request actions only.
  - Adds explicit protocol step prohibiting PR/issue comment mention triggers.
- `skills/github-pr/references/review-loop-commands.md`
  - Replaces mention fallback with a skip/log message when reviewer request is unsupported.
  - Clarifies polling loop note to use reviewer-request API only.

## Risk
- Low: documentation/skill workflow update only.
- Main tradeoff: repos that do not support reviewer-request API will skip Copilot re-review trigger rather than fallback to mentions.

## Test Evidence
- Manual verification:
  - Confirmed no `@copilot review` fallback remains in `$github-pr` references.
  - Confirmed workflow explicitly disallows mention-based triggers.
- Commands:
  - `rg -n "@copilot review|requested_reviewers|copilot_rerequested_on_head" skills/github-pr -S`
  - `git diff -- skills/github-pr/SKILL.md skills/github-pr/references/review-loop-commands.md`

## Reviewer Focus
- Validate that all Copilot trigger guidance is API-only and no mention fallback remains.
- Validate numbering/consistency in the updated workflow sections.

## Summary by Sourcery

Clarify the github-pr skill’s review loop so Copilot re-review is triggered only via reviewer-request APIs and never via @copilot review mentions.

Enhancements:
- Add explicit rules in the github-pr skill prohibiting @copilot review mentions and mandating reviewer-request API usage for Copilot re-review.
- Tighten the definition of copilot_rerequested_on_head to rely solely on reviewer-request actions on the current head.
- Clarify and renumber review loop workflow steps to call out API-only re-review triggers and avoid mention-based triggers.

Documentation:
- Update review-loop command reference to remove mention-based fallback, log when reviewer requests are unsupported, and document API-only re-review behavior.