### PR TITLE
Normalize GitHub issue label taxonomy

### DIFF
--- a/.github/workflows/issue-lifecycle-labels.yml
+++ b/.github/workflows/issue-lifecycle-labels.yml
@@ -591,7 +591,7 @@ jobs:
             async function handlePullRequestReviewEvent() {
               const review = context.payload.review;
               if (!review || review.state.toLowerCase() !== 'changes_requested') {
-                core.info('No stage transition required for this review state.');
+                core.info('No lifecycle status transition required for this review state.');
                 return;
               }
 

--- a/docs/dev-guide/workflow-catalog.md
+++ b/docs/dev-guide/workflow-catalog.md
@@ -69,8 +69,8 @@ Avoid ad hoc status labels and avoid stacking more than one `status:*` label on 
 
 ## PR mode matrix
 
-- Draft mode (default): PR package + verification evidence required; every PR runs an immediate full review pass after opening. A second pre-merge full pass is required only when the change is broad/high-concern or post-open review found findings; narrow clean PRs use a checklist pre-merge recheck.
-- AI-review-loop mode: merge-ready loop, comment resolution, and AI reviewer metrics required, plus immediate post-open pass and the same high-concern pre-merge pass/recheck requirements.
+- Draft mode (default): A PR package and verification evidence are required; every PR runs an immediate full review pass after opening. A second pre-merge full pass is required only when the change is broad/high-concern or post-open review found findings; narrow clean PRs use a checklist pre-merge recheck.
+- AI-review-loop mode: A merge-ready loop, comment resolution, and AI reviewer metrics are required, plus an immediate post-open pass and the same high-concern pre-merge pass/recheck requirements.
 
 ## PR review gate (all modes)
 
@@ -155,7 +155,7 @@ Parallel execution: execute issues {{1,2,3}} with dependency-aware sequencing, o
 
 After each PR is opened:
 - run an immediate full review pass on that PR
-- before merge, run another full review pass on latest head if post-open review has findings or risk is high; otherwise run a checklist recheck
+- before merge, run another full review pass on latest head if post-open review has findings or the change is broad/high-concern; otherwise run a checklist recheck
 ```
 
 ## GitHub event workflow review (recommended)

--- a/docs/github-issues/Phase-1-Foundations-Issues.md
+++ b/docs/github-issues/Phase-1-Foundations-Issues.md
@@ -606,4 +606,4 @@ Use this file to create GitHub issues for Phase 1 execution.
 1. `phase:1-foundations`
 2. `type:epic` or `type:feature`
 3. `lane:backend` / `lane:mobile` / `lane:platform` / `lane:cross-cutting`
-4. `status:triage` / `status:ready` / `status:in-progress` / `status:review` / `status:done`
+4. `status:triage` / `status:refined` / `status:ready` / `status:in-progress` / `status:blocked` / `status:review` / `status:done`


### PR DESCRIPTION
## Summary
- normalize the repository’s GitHub issue label policy around `phase:*`, `type:*`, `lane:*`, and `status:*`
- remove stale workflow-catalog guidance for priority, risk, and merge labels
- simplify the lifecycle workflow so it only manages the canonical lane/status label families

## Changes made
- removed legacy `area:*` and `stage:*` compatibility handling from `.github/workflows/issue-lifecycle-labels.yml`
- documented the canonical label policy and clarified that `merge-ready mode` is session metadata, not a GitHub label
- updated the Phase 1 issue-planning doc to use canonical `lane:*` and the full canonical `status:*` label set
- aligned the remaining workflow log/copy text with the canonical lifecycle terminology
- cleaned up deprecated GitHub labels and existing issue usage before opening this PR

## Acceptance criteria
- [x] Workflow docs define one canonical issue label policy.
- [x] Lifecycle automation matches that policy.
- [x] Deprecated issue labels are removed from the repo and from existing issues.

## Verification
- PR URL: https://github.com/garethbaumgart/money-tracker/pull/58
- Required checks run:
  - local: `actionlint .github/workflows/ci.yml .github/workflows/issue-lifecycle-labels.yml`
  - PR checks on final head: `workflow-lint`, `backend-quality`, `mobile-quality`, `security-baseline`, `required-checks-doc-parity`, `enforce-lifecycle`, `Sourcery review`
- AC mapped to tests:
  - AC-1/AC-2: local `actionlint` passed and the final-head CI workflow checks are green
  - AC-3: GitHub label and issue cleanup completed before PR creation and remained consistent through the final review pass
- Manual checks:
  - reviewed workflow `on:` triggers: unchanged
  - reviewed workflow permissions: unchanged and still narrowly scoped
  - reviewed timeout/failure behavior: unchanged
  - reviewed required-check implications: no required-check changes in `ci.yml`
- Known gaps:
  - `CodeRabbit` re-review on the latest head was rate-limited by the service
  - Copilot reviewer re-request is unsupported in this repo/environment
- Merge-readiness status:
  - final head `51b258a` has green required checks and resolved review threads
  - ready to merge

## Risk notes
- low runtime risk: no product runtime code changed
- moderate process impact: the lifecycle workflow now enforces canonical-only label handling, so future issue creation must use canonical labels only

## Review log
- post-open full review:
  - manual review on initial PR head `69fa321` found no self-review issues
  - `Sourcery` raised two grammar nits in `docs/dev-guide/workflow-catalog.md`; fixed in `51b258a`
  - `Copilot` raised four comments; three were fixed in `51b258a` and one was explicitly rebutted because reintroducing legacy-label self-healing would conflict with the chosen canonical-only policy
- pre-merge review/recheck:
  - final PR head `51b258a` reran green checks
  - all review threads were resolved after fix/rebuttal replies
  - `Sourcery review` completed successfully on the final head with no new actionable comments
  - `CodeRabbit` re-review was requested but the service returned a rate-limit status rather than actionable feedback

Closes #57
