### PR TITLE
Implement issue #52: auth endpoints + household invitations

### DIFF
--- a/backend/MoneyTracker.slnx
+++ b/backend/MoneyTracker.slnx
@@ -2,6 +2,7 @@
   <Folder Name="/src/">
     <Project Path="src/MoneyTracker.Api/MoneyTracker.Api.csproj" />
     <Project Path="src/Modules/Households/MoneyTracker.Modules.Households.csproj" />
+    <Project Path="src/Modules/Auth/MoneyTracker.Modules.Auth.csproj" />
   </Folder>
   <Folder Name="/tests/">
     <Project Path="tests/MoneyTracker.Api.Tests/MoneyTracker.Api.Tests.csproj" />

--- a/backend/openapi/openapi.v1.json
+++ b/backend/openapi/openapi.v1.json
@@ -1,78 +1,4 @@
 {
-  "components": {
-    "schemas": {
-      "CreateHouseholdRequest": {
-        "properties": {
-          "name": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "name"
-        ],
-        "type": "object"
-      },
-      "CreateHouseholdResponse": {
-        "properties": {
-          "createdAtUtc": {
-            "format": "date-time",
-            "type": "string"
-          },
-          "id": {
-            "format": "uuid",
-            "type": "string"
-          },
-          "name": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "id",
-          "name",
-          "createdAtUtc"
-        ],
-        "type": "object"
-      },
-      "ProblemDetails": {
-        "properties": {
-          "detail": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "instance": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "status": {
-            "format": "int32",
-            "pattern": "^-?(?:0|[1-9]\\d*)$",
-            "type": [
-              "null",
-              "integer",
-              "string"
-            ]
-          },
-          "title": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "type": {
-            "type": [
-              "null",
-              "string"
-            ]
-          }
-        },
-        "type": "object"
-      }
-    }
-  },
   "info": {
     "title": "MoneyTracker.Api | v1",
     "version": "1.0.0"
@@ -103,55 +29,80 @@
         ]
       }
     },
-    "/households": {
+    "/households/invitations/{invitationToken}/accept": {
       "post": {
-        "description": "Creates a household with a unique case-insensitive name.",
-        "operationId": "CreateHousehold",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/CreateHouseholdRequest"
-              }
+        "description": "Adds the authenticated user as a household member.",
+        "operationId": "AcceptHouseholdInvitation",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "invitationToken",
+            "required": true,
+            "schema": {
+              "type": "string"
             }
-          },
-          "required": true
-        },
+          }
+        ],
         "responses": {
-          "201": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/CreateHouseholdResponse"
-                }
-              }
-            },
-            "description": "Created"
-          },
-          "400": {
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            },
-            "description": "Bad Request"
-          },
-          "409": {
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            },
-            "description": "Conflict"
+          "200": {
+            "description": "OK"
           }
         },
-        "summary": "Create a household.",
+        "summary": "Accept a household invitation.",
         "tags": [
-          "MoneyTracker.Api"
+          "CreateHouseholdEndpoint"
+        ]
+      }
+    },
+    "/households/{householdId}/invite": {
+      "post": {
+        "description": "Only the household owner may issue an invitation token.",
+        "operationId": "InviteHouseholdMember",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "householdId",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "summary": "Invite a user to a household.",
+        "tags": [
+          "CreateHouseholdEndpoint"
+        ]
+      }
+    },
+    "/households/{householdId}/members": {
+      "get": {
+        "description": "Returns all members for an existing household.",
+        "operationId": "GetHouseholdMembers",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "householdId",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "summary": "Get household members.",
+        "tags": [
+          "CreateHouseholdEndpoint"
         ]
       }
     }
@@ -159,6 +110,9 @@
   "tags": [
     {
       "name": "MoneyTracker.Api"
+    },
+    {
+      "name": "CreateHouseholdEndpoint"
     }
   ]
 }

--- a/backend/src/Modules/Auth/Application/GetAuthenticatedUser/GetAuthenticatedUserHandler.cs
+++ b/backend/src/Modules/Auth/Application/GetAuthenticatedUser/GetAuthenticatedUserHandler.cs
@@ -1,0 +1,31 @@
+using MoneyTracker.Modules.Auth.Domain;
+
+namespace MoneyTracker.Modules.Auth.Application.GetAuthenticatedUser;
+
+public sealed class GetAuthenticatedUserHandler(IAuthRepository repository, TimeProvider timeProvider)
+{
+    public async Task<GetAuthenticatedUserResult> HandleAsync(
+        GetAuthenticatedUserQuery query,
+        CancellationToken cancellationToken)
+    {
+        var accessToken = query.AccessToken?.Trim() ?? string.Empty;
+        if (string.IsNullOrWhiteSpace(accessToken))
+        {
+            return GetAuthenticatedUserResult.Failure(AuthErrors.AccessTokenMissing, "Access token is missing.");
+        }
+
+        var session = await repository.GetSessionByAccessTokenAsync(accessToken, cancellationToken);
+        if (session is null)
+        {
+            return GetAuthenticatedUserResult.Failure(AuthErrors.AccessTokenInvalid, "Access token is invalid.");
+        }
+
+        var nowUtc = timeProvider.GetUtcNow();
+        if (session.AccessTokenExpiresAtUtc < nowUtc)
+        {
+            return GetAuthenticatedUserResult.Failure(AuthErrors.AccessTokenExpired, "Access token expired.");
+        }
+
+        return GetAuthenticatedUserResult.Success(session.UserId, session.UserEmail);
+    }
+}

--- a/backend/src/Modules/Auth/Application/GetAuthenticatedUser/GetAuthenticatedUserQuery.cs
+++ b/backend/src/Modules/Auth/Application/GetAuthenticatedUser/GetAuthenticatedUserQuery.cs
@@ -1,0 +1,3 @@
+namespace MoneyTracker.Modules.Auth.Application.GetAuthenticatedUser;
+
+public sealed record GetAuthenticatedUserQuery(string? AccessToken);

--- a/backend/src/Modules/Auth/Application/GetAuthenticatedUser/GetAuthenticatedUserResult.cs
+++ b/backend/src/Modules/Auth/Application/GetAuthenticatedUser/GetAuthenticatedUserResult.cs
@@ -1,0 +1,39 @@
+namespace MoneyTracker.Modules.Auth.Application.GetAuthenticatedUser;
+
+public sealed class GetAuthenticatedUserResult
+{
+    private GetAuthenticatedUserResult(bool isSuccess, Guid userId, string email, string? errorCode, string? errorMessage)
+    {
+        IsSuccess = isSuccess;
+        UserId = userId;
+        Email = email;
+        ErrorCode = errorCode;
+        ErrorMessage = errorMessage;
+    }
+
+    public bool IsSuccess { get; }
+    public Guid UserId { get; }
+    public string Email { get; }
+    public string? ErrorCode { get; }
+    public string? ErrorMessage { get; }
+
+    public static GetAuthenticatedUserResult Success(Guid userId, string email)
+    {
+        return new GetAuthenticatedUserResult(
+            isSuccess: true,
+            userId: userId,
+            email: email,
+            errorCode: null,
+            errorMessage: null);
+    }
+
+    public static GetAuthenticatedUserResult Failure(string errorCode, string errorMessage)
+    {
+        return new GetAuthenticatedUserResult(
+            isSuccess: false,
+            userId: Guid.Empty,
+            email: string.Empty,
+            errorCode: errorCode,
+            errorMessage: errorMessage);
+        }
+}

--- a/backend/src/Modules/Auth/Application/GetAuthenticatedUser/GetAuthenticatedUserResult.cs
+++ b/backend/src/Modules/Auth/Application/GetAuthenticatedUser/GetAuthenticatedUserResult.cs
@@ -35,5 +35,5 @@ public sealed class GetAuthenticatedUserResult
             email: string.Empty,
             errorCode: errorCode,
             errorMessage: errorMessage);
-        }
+    }
 }

--- a/backend/src/Modules/Auth/Application/Logout/LogoutSessionCommand.cs
+++ b/backend/src/Modules/Auth/Application/Logout/LogoutSessionCommand.cs
@@ -1,0 +1,3 @@
+namespace MoneyTracker.Modules.Auth.Application.Logout;
+
+public sealed record LogoutSessionCommand(string RefreshToken);

--- a/backend/src/Modules/Auth/Application/Logout/LogoutSessionHandler.cs
+++ b/backend/src/Modules/Auth/Application/Logout/LogoutSessionHandler.cs
@@ -1,0 +1,18 @@
+using MoneyTracker.Modules.Auth.Domain;
+
+namespace MoneyTracker.Modules.Auth.Application.Logout;
+
+public sealed class LogoutSessionHandler(IAuthRepository repository)
+{
+    public async Task<LogoutSessionResult> HandleAsync(LogoutSessionCommand command, CancellationToken cancellationToken)
+    {
+        var normalizedToken = command.RefreshToken?.Trim() ?? string.Empty;
+        if (string.IsNullOrWhiteSpace(normalizedToken))
+        {
+            return LogoutSessionResult.Success();
+        }
+
+        await repository.RemoveSessionByRefreshTokenAsync(normalizedToken, cancellationToken);
+        return LogoutSessionResult.Success();
+    }
+}

--- a/backend/src/Modules/Auth/Application/Logout/LogoutSessionResult.cs
+++ b/backend/src/Modules/Auth/Application/Logout/LogoutSessionResult.cs
@@ -1,0 +1,15 @@
+namespace MoneyTracker.Modules.Auth.Application.Logout;
+
+public sealed class LogoutSessionResult
+{
+    private LogoutSessionResult(bool isSuccess, string? errorCode = null)
+    {
+        IsSuccess = isSuccess;
+        ErrorCode = errorCode;
+    }
+
+    public bool IsSuccess { get; }
+    public string? ErrorCode { get; }
+
+    public static LogoutSessionResult Success() => new(isSuccess: true);
+}

--- a/backend/src/Modules/Auth/Application/RefreshSession/RefreshSessionCommand.cs
+++ b/backend/src/Modules/Auth/Application/RefreshSession/RefreshSessionCommand.cs
@@ -1,0 +1,3 @@
+namespace MoneyTracker.Modules.Auth.Application.RefreshSession;
+
+public sealed record RefreshSessionCommand(string RefreshToken);

--- a/backend/src/Modules/Auth/Application/RefreshSession/RefreshSessionHandler.cs
+++ b/backend/src/Modules/Auth/Application/RefreshSession/RefreshSessionHandler.cs
@@ -1,0 +1,53 @@
+using MoneyTracker.Modules.Auth.Domain;
+
+namespace MoneyTracker.Modules.Auth.Application.RefreshSession;
+
+public sealed class RefreshSessionHandler(IAuthRepository repository, TimeProvider timeProvider)
+{
+    public async Task<RefreshSessionResult> HandleAsync(RefreshSessionCommand command, CancellationToken cancellationToken)
+    {
+        var normalizedRefreshToken = command.RefreshToken?.Trim() ?? string.Empty;
+        if (string.IsNullOrWhiteSpace(normalizedRefreshToken))
+        {
+            return RefreshSessionResult.Failure(AuthErrors.ValidationError, "Refresh token is required.");
+        }
+
+        var nowUtc = timeProvider.GetUtcNow();
+        var existingSession = await repository.GetSessionByRefreshTokenAsync(normalizedRefreshToken, cancellationToken);
+        if (existingSession is null)
+        {
+            return RefreshSessionResult.Failure(AuthErrors.RefreshTokenInvalid, "Refresh token not found.");
+        }
+
+        if (existingSession.RefreshTokenExpiresAtUtc < nowUtc)
+        {
+            await repository.RemoveSessionByRefreshTokenAsync(existingSession.RefreshToken, cancellationToken);
+            return RefreshSessionResult.Failure(AuthErrors.RefreshTokenExpired, "Refresh token expired.");
+        }
+
+        var accessToken = Guid.NewGuid().ToString("N");
+        var refreshToken = Guid.NewGuid().ToString("N");
+        var newSession = new AuthSession(
+            existingSession.UserId,
+            existingSession.UserEmail,
+            accessToken,
+            nowUtc.Add(AuthPolicy.AccessTokenLifetime),
+            refreshToken,
+            nowUtc.Add(AuthPolicy.RefreshTokenLifetime),
+            nowUtc);
+
+        await repository.ReplaceSessionAsync(
+            existingSession.RefreshToken,
+            existingSession.AccessToken,
+            newSession,
+            cancellationToken);
+
+        return RefreshSessionResult.Success(new VerifyCode.AuthTokenSet(
+            existingSession.UserId,
+            existingSession.UserEmail,
+            accessToken,
+            newSession.AccessTokenExpiresAtUtc,
+            refreshToken,
+            newSession.RefreshTokenExpiresAtUtc));
+    }
+}

--- a/backend/src/Modules/Auth/Application/RefreshSession/RefreshSessionResult.cs
+++ b/backend/src/Modules/Auth/Application/RefreshSession/RefreshSessionResult.cs
@@ -1,0 +1,37 @@
+using MoneyTracker.Modules.Auth.Application.VerifyCode;
+
+namespace MoneyTracker.Modules.Auth.Application.RefreshSession;
+
+public sealed class RefreshSessionResult
+{
+    private RefreshSessionResult(bool isSuccess, AuthTokenSet? tokens, string? errorCode, string? errorMessage)
+    {
+        IsSuccess = isSuccess;
+        Tokens = tokens;
+        ErrorCode = errorCode;
+        ErrorMessage = errorMessage;
+    }
+
+    public bool IsSuccess { get; }
+    public AuthTokenSet? Tokens { get; }
+    public string? ErrorCode { get; }
+    public string? ErrorMessage { get; }
+
+    public static RefreshSessionResult Success(AuthTokenSet tokens)
+    {
+        return new RefreshSessionResult(
+            isSuccess: true,
+            tokens: tokens,
+            errorCode: null,
+            errorMessage: null);
+    }
+
+    public static RefreshSessionResult Failure(string errorCode, string errorMessage)
+    {
+        return new RefreshSessionResult(
+            isSuccess: false,
+            tokens: null,
+            errorCode: errorCode,
+            errorMessage: errorMessage);
+    }
+}

--- a/backend/src/Modules/Auth/Application/RequestAuthCode/RequestAuthCodeCommand.cs
+++ b/backend/src/Modules/Auth/Application/RequestAuthCode/RequestAuthCodeCommand.cs
@@ -1,0 +1,3 @@
+namespace MoneyTracker.Modules.Auth.Application.RequestAuthCode;
+
+public sealed record RequestAuthCodeCommand(string Email);

--- a/backend/src/Modules/Auth/Application/RequestAuthCode/RequestAuthCodeHandler.cs
+++ b/backend/src/Modules/Auth/Application/RequestAuthCode/RequestAuthCodeHandler.cs
@@ -1,0 +1,24 @@
+using MoneyTracker.Modules.Auth.Domain;
+
+namespace MoneyTracker.Modules.Auth.Application.RequestAuthCode;
+
+public sealed class RequestAuthCodeHandler(IAuthRepository repository, TimeProvider timeProvider)
+{
+    public async Task<RequestAuthCodeResult> HandleAsync(RequestAuthCodeCommand command, CancellationToken cancellationToken)
+    {
+        var normalizedEmail = AuthUser.NormalizeEmail(command.Email);
+        if (string.IsNullOrWhiteSpace(normalizedEmail))
+        {
+            return RequestAuthCodeResult.Validation("Email is required.");
+        }
+
+        var challenge = new AuthChallenge(
+            Guid.NewGuid().ToString("N"),
+            normalizedEmail,
+            timeProvider.GetUtcNow().Add(AuthPolicy.ChallengeLifetime));
+
+        await repository.AddChallengeAsync(challenge, cancellationToken);
+
+        return RequestAuthCodeResult.Success(challenge);
+    }
+}

--- a/backend/src/Modules/Auth/Application/RequestAuthCode/RequestAuthCodeResult.cs
+++ b/backend/src/Modules/Auth/Application/RequestAuthCode/RequestAuthCodeResult.cs
@@ -1,0 +1,37 @@
+using MoneyTracker.Modules.Auth.Domain;
+
+namespace MoneyTracker.Modules.Auth.Application.RequestAuthCode;
+
+public sealed class RequestAuthCodeResult
+{
+    private RequestAuthCodeResult(bool isSuccess, AuthChallenge? challenge, string? errorCode, string? errorMessage)
+    {
+        IsSuccess = isSuccess;
+        Challenge = challenge;
+        ErrorCode = errorCode;
+        ErrorMessage = errorMessage;
+    }
+
+    public bool IsSuccess { get; }
+    public AuthChallenge? Challenge { get; }
+    public string? ErrorCode { get; }
+    public string? ErrorMessage { get; }
+
+    public static RequestAuthCodeResult Success(AuthChallenge challenge)
+    {
+        return new RequestAuthCodeResult(
+            isSuccess: true,
+            challenge: challenge,
+            errorCode: null,
+            errorMessage: null);
+    }
+
+    public static RequestAuthCodeResult Validation(string message)
+    {
+        return new RequestAuthCodeResult(
+            isSuccess: false,
+            challenge: null,
+            errorCode: AuthErrors.ValidationError,
+            errorMessage: message);
+    }
+}

--- a/backend/src/Modules/Auth/Application/VerifyCode/AuthTokenSet.cs
+++ b/backend/src/Modules/Auth/Application/VerifyCode/AuthTokenSet.cs
@@ -1,0 +1,9 @@
+namespace MoneyTracker.Modules.Auth.Application.VerifyCode;
+
+public sealed record AuthTokenSet(
+    Guid UserId,
+    string Email,
+    string AccessToken,
+    DateTimeOffset AccessTokenExpiresAtUtc,
+    string RefreshToken,
+    DateTimeOffset RefreshTokenExpiresAtUtc);

--- a/backend/src/Modules/Auth/Application/VerifyCode/VerifyCodeCommand.cs
+++ b/backend/src/Modules/Auth/Application/VerifyCode/VerifyCodeCommand.cs
@@ -1,0 +1,3 @@
+namespace MoneyTracker.Modules.Auth.Application.VerifyCode;
+
+public sealed record VerifyCodeCommand(string Email, string ChallengeToken);

--- a/backend/src/Modules/Auth/Application/VerifyCode/VerifyCodeHandler.cs
+++ b/backend/src/Modules/Auth/Application/VerifyCode/VerifyCodeHandler.cs
@@ -1,0 +1,84 @@
+using MoneyTracker.Modules.Auth.Domain;
+
+namespace MoneyTracker.Modules.Auth.Application.VerifyCode;
+
+public sealed class VerifyCodeHandler(IAuthRepository repository, TimeProvider timeProvider)
+{
+    public async Task<VerifyCodeResult> HandleAsync(VerifyCodeCommand command, CancellationToken cancellationToken)
+    {
+        var normalizedEmail = AuthUser.NormalizeEmail(command.Email);
+        if (string.IsNullOrWhiteSpace(normalizedEmail))
+        {
+            return VerifyCodeResult.Failure(AuthErrors.ValidationError, "Email is required.");
+        }
+
+        if (string.IsNullOrWhiteSpace(command.ChallengeToken))
+        {
+            return VerifyCodeResult.Failure(AuthErrors.ValidationError, "Challenge token is required.");
+        }
+
+        var nowUtc = timeProvider.GetUtcNow();
+        var challenge = await repository.GetChallengeAsync(command.ChallengeToken, cancellationToken);
+        if (challenge is null)
+        {
+            return VerifyCodeResult.Failure(AuthErrors.ChallengeNotFound, "Challenge token not found.");
+        }
+
+        if (challenge.IsUsed)
+        {
+            return VerifyCodeResult.Failure(AuthErrors.ChallengeUsed, "Challenge token already used.");
+        }
+
+        if (challenge.IsExpired(nowUtc))
+        {
+            return VerifyCodeResult.Failure(AuthErrors.ChallengeExpired, "Challenge token expired.");
+        }
+
+        if (challenge.IsChallengeLocked())
+        {
+            return VerifyCodeResult.Failure(AuthErrors.ChallengeAttemptLimitReached, "Too many failed verification attempts.");
+        }
+
+        if (!challenge.IsMatchEmail(normalizedEmail))
+        {
+            challenge.RecordFailedAttempt();
+            await repository.AddChallengeAsync(challenge, cancellationToken);
+
+            return VerifyCodeResult.Failure(
+                AuthErrors.ChallengeEmailMismatch,
+                "Challenge email does not match the requested email.");
+        }
+
+        challenge.MarkUsed();
+        await repository.AddChallengeAsync(challenge, cancellationToken);
+
+        var user = await repository.GetOrCreateUserAsync(normalizedEmail, cancellationToken);
+        var issuedAtUtc = nowUtc;
+        var accessToken = GenerateToken();
+        var refreshToken = GenerateToken();
+
+        var session = new AuthSession(
+            user.Id,
+            user.Email,
+            accessToken,
+            issuedAtUtc.Add(AuthPolicy.AccessTokenLifetime),
+            refreshToken,
+            issuedAtUtc.Add(AuthPolicy.RefreshTokenLifetime),
+            issuedAtUtc);
+
+        await repository.AddSessionAsync(session, cancellationToken);
+
+        return VerifyCodeResult.Success(new AuthTokenSet(
+            user.Id,
+            user.Email,
+            accessToken,
+            session.AccessTokenExpiresAtUtc,
+            refreshToken,
+            session.RefreshTokenExpiresAtUtc));
+    }
+
+    private static string GenerateToken()
+    {
+        return Guid.NewGuid().ToString("N");
+    }
+}

--- a/backend/src/Modules/Auth/Application/VerifyCode/VerifyCodeResult.cs
+++ b/backend/src/Modules/Auth/Application/VerifyCode/VerifyCodeResult.cs
@@ -1,0 +1,41 @@
+using MoneyTracker.Modules.Auth.Domain;
+
+namespace MoneyTracker.Modules.Auth.Application.VerifyCode;
+
+public sealed class VerifyCodeResult
+{
+    private VerifyCodeResult(
+        bool isSuccess,
+        AuthTokenSet? tokens,
+        string? errorCode,
+        string? errorMessage)
+    {
+        IsSuccess = isSuccess;
+        Tokens = tokens;
+        ErrorCode = errorCode;
+        ErrorMessage = errorMessage;
+    }
+
+    public bool IsSuccess { get; }
+    public AuthTokenSet? Tokens { get; }
+    public string? ErrorCode { get; }
+    public string? ErrorMessage { get; }
+
+    public static VerifyCodeResult Success(AuthTokenSet tokens)
+    {
+        return new VerifyCodeResult(
+            isSuccess: true,
+            tokens: tokens,
+            errorCode: null,
+            errorMessage: null);
+    }
+
+    public static VerifyCodeResult Failure(string errorCode, string errorMessage)
+    {
+        return new VerifyCodeResult(
+            isSuccess: false,
+            tokens: null,
+            errorCode: errorCode,
+            errorMessage: errorMessage);
+    }
+}

--- a/backend/src/Modules/Auth/Domain/AuthChallenge.cs
+++ b/backend/src/Modules/Auth/Domain/AuthChallenge.cs
@@ -1,0 +1,42 @@
+namespace MoneyTracker.Modules.Auth.Domain;
+
+public sealed class AuthChallenge
+{
+    public AuthChallenge(string token, string email, DateTimeOffset expiresAtUtc)
+    {
+        Token = token;
+        Email = email;
+        ExpiresAtUtc = expiresAtUtc;
+    }
+
+    public string Token { get; }
+    public string Email { get; }
+    public DateTimeOffset ExpiresAtUtc { get; }
+    public int FailedAttempts { get; private set; }
+    public bool IsUsed { get; private set; }
+
+    public bool IsExpired(DateTimeOffset nowUtc)
+    {
+        return nowUtc >= ExpiresAtUtc;
+    }
+
+    public bool IsMatchEmail(string normalizedEmail)
+    {
+        return string.Equals(Email, normalizedEmail, StringComparison.OrdinalIgnoreCase);
+    }
+
+    public bool IsChallengeLocked()
+    {
+        return FailedAttempts >= AuthPolicy.MaxChallengeAttempts;
+    }
+
+    public void RecordFailedAttempt()
+    {
+        FailedAttempts++;
+    }
+
+    public void MarkUsed()
+    {
+        IsUsed = true;
+    }
+}

--- a/backend/src/Modules/Auth/Domain/AuthDomainException.cs
+++ b/backend/src/Modules/Auth/Domain/AuthDomainException.cs
@@ -1,0 +1,6 @@
+namespace MoneyTracker.Modules.Auth.Domain;
+
+public sealed class AuthDomainException(string code, string message) : Exception(message)
+{
+    public string Code { get; } = code;
+}

--- a/backend/src/Modules/Auth/Domain/AuthErrors.cs
+++ b/backend/src/Modules/Auth/Domain/AuthErrors.cs
@@ -1,0 +1,24 @@
+namespace MoneyTracker.Modules.Auth.Domain;
+
+public static class AuthErrors
+{
+    public const string ValidationError = "validation_error";
+    public const string ChallengeNotFound = "auth_challenge_not_found";
+    public const string ChallengeExpired = "auth_challenge_expired";
+    public const string ChallengeUsed = "auth_challenge_used";
+    public const string ChallengeEmailMismatch = "auth_challenge_email_mismatch";
+    public const string ChallengeAttemptLimitReached = "auth_challenge_attempt_limit_reached";
+    public const string AccessTokenMissing = "auth_access_token_missing";
+    public const string AccessTokenInvalid = "auth_access_token_invalid";
+    public const string AccessTokenExpired = "auth_access_token_expired";
+    public const string RefreshTokenInvalid = "auth_refresh_token_invalid";
+    public const string RefreshTokenExpired = "auth_refresh_token_expired";
+}
+
+public static class AuthPolicy
+{
+    public static readonly TimeSpan ChallengeLifetime = TimeSpan.FromMinutes(10);
+    public static readonly TimeSpan AccessTokenLifetime = TimeSpan.FromMinutes(15);
+    public static readonly TimeSpan RefreshTokenLifetime = TimeSpan.FromDays(7);
+    public const int MaxChallengeAttempts = 5;
+}

--- a/backend/src/Modules/Auth/Domain/AuthSession.cs
+++ b/backend/src/Modules/Auth/Domain/AuthSession.cs
@@ -1,0 +1,30 @@
+namespace MoneyTracker.Modules.Auth.Domain;
+
+public sealed class AuthSession
+{
+    public AuthSession(
+        Guid userId,
+        string userEmail,
+        string accessToken,
+        DateTimeOffset accessTokenExpiresAtUtc,
+        string refreshToken,
+        DateTimeOffset refreshTokenExpiresAtUtc,
+        DateTimeOffset issuedAtUtc)
+    {
+        UserId = userId;
+        UserEmail = userEmail;
+        AccessToken = accessToken;
+        AccessTokenExpiresAtUtc = accessTokenExpiresAtUtc;
+        RefreshToken = refreshToken;
+        RefreshTokenExpiresAtUtc = refreshTokenExpiresAtUtc;
+        IssuedAtUtc = issuedAtUtc;
+    }
+
+    public Guid UserId { get; }
+    public string UserEmail { get; }
+    public string AccessToken { get; }
+    public DateTimeOffset AccessTokenExpiresAtUtc { get; }
+    public string RefreshToken { get; }
+    public DateTimeOffset RefreshTokenExpiresAtUtc { get; }
+    public DateTimeOffset IssuedAtUtc { get; }
+}

--- a/backend/src/Modules/Auth/Domain/AuthUser.cs
+++ b/backend/src/Modules/Auth/Domain/AuthUser.cs
@@ -1,0 +1,29 @@
+namespace MoneyTracker.Modules.Auth.Domain;
+
+public sealed class AuthUser
+{
+    public AuthUser(Guid id, string email)
+    {
+        Id = id;
+        Email = email;
+    }
+
+    public Guid Id { get; }
+    public string Email { get; }
+
+    public static AuthUser Create(string email)
+    {
+        var normalizedEmail = NormalizeEmail(email);
+        if (string.IsNullOrWhiteSpace(normalizedEmail))
+        {
+            throw new AuthDomainException(AuthErrors.ValidationError, "Email is required.");
+        }
+
+        return new AuthUser(Guid.NewGuid(), normalizedEmail);
+    }
+
+    public static string NormalizeEmail(string? email)
+    {
+        return email?.Trim().ToLowerInvariant() ?? string.Empty;
+    }
+}

--- a/backend/src/Modules/Auth/Domain/IAuthRepository.cs
+++ b/backend/src/Modules/Auth/Domain/IAuthRepository.cs
@@ -1,0 +1,24 @@
+namespace MoneyTracker.Modules.Auth.Domain;
+
+public interface IAuthRepository
+{
+    Task AddChallengeAsync(AuthChallenge challenge, CancellationToken cancellationToken);
+
+    Task<AuthChallenge?> GetChallengeAsync(string challengeToken, CancellationToken cancellationToken);
+
+    Task<AuthUser> GetOrCreateUserAsync(string normalizedEmail, CancellationToken cancellationToken);
+
+    Task AddSessionAsync(AuthSession session, CancellationToken cancellationToken);
+
+    Task<AuthSession?> GetSessionByAccessTokenAsync(string accessToken, CancellationToken cancellationToken);
+
+    Task<AuthSession?> GetSessionByRefreshTokenAsync(string refreshToken, CancellationToken cancellationToken);
+
+    Task ReplaceSessionAsync(
+        string oldRefreshToken,
+        string oldAccessToken,
+        AuthSession newSession,
+        CancellationToken cancellationToken);
+
+    Task RemoveSessionByRefreshTokenAsync(string refreshToken, CancellationToken cancellationToken);
+}

--- a/backend/src/Modules/Auth/Infrastructure/InMemoryAuthRepository.cs
+++ b/backend/src/Modules/Auth/Infrastructure/InMemoryAuthRepository.cs
@@ -1,0 +1,145 @@
+using MoneyTracker.Modules.Auth.Domain;
+
+namespace MoneyTracker.Modules.Auth.Infrastructure;
+
+public sealed class InMemoryAuthRepository : IAuthRepository
+{
+    private readonly object _sync = new();
+    private readonly Dictionary<string, AuthChallenge> _challenges = new();
+    private readonly Dictionary<string, AuthSession> _sessionsByAccessToken = new();
+    private readonly Dictionary<string, AuthSession> _sessionsByRefreshToken = new();
+    private readonly Dictionary<string, AuthUser> _usersByEmail = new(StringComparer.OrdinalIgnoreCase);
+    private readonly Dictionary<Guid, AuthUser> _usersById = new();
+
+    public Task AddChallengeAsync(AuthChallenge challenge, CancellationToken cancellationToken)
+    {
+        if (cancellationToken.IsCancellationRequested)
+        {
+            return Task.FromCanceled(cancellationToken);
+        }
+
+        lock (_sync)
+        {
+            _challenges[challenge.Token] = challenge;
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public Task<AuthChallenge?> GetChallengeAsync(string challengeToken, CancellationToken cancellationToken)
+    {
+        if (cancellationToken.IsCancellationRequested)
+        {
+            return Task.FromCanceled<AuthChallenge?>(cancellationToken);
+        }
+
+        lock (_sync)
+        {
+            return Task.FromResult<AuthChallenge?>(_challenges.GetValueOrDefault(challengeToken));
+        }
+    }
+
+    public Task<AuthUser> GetOrCreateUserAsync(string normalizedEmail, CancellationToken cancellationToken)
+    {
+        if (cancellationToken.IsCancellationRequested)
+        {
+            return Task.FromCanceled<AuthUser>(cancellationToken);
+        }
+
+        lock (_sync)
+        {
+            if (_usersByEmail.TryGetValue(normalizedEmail, out var existingUser))
+            {
+                return Task.FromResult(existingUser);
+            }
+
+            var createdUser = new AuthUser(Guid.NewGuid(), normalizedEmail);
+            _usersByEmail[createdUser.Email] = createdUser;
+            _usersById[createdUser.Id] = createdUser;
+            return Task.FromResult(createdUser);
+        }
+    }
+
+    public Task AddSessionAsync(AuthSession session, CancellationToken cancellationToken)
+    {
+        if (cancellationToken.IsCancellationRequested)
+        {
+            return Task.FromCanceled(cancellationToken);
+        }
+
+        lock (_sync)
+        {
+            _sessionsByAccessToken[session.AccessToken] = session;
+            _sessionsByRefreshToken[session.RefreshToken] = session;
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public Task<AuthSession?> GetSessionByAccessTokenAsync(string accessToken, CancellationToken cancellationToken)
+    {
+        if (cancellationToken.IsCancellationRequested)
+        {
+            return Task.FromCanceled<AuthSession?>(cancellationToken);
+        }
+
+        lock (_sync)
+        {
+            return Task.FromResult<AuthSession?>(_sessionsByAccessToken.GetValueOrDefault(accessToken));
+        }
+    }
+
+    public Task<AuthSession?> GetSessionByRefreshTokenAsync(string refreshToken, CancellationToken cancellationToken)
+    {
+        if (cancellationToken.IsCancellationRequested)
+        {
+            return Task.FromCanceled<AuthSession?>(cancellationToken);
+        }
+
+        lock (_sync)
+        {
+            return Task.FromResult<AuthSession?>(_sessionsByRefreshToken.GetValueOrDefault(refreshToken));
+        }
+    }
+
+    public Task ReplaceSessionAsync(
+        string oldRefreshToken,
+        string oldAccessToken,
+        AuthSession newSession,
+        CancellationToken cancellationToken)
+    {
+        if (cancellationToken.IsCancellationRequested)
+        {
+            return Task.FromCanceled(cancellationToken);
+        }
+
+        lock (_sync)
+        {
+            _sessionsByAccessToken.Remove(oldAccessToken);
+            _sessionsByRefreshToken.Remove(oldRefreshToken);
+
+            _sessionsByAccessToken[newSession.AccessToken] = newSession;
+            _sessionsByRefreshToken[newSession.RefreshToken] = newSession;
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public Task RemoveSessionByRefreshTokenAsync(string refreshToken, CancellationToken cancellationToken)
+    {
+        if (cancellationToken.IsCancellationRequested)
+        {
+            return Task.FromCanceled(cancellationToken);
+        }
+
+        lock (_sync)
+        {
+            if (_sessionsByRefreshToken.Remove(refreshToken, out var existingSession))
+            {
+                _sessionsByAccessToken.Remove(existingSession.AccessToken);
+            }
+        }
+
+        return Task.CompletedTask;
+    }
+}

--- a/backend/src/Modules/Auth/MoneyTracker.Modules.Auth.csproj
+++ b/backend/src/Modules/Auth/MoneyTracker.Modules.Auth.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+</Project>

--- a/backend/src/Modules/Auth/Presentation/AuthEndpoint.cs
+++ b/backend/src/Modules/Auth/Presentation/AuthEndpoint.cs
@@ -2,7 +2,6 @@ using System.Text.Json;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
-using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.DependencyInjection;
 using MoneyTracker.Modules.Auth.Application.GetAuthenticatedUser;
@@ -62,11 +61,9 @@ public static class AuthEndpoint
             var httpResult = TypedResults.Created($"/auth/challenges/{result.Challenge.Token}", response);
             await httpResult.ExecuteAsync(httpContext);
         })
-            .WithName("RequestAuthCode")
-            .WithSummary("Request a challenge code.")
-            .WithDescription("Issues a short-lived, single-use challenge token for sign-in verification.")
-            .Produces<RequestAuthCodeResponse>(StatusCodes.Status201Created)
-            .ProducesProblem(StatusCodes.Status400BadRequest);
+        .WithName("RequestAuthCode")
+        .WithSummary("Request a challenge code.")
+        .WithDescription("Issues a short-lived, single-use challenge token for sign-in verification.");
 
         app.MapPost("/auth/verify-code", async (HttpContext httpContext) =>
         {
@@ -104,11 +101,9 @@ public static class AuthEndpoint
             var httpResult = TypedResults.Ok(response);
             await httpResult.ExecuteAsync(httpContext);
         })
-            .WithName("VerifyAuthCode")
-            .WithSummary("Verify a challenge code.")
-            .WithDescription("Exchanges an email and challenge token for access and refresh tokens.")
-            .Produces<VerifyCodeResponse>(StatusCodes.Status200OK)
-            .ProducesProblem(StatusCodes.Status401Unauthorized);
+        .WithName("VerifyAuthCode")
+        .WithSummary("Verify a challenge code.")
+        .WithDescription("Exchanges an email and challenge token for access and refresh tokens.");
 
         app.MapPost("/auth/refresh", async (HttpContext httpContext) =>
         {
@@ -145,12 +140,10 @@ public static class AuthEndpoint
                 result.Tokens.RefreshTokenExpiresAtUtc);
             await TypedResults.Ok(response).ExecuteAsync(httpContext);
         })
-            .WithName("RefreshAuthSession")
-            .WithSummary("Refresh an authentication session.")
-            .WithDescription("Uses a refresh token to rotate access and refresh credentials.")
-            .Produces<VerifyCodeResponse>(StatusCodes.Status200OK)
-            .ProducesProblem(StatusCodes.Status401Unauthorized)
-            .ProducesProblem(StatusCodes.Status400BadRequest);
+        .WithName("RefreshAuthSession")
+        .WithSummary("Refresh an authentication session.")
+        .WithDescription("Uses a refresh token to rotate access and refresh credentials.")
+        .WithDescription("Uses a refresh token to rotate access and refresh credentials.");
 
         app.MapPost("/auth/logout", async (HttpContext httpContext) =>
         {
@@ -166,11 +159,10 @@ public static class AuthEndpoint
 
             await TypedResults.NoContent().ExecuteAsync(httpContext);
         })
-            .WithName("Logout")
-            .WithSummary("Logout an authenticated session.")
-            .WithDescription("Revokes a refresh token and associated access token.")
-            .Produces(StatusCodes.Status204NoContent)
-            .ProducesProblem(StatusCodes.Status400BadRequest);
+        .WithName("Logout")
+        .WithSummary("Logout an authenticated session.")
+        .WithDescription("Revokes a refresh token and associated access token.")
+        .WithDescription("Revokes a refresh token and associated access token.");
 
         return app;
     }

--- a/backend/src/Modules/Auth/Presentation/AuthEndpoint.cs
+++ b/backend/src/Modules/Auth/Presentation/AuthEndpoint.cs
@@ -1,4 +1,6 @@
 using System.Text.Json;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.DependencyInjection;

--- a/backend/src/Modules/Auth/Presentation/AuthEndpoint.cs
+++ b/backend/src/Modules/Auth/Presentation/AuthEndpoint.cs
@@ -1,0 +1,289 @@
+using System.Text.Json;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
+using MoneyTracker.Modules.Auth.Application.GetAuthenticatedUser;
+using MoneyTracker.Modules.Auth.Application.Logout;
+using MoneyTracker.Modules.Auth.Application.RefreshSession;
+using MoneyTracker.Modules.Auth.Application.RequestAuthCode;
+using MoneyTracker.Modules.Auth.Application.VerifyCode;
+using MoneyTracker.Modules.Auth.Domain;
+
+namespace MoneyTracker.Modules.Auth.Presentation;
+
+public static class AuthEndpoint
+{
+    public static IServiceCollection AddAuthModule(this IServiceCollection services)
+    {
+        services.AddSingleton<IAuthRepository, InMemoryAuthRepository>();
+        services.AddSingleton(TimeProvider.System);
+        services.AddScoped<RequestAuthCodeHandler>();
+        services.AddScoped<VerifyCodeHandler>();
+        services.AddScoped<RefreshSessionHandler>();
+        services.AddScoped<LogoutSessionHandler>();
+        services.AddScoped<GetAuthenticatedUserHandler>();
+
+        return services;
+    }
+
+    public static IEndpointRouteBuilder MapAuthEndpoints(this IEndpointRouteBuilder app)
+    {
+        app.MapPost("/auth/request-code", async (HttpContext httpContext) =>
+        {
+            var handler = httpContext.RequestServices.GetRequiredService<RequestAuthCodeHandler>();
+            var (isValidRequest, request, parseProblem) = await ReadJsonRequestAsync<RequestAuthCodeRequest>(httpContext);
+            if (!isValidRequest)
+            {
+                await parseProblem!.ExecuteAsync(httpContext);
+                return;
+            }
+
+            var result = await handler.HandleAsync(
+                new RequestAuthCodeCommand(request!.Email),
+                httpContext.RequestAborted);
+
+            if (!result.IsSuccess)
+            {
+                await WriteProblemAsync(
+                    httpContext,
+                    StatusCodes.Status400BadRequest,
+                    "Validation failed.",
+                    result.ErrorMessage!,
+                    result.ErrorCode!,
+                    AuthErrors.ValidationError);
+                return;
+            }
+
+            var response = new RequestAuthCodeResponse(result.Challenge!.Token, result.Challenge.ExpiresAtUtc);
+            var httpResult = TypedResults.Created($"/auth/challenges/{result.Challenge.Token}", response);
+            await httpResult.ExecuteAsync(httpContext);
+        })
+            .WithName("RequestAuthCode")
+            .WithSummary("Request a challenge code.")
+            .WithDescription("Issues a short-lived, single-use challenge token for sign-in verification.")
+            .Accepts<RequestAuthCodeRequest>("application/json")
+            .Produces<RequestAuthCodeResponse>(StatusCodes.Status201Created)
+            .ProducesProblem(StatusCodes.Status400BadRequest);
+
+        app.MapPost("/auth/verify-code", async (HttpContext httpContext) =>
+        {
+            var handler = httpContext.RequestServices.GetRequiredService<VerifyCodeHandler>();
+            var (isValidRequest, request, parseProblem) = await ReadJsonRequestAsync<VerifyCodeRequest>(httpContext);
+            if (!isValidRequest)
+            {
+                await parseProblem!.ExecuteAsync(httpContext);
+                return;
+            }
+
+            var result = await handler.HandleAsync(
+                new VerifyCodeCommand(request!.Email, request.ChallengeToken),
+                httpContext.RequestAborted);
+
+            if (!result.IsSuccess)
+            {
+                await WriteProblemAsync(
+                    httpContext,
+                    StatusCodes.Status401Unauthorized,
+                    "Verification failed.",
+                    result.ErrorMessage!,
+                    result.ErrorCode!,
+                    AuthErrors.ValidationError);
+                return;
+            }
+
+            var response = new VerifyCodeResponse(
+                result.Tokens!.UserId,
+                result.Tokens.Email,
+                result.Tokens.AccessToken,
+                result.Tokens.AccessTokenExpiresAtUtc,
+                result.Tokens.RefreshToken,
+                result.Tokens.RefreshTokenExpiresAtUtc);
+            var httpResult = TypedResults.Ok(response);
+            await httpResult.ExecuteAsync(httpContext);
+        })
+            .WithName("VerifyAuthCode")
+            .WithSummary("Verify a challenge code.")
+            .WithDescription("Exchanges an email and challenge token for access and refresh tokens.")
+            .Accepts<VerifyCodeRequest>("application/json")
+            .Produces<VerifyCodeResponse>(StatusCodes.Status200OK)
+            .ProducesProblem(StatusCodes.Status401Unauthorized);
+
+        app.MapPost("/auth/refresh", async (HttpContext httpContext) =>
+        {
+            var handler = httpContext.RequestServices.GetRequiredService<RefreshSessionHandler>();
+            var (isValidRequest, request, parseProblem) = await ReadJsonRequestAsync<RefreshRequest>(httpContext);
+            if (!isValidRequest)
+            {
+                await parseProblem!.ExecuteAsync(httpContext);
+                return;
+            }
+
+            var result = await handler.HandleAsync(
+                new RefreshSessionCommand(request!.RefreshToken),
+                httpContext.RequestAborted);
+
+            if (!result.IsSuccess)
+            {
+                await WriteProblemAsync(
+                    httpContext,
+                    StatusCodes.Status401Unauthorized,
+                    "Session refresh failed.",
+                    result.ErrorMessage!,
+                    result.ErrorCode!,
+                    AuthErrors.ValidationError);
+                return;
+            }
+
+            var response = new VerifyCodeResponse(
+                result.Tokens!.UserId,
+                result.Tokens.Email,
+                result.Tokens.AccessToken,
+                result.Tokens.AccessTokenExpiresAtUtc,
+                result.Tokens.RefreshToken,
+                result.Tokens.RefreshTokenExpiresAtUtc);
+            await TypedResults.Ok(response).ExecuteAsync(httpContext);
+        })
+            .WithName("RefreshAuthSession")
+            .WithSummary("Refresh an authentication session.")
+            .WithDescription("Uses a refresh token to rotate access and refresh credentials.")
+            .Accepts<RefreshRequest>("application/json")
+            .Produces<VerifyCodeResponse>(StatusCodes.Status200OK)
+            .ProducesProblem(StatusCodes.Status401Unauthorized)
+            .ProducesProblem(StatusCodes.Status400BadRequest);
+
+        app.MapPost("/auth/logout", async (HttpContext httpContext) =>
+        {
+            var handler = httpContext.RequestServices.GetRequiredService<LogoutSessionHandler>();
+            var (isValidRequest, request, parseProblem) = await ReadJsonRequestAsync<LogoutRequest>(httpContext);
+            if (!isValidRequest)
+            {
+                await parseProblem!.ExecuteAsync(httpContext);
+                return;
+            }
+
+            await handler.HandleAsync(new LogoutSessionCommand(request!.RefreshToken), httpContext.RequestAborted);
+
+            await TypedResults.NoContent().ExecuteAsync(httpContext);
+        })
+            .WithName("Logout")
+            .WithSummary("Logout an authenticated session.")
+            .WithDescription("Revokes a refresh token and associated access token.")
+            .Accepts<LogoutRequest>("application/json")
+            .Produces(StatusCodes.Status204NoContent)
+            .ProducesProblem(StatusCodes.Status400BadRequest);
+
+        return app;
+    }
+
+    private static async Task<(bool IsValid, TRequest? Request, IResult? Error)> ReadJsonRequestAsync<TRequest>(HttpContext httpContext)
+        where TRequest : class
+    {
+        var contentType = httpContext.Request.ContentType;
+        if (string.IsNullOrWhiteSpace(contentType) || !IsJsonContentType(contentType))
+        {
+            return (false, default, BuildValidationProblem(
+                StatusCodes.Status400BadRequest,
+                "Validation failed.",
+                "The request payload is required to be JSON.",
+                AuthErrors.ValidationError,
+                httpContext.Request.Path));
+        }
+
+        try
+        {
+            var request = await httpContext.Request.ReadFromJsonAsync<TRequest>(cancellationToken: httpContext.RequestAborted);
+            if (request is null)
+            {
+                return (false, default, BuildValidationProblem(
+                StatusCodes.Status400BadRequest,
+                "Validation failed.",
+                "The request payload is invalid.",
+                AuthErrors.ValidationError,
+                httpContext.Request.Path));
+            }
+
+            return (true, request, null);
+        }
+        catch (JsonException)
+        {
+            return (false, default, BuildValidationProblem(
+                StatusCodes.Status400BadRequest,
+                "Validation failed.",
+                "The request payload is invalid.",
+                AuthErrors.ValidationError,
+                httpContext.Request.Path));
+        }
+        catch (NotSupportedException)
+        {
+            return (false, default, BuildValidationProblem(
+                StatusCodes.Status400BadRequest,
+                "Validation failed.",
+                "The request payload is invalid.",
+                AuthErrors.ValidationError,
+                httpContext.Request.Path));
+        }
+        catch (BadHttpRequestException)
+        {
+            return (false, default, BuildValidationProblem(
+                StatusCodes.Status400BadRequest,
+                "Validation failed.",
+                "The request payload is invalid.",
+                AuthErrors.ValidationError,
+                httpContext.Request.Path));
+        }
+    }
+
+    private static async Task WriteProblemAsync(
+        HttpContext httpContext,
+        int statusCode,
+        string title,
+        string detail,
+        string code,
+        string fallbackCode)
+    {
+        var result = BuildProblem(statusCode, title, detail, code ?? fallbackCode, httpContext.Request.Path);
+        await TypedResults.Problem(result).ExecuteAsync(httpContext);
+    }
+
+    private static IResult BuildValidationProblem(int statusCode, string title, string detail, string code, string? instance)
+    {
+        return TypedResults.Problem(BuildProblem(statusCode, title, detail, code, instance));
+    }
+
+    private static ProblemDetails BuildProblem(int statusCode, string title, string detail, string code, string? instance)
+    {
+        var problem = new ProblemDetails
+        {
+            Status = statusCode,
+            Title = title,
+            Detail = detail,
+            Instance = instance
+        };
+        problem.Extensions["code"] = code;
+        return problem;
+    }
+
+    private static bool IsJsonContentType(string contentType)
+    {
+        var mediaType = contentType.Split(';')[0].Trim();
+        return mediaType.Equals("application/json", StringComparison.OrdinalIgnoreCase);
+    }
+}
+
+public sealed record RequestAuthCodeRequest(string Email);
+
+public sealed record RequestAuthCodeResponse(string ChallengeToken, DateTimeOffset ExpiresAtUtc);
+
+public sealed record VerifyCodeRequest(string Email, string ChallengeToken);
+
+public sealed record VerifyCodeResponse(
+    Guid UserId,
+    string Email,
+    string AccessToken,
+    DateTimeOffset AccessTokenExpiresAtUtc,
+    string RefreshToken,
+    DateTimeOffset RefreshTokenExpiresAtUtc);
+
+public sealed record RefreshRequest(string RefreshToken);
+
+public sealed record LogoutRequest(string RefreshToken);

--- a/backend/src/Modules/Auth/Presentation/AuthEndpoint.cs
+++ b/backend/src/Modules/Auth/Presentation/AuthEndpoint.cs
@@ -10,6 +10,7 @@ using MoneyTracker.Modules.Auth.Application.Logout;
 using MoneyTracker.Modules.Auth.Application.RefreshSession;
 using MoneyTracker.Modules.Auth.Application.RequestAuthCode;
 using MoneyTracker.Modules.Auth.Application.VerifyCode;
+using MoneyTracker.Modules.Auth.Infrastructure;
 using MoneyTracker.Modules.Auth.Domain;
 
 namespace MoneyTracker.Modules.Auth.Presentation;
@@ -64,7 +65,6 @@ public static class AuthEndpoint
             .WithName("RequestAuthCode")
             .WithSummary("Request a challenge code.")
             .WithDescription("Issues a short-lived, single-use challenge token for sign-in verification.")
-            .Accepts<RequestAuthCodeRequest>("application/json")
             .Produces<RequestAuthCodeResponse>(StatusCodes.Status201Created)
             .ProducesProblem(StatusCodes.Status400BadRequest);
 
@@ -107,7 +107,6 @@ public static class AuthEndpoint
             .WithName("VerifyAuthCode")
             .WithSummary("Verify a challenge code.")
             .WithDescription("Exchanges an email and challenge token for access and refresh tokens.")
-            .Accepts<VerifyCodeRequest>("application/json")
             .Produces<VerifyCodeResponse>(StatusCodes.Status200OK)
             .ProducesProblem(StatusCodes.Status401Unauthorized);
 
@@ -149,7 +148,6 @@ public static class AuthEndpoint
             .WithName("RefreshAuthSession")
             .WithSummary("Refresh an authentication session.")
             .WithDescription("Uses a refresh token to rotate access and refresh credentials.")
-            .Accepts<RefreshRequest>("application/json")
             .Produces<VerifyCodeResponse>(StatusCodes.Status200OK)
             .ProducesProblem(StatusCodes.Status401Unauthorized)
             .ProducesProblem(StatusCodes.Status400BadRequest);
@@ -171,7 +169,6 @@ public static class AuthEndpoint
             .WithName("Logout")
             .WithSummary("Logout an authenticated session.")
             .WithDescription("Revokes a refresh token and associated access token.")
-            .Accepts<LogoutRequest>("application/json")
             .Produces(StatusCodes.Status204NoContent)
             .ProducesProblem(StatusCodes.Status400BadRequest);
 

--- a/backend/src/Modules/Auth/Presentation/AuthEndpoint.cs
+++ b/backend/src/Modules/Auth/Presentation/AuthEndpoint.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.DependencyInjection;
 using MoneyTracker.Modules.Auth.Application.GetAuthenticatedUser;

--- a/backend/src/Modules/Households/Application/AcceptHouseholdInvitation/AcceptHouseholdInvitationCommand.cs
+++ b/backend/src/Modules/Households/Application/AcceptHouseholdInvitation/AcceptHouseholdInvitationCommand.cs
@@ -1,0 +1,8 @@
+using MoneyTracker.Modules.Households.Domain;
+
+namespace MoneyTracker.Modules.Households.Application.AcceptHouseholdInvitation;
+
+public sealed record AcceptHouseholdInvitationCommand(
+    string InvitationToken,
+    Guid AcceptingUserId,
+    string AcceptingEmail);

--- a/backend/src/Modules/Households/Application/AcceptHouseholdInvitation/AcceptHouseholdInvitationHandler.cs
+++ b/backend/src/Modules/Households/Application/AcceptHouseholdInvitation/AcceptHouseholdInvitationHandler.cs
@@ -1,0 +1,74 @@
+using MoneyTracker.Modules.Households.Domain;
+
+namespace MoneyTracker.Modules.Households.Application.AcceptHouseholdInvitation;
+
+public sealed class AcceptHouseholdInvitationHandler(IHouseholdRepository repository, TimeProvider timeProvider)
+{
+    public async Task<AcceptHouseholdInvitationResult> HandleAsync(
+        AcceptHouseholdInvitationCommand command,
+        CancellationToken cancellationToken)
+    {
+        var invitation = await repository.GetInvitationAsync(command.InvitationToken, cancellationToken);
+        if (invitation is null)
+        {
+            return AcceptHouseholdInvitationResult.Failure(
+                HouseholdErrors.HouseholdInvitationNotFound,
+                "Invitation token not found.");
+        }
+
+        var nowUtc = timeProvider.GetUtcNow();
+        if (invitation.IsUsed)
+        {
+            return AcceptHouseholdInvitationResult.Failure(
+                HouseholdErrors.HouseholdInvitationUsed,
+                "Invitation already used.");
+        }
+
+        if (invitation.IsExpired(nowUtc))
+        {
+            return AcceptHouseholdInvitationResult.Failure(
+                HouseholdErrors.HouseholdInvitationExpired,
+                "Invitation token expired.");
+        }
+
+        if (!string.Equals(
+                invitation.InviteeEmail,
+                HouseholdInvitation.NormalizeEmail(command.AcceptingEmail),
+                StringComparison.OrdinalIgnoreCase))
+        {
+            return AcceptHouseholdInvitationResult.Failure(
+                HouseholdErrors.HouseholdInvitationEmailMismatch,
+                "Invitation email does not match the accepting account.");
+        }
+
+        var household = await repository.GetByIdAsync(invitation.HouseholdId, cancellationToken);
+        if (household is null)
+        {
+            return AcceptHouseholdInvitationResult.Failure(
+                HouseholdErrors.HouseholdNotFound,
+                "Household not found.");
+        }
+
+        var added = await repository.AddMemberAsync(invitation.HouseholdId, command.AcceptingUserId, HouseholdRole.Member, cancellationToken);
+        if (!added)
+        {
+            return AcceptHouseholdInvitationResult.Failure(
+                HouseholdErrors.HouseholdAlreadyMember,
+                "User is already a member of this household.");
+        }
+
+        var marked = await repository.MarkInvitationUsedAsync(
+            command.InvitationToken,
+            command.AcceptingUserId,
+            nowUtc,
+            cancellationToken);
+        if (!marked)
+        {
+            return AcceptHouseholdInvitationResult.Failure(
+                HouseholdErrors.HouseholdInvitationUsed,
+                "Invitation already used.");
+        }
+
+        return AcceptHouseholdInvitationResult.Success();
+    }
+}

--- a/backend/src/Modules/Households/Application/AcceptHouseholdInvitation/AcceptHouseholdInvitationResult.cs
+++ b/backend/src/Modules/Households/Application/AcceptHouseholdInvitation/AcceptHouseholdInvitationResult.cs
@@ -1,0 +1,28 @@
+namespace MoneyTracker.Modules.Households.Application.AcceptHouseholdInvitation;
+
+public sealed class AcceptHouseholdInvitationResult
+{
+    private AcceptHouseholdInvitationResult(
+        bool isSuccess,
+        string? errorCode,
+        string? errorMessage)
+    {
+        IsSuccess = isSuccess;
+        ErrorCode = errorCode;
+        ErrorMessage = errorMessage;
+    }
+
+    public bool IsSuccess { get; }
+    public string? ErrorCode { get; }
+    public string? ErrorMessage { get; }
+
+    public static AcceptHouseholdInvitationResult Success()
+    {
+        return new AcceptHouseholdInvitationResult(isSuccess: true, errorCode: null, errorMessage: null);
+    }
+
+    public static AcceptHouseholdInvitationResult Failure(string errorCode, string errorMessage)
+    {
+        return new AcceptHouseholdInvitationResult(isSuccess: false, errorCode: errorCode, errorMessage: errorMessage);
+    }
+}

--- a/backend/src/Modules/Households/Application/CreateHousehold/CreateHouseholdCommand.cs
+++ b/backend/src/Modules/Households/Application/CreateHousehold/CreateHouseholdCommand.cs
@@ -1,3 +1,3 @@
 namespace MoneyTracker.Modules.Households.Application.CreateHousehold;
 
-public sealed record CreateHouseholdCommand(string Name);
+public sealed record CreateHouseholdCommand(string Name, Guid OwnerUserId);

--- a/backend/src/Modules/Households/Application/CreateHousehold/CreateHouseholdHandler.cs
+++ b/backend/src/Modules/Households/Application/CreateHousehold/CreateHouseholdHandler.cs
@@ -10,7 +10,7 @@ public sealed class CreateHouseholdHandler(IHouseholdRepository repository, Time
 
         try
         {
-            household = Household.Create(command.Name, timeProvider.GetUtcNow());
+            household = Household.Create(command.Name, command.OwnerUserId, timeProvider.GetUtcNow());
         }
         catch (HouseholdDomainException exception) when (exception.Code == HouseholdErrors.ValidationError)
         {

--- a/backend/src/Modules/Households/Application/GetHouseholdMembers/GetHouseholdMembersHandler.cs
+++ b/backend/src/Modules/Households/Application/GetHouseholdMembers/GetHouseholdMembersHandler.cs
@@ -1,0 +1,26 @@
+using MoneyTracker.Modules.Households.Domain;
+
+namespace MoneyTracker.Modules.Households.Application.GetHouseholdMembers;
+
+public sealed class GetHouseholdMembersHandler(IHouseholdRepository repository)
+{
+    public async Task<GetHouseholdMembersResult> HandleAsync(
+        GetHouseholdMembersQuery query,
+        CancellationToken cancellationToken)
+    {
+        var household = await repository.GetByIdAsync(query.HouseholdId, cancellationToken);
+        if (household is null)
+        {
+            return GetHouseholdMembersResult.Failure(HouseholdErrors.HouseholdNotFound, "Household not found.");
+        }
+
+        if (!household.IsMember(query.RequestingUserId))
+        {
+            return GetHouseholdMembersResult.Failure(
+                HouseholdErrors.HouseholdAccessDenied,
+                "User is not a member of this household.");
+        }
+
+        return GetHouseholdMembersResult.Success(household.Members.ToArray());
+    }
+}

--- a/backend/src/Modules/Households/Application/GetHouseholdMembers/GetHouseholdMembersQuery.cs
+++ b/backend/src/Modules/Households/Application/GetHouseholdMembers/GetHouseholdMembersQuery.cs
@@ -1,0 +1,5 @@
+using MoneyTracker.Modules.Households.Domain;
+
+namespace MoneyTracker.Modules.Households.Application.GetHouseholdMembers;
+
+public sealed record GetHouseholdMembersQuery(HouseholdId HouseholdId, Guid RequestingUserId);

--- a/backend/src/Modules/Households/Application/GetHouseholdMembers/GetHouseholdMembersResult.cs
+++ b/backend/src/Modules/Households/Application/GetHouseholdMembers/GetHouseholdMembersResult.cs
@@ -1,0 +1,33 @@
+using MoneyTracker.Modules.Households.Domain;
+
+namespace MoneyTracker.Modules.Households.Application.GetHouseholdMembers;
+
+public sealed class GetHouseholdMembersResult
+{
+    private GetHouseholdMembersResult(
+        bool isSuccess,
+        HouseholdMember[]? members,
+        string? errorCode,
+        string? errorMessage)
+    {
+        IsSuccess = isSuccess;
+        Members = members;
+        ErrorCode = errorCode;
+        ErrorMessage = errorMessage;
+    }
+
+    public bool IsSuccess { get; }
+    public HouseholdMember[]? Members { get; }
+    public string? ErrorCode { get; }
+    public string? ErrorMessage { get; }
+
+    public static GetHouseholdMembersResult Success(HouseholdMember[] members)
+    {
+        return new GetHouseholdMembersResult(isSuccess: true, members: members, errorCode: null, errorMessage: null);
+    }
+
+    public static GetHouseholdMembersResult Failure(string errorCode, string errorMessage)
+    {
+        return new GetHouseholdMembersResult(isSuccess: false, members: null, errorCode: errorCode, errorMessage: errorMessage);
+    }
+}

--- a/backend/src/Modules/Households/Application/InviteHouseholdMember/InviteHouseholdMemberCommand.cs
+++ b/backend/src/Modules/Households/Application/InviteHouseholdMember/InviteHouseholdMemberCommand.cs
@@ -1,0 +1,5 @@
+using MoneyTracker.Modules.Households.Domain;
+
+namespace MoneyTracker.Modules.Households.Application.InviteHouseholdMember;
+
+public sealed record InviteHouseholdMemberCommand(HouseholdId HouseholdId, Guid InviterUserId, string InviteeEmail);

--- a/backend/src/Modules/Households/Application/InviteHouseholdMember/InviteHouseholdMemberHandler.cs
+++ b/backend/src/Modules/Households/Application/InviteHouseholdMember/InviteHouseholdMemberHandler.cs
@@ -1,0 +1,44 @@
+using MoneyTracker.Modules.Households.Domain;
+
+namespace MoneyTracker.Modules.Households.Application.InviteHouseholdMember;
+
+public sealed class InviteHouseholdMemberHandler(IHouseholdRepository repository)
+{
+    public async Task<InviteHouseholdMemberResult> HandleAsync(
+        InviteHouseholdMemberCommand command,
+        CancellationToken cancellationToken)
+    {
+        var inviteeEmail = HouseholdInvitation.NormalizeEmail(command.InviteeEmail);
+        if (string.IsNullOrWhiteSpace(inviteeEmail))
+        {
+            return InviteHouseholdMemberResult.Failure(HouseholdErrors.ValidationError, "Invitee email is required.");
+        }
+
+        var household = await repository.GetByIdAsync(command.HouseholdId, cancellationToken);
+        if (household is null)
+        {
+            return InviteHouseholdMemberResult.Failure(HouseholdErrors.HouseholdNotFound, "Household not found.");
+        }
+
+        if (!household.IsOwner(command.InviterUserId))
+        {
+            return InviteHouseholdMemberResult.Failure(HouseholdErrors.HouseholdAccessDenied, "Only household owners can invite members.");
+        }
+
+        var invitationToken = Guid.NewGuid().ToString("N");
+        var expiresAtUtc = DateTimeOffset.UtcNow.AddDays(7);
+        var invitation = new HouseholdInvitation(
+            invitationToken,
+            household.Id,
+            command.InviterUserId,
+            inviteeEmail,
+            expiresAtUtc);
+
+        var created = await repository.AddInvitationAsync(invitation, cancellationToken);
+        if (!created)
+        {
+            return InviteHouseholdMemberResult.Failure(HouseholdErrors.ValidationError, "Invitation could not be created.");
+        }
+
+        return InviteHouseholdMemberResult.Success(invitationToken, expiresAtUtc);
+    }

--- a/backend/src/Modules/Households/Application/InviteHouseholdMember/InviteHouseholdMemberHandler.cs
+++ b/backend/src/Modules/Households/Application/InviteHouseholdMember/InviteHouseholdMemberHandler.cs
@@ -2,7 +2,7 @@ using MoneyTracker.Modules.Households.Domain;
 
 namespace MoneyTracker.Modules.Households.Application.InviteHouseholdMember;
 
-public sealed class InviteHouseholdMemberHandler(IHouseholdRepository repository)
+public sealed class InviteHouseholdMemberHandler(IHouseholdRepository repository, TimeProvider timeProvider)
 {
     public async Task<InviteHouseholdMemberResult> HandleAsync(
         InviteHouseholdMemberCommand command,
@@ -26,7 +26,7 @@ public sealed class InviteHouseholdMemberHandler(IHouseholdRepository repository
         }
 
         var invitationToken = Guid.NewGuid().ToString("N");
-        var expiresAtUtc = DateTimeOffset.UtcNow.AddDays(7);
+        var expiresAtUtc = timeProvider.GetUtcNow().AddDays(7);
         var invitation = new HouseholdInvitation(
             invitationToken,
             household.Id,
@@ -42,3 +42,4 @@ public sealed class InviteHouseholdMemberHandler(IHouseholdRepository repository
 
         return InviteHouseholdMemberResult.Success(invitationToken, expiresAtUtc);
     }
+}

--- a/backend/src/Modules/Households/Application/InviteHouseholdMember/InviteHouseholdMemberResult.cs
+++ b/backend/src/Modules/Households/Application/InviteHouseholdMember/InviteHouseholdMemberResult.cs
@@ -1,0 +1,46 @@
+using MoneyTracker.Modules.Households.Domain;
+
+namespace MoneyTracker.Modules.Households.Application.InviteHouseholdMember;
+
+public sealed class InviteHouseholdMemberResult
+{
+    private InviteHouseholdMemberResult(
+        bool isSuccess,
+        string? invitationToken,
+        DateTimeOffset? invitationExpiresAtUtc,
+        string? errorCode,
+        string? errorMessage)
+    {
+        IsSuccess = isSuccess;
+        InvitationToken = invitationToken;
+        InvitationExpiresAtUtc = invitationExpiresAtUtc;
+        ErrorCode = errorCode;
+        ErrorMessage = errorMessage;
+    }
+
+    public bool IsSuccess { get; }
+    public string? InvitationToken { get; }
+    public DateTimeOffset? InvitationExpiresAtUtc { get; }
+    public string? ErrorCode { get; }
+    public string? ErrorMessage { get; }
+
+    public static InviteHouseholdMemberResult Success(string invitationToken, DateTimeOffset invitationExpiresAtUtc)
+    {
+        return new InviteHouseholdMemberResult(
+            isSuccess: true,
+            invitationToken: invitationToken,
+            invitationExpiresAtUtc: invitationExpiresAtUtc,
+            errorCode: null,
+            errorMessage: null);
+    }
+
+    public static InviteHouseholdMemberResult Failure(string errorCode, string errorMessage)
+    {
+        return new InviteHouseholdMemberResult(
+            isSuccess: false,
+            invitationToken: null,
+            invitationExpiresAtUtc: null,
+            errorCode: errorCode,
+            errorMessage: errorMessage);
+    }
+}

--- a/backend/src/Modules/Households/Domain/Household.cs
+++ b/backend/src/Modules/Households/Domain/Household.cs
@@ -6,16 +6,25 @@ public sealed class Household
 
     public HouseholdId Id { get; }
     public string Name { get; }
+    public Guid OwnerUserId { get; }
     public DateTimeOffset CreatedAtUtc { get; }
+    private readonly List<HouseholdMember> _members;
 
-    private Household(HouseholdId id, string name, DateTimeOffset createdAtUtc)
+    private Household(
+        HouseholdId id,
+        string name,
+        DateTimeOffset createdAtUtc,
+        Guid ownerUserId,
+        IEnumerable<HouseholdMember>? initialMembers = null)
     {
         Id = id;
         Name = name;
+        OwnerUserId = ownerUserId;
         CreatedAtUtc = createdAtUtc;
+        _members = initialMembers?.ToList() ?? [];
     }
 
-    public static Household Create(string name, DateTimeOffset nowUtc)
+    public static Household Create(string name, Guid ownerUserId, DateTimeOffset nowUtc)
     {
         var normalizedName = NormalizeName(name);
         if (normalizedName.Length == 0)
@@ -32,7 +41,35 @@ public sealed class Household
                 $"Household name must be {MaxNameLength} characters or fewer.");
         }
 
-        return new Household(HouseholdId.New(), normalizedName, nowUtc);
+        return new Household(
+            HouseholdId.New(),
+            normalizedName,
+            nowUtc,
+            ownerUserId,
+            new[] { new HouseholdMember(ownerUserId, HouseholdRole.Owner) });
+    }
+
+    public IReadOnlyCollection<HouseholdMember> Members => _members.AsReadOnly();
+
+    public bool IsOwner(Guid userId)
+    {
+        return OwnerUserId == userId;
+    }
+
+    public bool IsMember(Guid userId)
+    {
+        return _members.Any(member => member.UserId == userId);
+    }
+
+    public bool TryAddMember(Guid userId, string role)
+    {
+        if (_members.Any(member => member.UserId == userId))
+        {
+            return false;
+        }
+
+        _members.Add(new HouseholdMember(userId, role));
+        return true;
     }
 
     public static string NormalizeName(string? name)

--- a/backend/src/Modules/Households/Domain/HouseholdErrors.cs
+++ b/backend/src/Modules/Households/Domain/HouseholdErrors.cs
@@ -4,4 +4,11 @@ public static class HouseholdErrors
 {
     public const string ValidationError = "validation_error";
     public const string HouseholdNameConflict = "household_name_conflict";
+    public const string HouseholdNotFound = "household_not_found";
+    public const string HouseholdAccessDenied = "household_access_denied";
+    public const string HouseholdInvitationNotFound = "household_invitation_not_found";
+    public const string HouseholdInvitationExpired = "household_invitation_expired";
+    public const string HouseholdInvitationUsed = "household_invitation_used";
+    public const string HouseholdInvitationEmailMismatch = "household_invitation_email_mismatch";
+    public const string HouseholdAlreadyMember = "household_already_member";
 }

--- a/backend/src/Modules/Households/Domain/HouseholdInvitation.cs
+++ b/backend/src/Modules/Households/Domain/HouseholdInvitation.cs
@@ -1,0 +1,42 @@
+namespace MoneyTracker.Modules.Households.Domain;
+
+public sealed class HouseholdInvitation
+{
+    public HouseholdInvitation(
+        string token,
+        HouseholdId householdId,
+        Guid inviterUserId,
+        string inviteeEmail,
+        DateTimeOffset expiresAtUtc)
+    {
+        Token = token;
+        HouseholdId = householdId;
+        InviterUserId = inviterUserId;
+        InviteeEmail = inviteeEmail;
+        ExpiresAtUtc = expiresAtUtc;
+    }
+
+    public string Token { get; }
+    public HouseholdId HouseholdId { get; }
+    public Guid InviterUserId { get; }
+    public string InviteeEmail { get; }
+    public DateTimeOffset ExpiresAtUtc { get; }
+    public bool IsUsed { get; private set; }
+    public Guid? AcceptedByUserId { get; private set; }
+
+    public bool IsExpired(DateTimeOffset nowUtc)
+    {
+        return nowUtc >= ExpiresAtUtc;
+    }
+
+    public void MarkUsed(Guid acceptingUserId)
+    {
+        IsUsed = true;
+        AcceptedByUserId = acceptingUserId;
+    }
+
+    public static string NormalizeEmail(string? email)
+    {
+        return email?.Trim().ToLowerInvariant() ?? string.Empty;
+    }
+}

--- a/backend/src/Modules/Households/Domain/HouseholdMember.cs
+++ b/backend/src/Modules/Households/Domain/HouseholdMember.cs
@@ -1,0 +1,3 @@
+namespace MoneyTracker.Modules.Households.Domain;
+
+public sealed record HouseholdMember(Guid UserId, string Role);

--- a/backend/src/Modules/Households/Domain/HouseholdRole.cs
+++ b/backend/src/Modules/Households/Domain/HouseholdRole.cs
@@ -1,0 +1,7 @@
+namespace MoneyTracker.Modules.Households.Domain;
+
+public static class HouseholdRole
+{
+    public const string Owner = "owner";
+    public const string Member = "member";
+}

--- a/backend/src/Modules/Households/Domain/IHouseholdRepository.cs
+++ b/backend/src/Modules/Households/Domain/IHouseholdRepository.cs
@@ -3,4 +3,15 @@ namespace MoneyTracker.Modules.Households.Domain;
 public interface IHouseholdRepository
 {
     Task<bool> AddIfNotExistsAsync(Household household, CancellationToken cancellationToken);
+    Task<Household?> GetByIdAsync(HouseholdId householdId, CancellationToken cancellationToken);
+    Task<bool> IsMemberAsync(HouseholdId householdId, Guid userId, CancellationToken cancellationToken);
+    Task<bool> AddMemberAsync(HouseholdId householdId, Guid userId, string role, CancellationToken cancellationToken);
+
+    Task<bool> AddInvitationAsync(HouseholdInvitation invitation, CancellationToken cancellationToken);
+    Task<HouseholdInvitation?> GetInvitationAsync(string invitationToken, CancellationToken cancellationToken);
+    Task<bool> MarkInvitationUsedAsync(
+        string invitationToken,
+        Guid acceptingUserId,
+        DateTimeOffset nowUtc,
+        CancellationToken cancellationToken);
 }

--- a/backend/src/Modules/Households/Infrastructure/InMemoryHouseholdRepository.cs
+++ b/backend/src/Modules/Households/Infrastructure/InMemoryHouseholdRepository.cs
@@ -5,13 +5,130 @@ namespace MoneyTracker.Modules.Households.Infrastructure;
 public sealed class InMemoryHouseholdRepository : IHouseholdRepository
 {
     private readonly object _sync = new();
-    private readonly Dictionary<string, Household> _households = new(StringComparer.OrdinalIgnoreCase);
+    private readonly Dictionary<string, Household> _householdsByName = new(StringComparer.OrdinalIgnoreCase);
+    private readonly Dictionary<HouseholdId, Household> _householdsById = new();
+    private readonly Dictionary<string, HouseholdInvitation> _invitationsByToken = new();
 
     public Task<bool> AddIfNotExistsAsync(Household household, CancellationToken cancellationToken)
     {
+        if (cancellationToken.IsCancellationRequested)
+        {
+            return Task.FromCanceled<bool>(cancellationToken);
+        }
+
         lock (_sync)
         {
-            return Task.FromResult(_households.TryAdd(household.Name, household));
+            if (_householdsByName.ContainsKey(household.Name))
+            {
+                return Task.FromResult(false);
+            }
+
+            _householdsByName[household.Name] = household;
+            _householdsById[household.Id] = household;
+            return Task.FromResult(true);
+        }
+    }
+
+    public Task<Household?> GetByIdAsync(HouseholdId householdId, CancellationToken cancellationToken)
+    {
+        if (cancellationToken.IsCancellationRequested)
+        {
+            return Task.FromCanceled<Household?>(cancellationToken);
+        }
+
+        lock (_sync)
+        {
+            return Task.FromResult<Household?>(_householdsById.GetValueOrDefault(householdId));
+        }
+    }
+
+    public Task<bool> IsMemberAsync(HouseholdId householdId, Guid userId, CancellationToken cancellationToken)
+    {
+        if (cancellationToken.IsCancellationRequested)
+        {
+            return Task.FromCanceled<bool>(cancellationToken);
+        }
+
+        lock (_sync)
+        {
+            return Task.FromResult(_householdsById.TryGetValue(householdId, out var household)
+                && household.IsMember(userId));
+        }
+    }
+
+    public Task<bool> AddMemberAsync(HouseholdId householdId, Guid userId, string role, CancellationToken cancellationToken)
+    {
+        if (cancellationToken.IsCancellationRequested)
+        {
+            return Task.FromCanceled<bool>(cancellationToken);
+        }
+
+        lock (_sync)
+        {
+            if (!_householdsById.TryGetValue(householdId, out var household))
+            {
+                return Task.FromResult(false);
+            }
+
+            var added = household.TryAddMember(userId, role);
+            return Task.FromResult(added);
+        }
+    }
+
+    public Task<bool> AddInvitationAsync(HouseholdInvitation invitation, CancellationToken cancellationToken)
+    {
+        if (cancellationToken.IsCancellationRequested)
+        {
+            return Task.FromCanceled<bool>(cancellationToken);
+        }
+
+        lock (_sync)
+        {
+            if (_invitationsByToken.ContainsKey(invitation.Token))
+            {
+                return Task.FromResult(false);
+            }
+
+            _invitationsByToken[invitation.Token] = invitation;
+            return Task.FromResult(true);
+        }
+    }
+
+    public Task<HouseholdInvitation?> GetInvitationAsync(
+        string invitationToken,
+        CancellationToken cancellationToken)
+    {
+        if (cancellationToken.IsCancellationRequested)
+        {
+            return Task.FromCanceled<HouseholdInvitation?>(cancellationToken);
+        }
+
+        lock (_sync)
+        {
+            return Task.FromResult<HouseholdInvitation?>(_invitationsByToken.GetValueOrDefault(invitationToken));
+        }
+    }
+
+    public Task<bool> MarkInvitationUsedAsync(
+        string invitationToken,
+        Guid acceptingUserId,
+        DateTimeOffset nowUtc,
+        CancellationToken cancellationToken)
+    {
+        if (cancellationToken.IsCancellationRequested)
+        {
+            return Task.FromCanceled<bool>(cancellationToken);
+        }
+
+        lock (_sync)
+        {
+            if (!_invitationsByToken.TryGetValue(invitationToken, out var invitation) || invitation.IsUsed)
+            {
+                return Task.FromResult(false);
+            }
+
+            invitation.MarkUsed(acceptingUserId);
+            return Task.FromResult(true);
         }
     }
 }

--- a/backend/src/Modules/Households/MoneyTracker.Modules.Households.csproj
+++ b/backend/src/Modules/Households/MoneyTracker.Modules.Households.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    <ProjectReference Include="..\\Auth\\MoneyTracker.Modules.Auth.csproj" />
   </ItemGroup>
 
 </Project>

--- a/backend/src/Modules/Households/Presentation/CreateHouseholdEndpoint.cs
+++ b/backend/src/Modules/Households/Presentation/CreateHouseholdEndpoint.cs
@@ -1,11 +1,13 @@
-using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Routing;
-using Microsoft.Extensions.DependencyInjection;
-using MoneyTracker.Modules.Households.Application.CreateHousehold;
-using MoneyTracker.Modules.Households.Domain;
 using System.Text.Json;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
+using MoneyTracker.Modules.Auth.Application.GetAuthenticatedUser;
+using MoneyTracker.Modules.Auth.Domain;
+using MoneyTracker.Modules.Households.Application.AcceptHouseholdInvitation;
+using MoneyTracker.Modules.Households.Application.CreateHousehold;
+using MoneyTracker.Modules.Households.Application.GetHouseholdMembers;
+using MoneyTracker.Modules.Households.Application.InviteHouseholdMember;
+using MoneyTracker.Modules.Households.Domain;
 
 namespace MoneyTracker.Modules.Households.Presentation;
 
@@ -16,108 +18,305 @@ public static class CreateHouseholdEndpoint
         services.AddSingleton<IHouseholdRepository, Infrastructure.InMemoryHouseholdRepository>();
         services.AddSingleton(TimeProvider.System);
         services.AddScoped<CreateHouseholdHandler>();
+        services.AddScoped<InviteHouseholdMemberHandler>();
+        services.AddScoped<AcceptHouseholdInvitationHandler>();
+        services.AddScoped<GetHouseholdMembersHandler>();
 
         return services;
     }
 
     public static IEndpointRouteBuilder MapHouseholdEndpoints(this IEndpointRouteBuilder app)
     {
-        Delegate createHouseholdHandler = async (HttpContext httpContext) =>
-        {
-            CreateHouseholdRequest? request;
-            try
-            {
-                var contentType = httpContext.Request.ContentType;
-                if (string.IsNullOrWhiteSpace(contentType) || !IsJsonContentType(contentType))
-                {
-                    await WriteValidationProblemAsync(httpContext, "The request payload is required to be JSON.");
-                    return;
-                }
-
-                request = await httpContext.Request.ReadFromJsonAsync<CreateHouseholdRequest>(cancellationToken: httpContext.RequestAborted);
-            }
-            catch (JsonException)
-            {
-                await WriteValidationProblemAsync(httpContext, "The request payload is invalid.");
-                return;
-            }
-            catch (NotSupportedException)
-            {
-                await WriteValidationProblemAsync(httpContext, "The request payload is invalid.");
-                return;
-            }
-            catch (BadHttpRequestException)
-            {
-                await WriteValidationProblemAsync(httpContext, "The request payload is invalid.");
-                return;
-            }
-
-            var handler = httpContext.RequestServices.GetRequiredService<CreateHouseholdHandler>();
-            IResult httpResult;
-
-            if (request is null)
-            {
-                httpResult = TypedResults.Problem(CreateProblemDetails(
-                    statusCode: StatusCodes.Status400BadRequest,
-                    title: "Validation failed.",
-                    detail: "The request payload is invalid.",
-                    code: HouseholdErrors.ValidationError,
-                    instance: httpContext.Request.Path));
-
-                await httpResult.ExecuteAsync(httpContext);
-                return;
-            }
-
-            var createResult = await handler.HandleAsync(new CreateHouseholdCommand(request.Name), httpContext.RequestAborted);
-            if (createResult.IsSuccess)
-            {
-                var household = createResult.Household!;
-                httpResult = TypedResults.Created(
-                    $"/households/{household.Id.Value}",
-                    new CreateHouseholdResponse(
-                        household.Id.Value,
-                        household.Name,
-                        household.CreatedAtUtc));
-
-                await httpResult.ExecuteAsync(httpContext);
-                return;
-            }
-
-            if (createResult.ErrorCode == HouseholdErrors.HouseholdNameConflict)
-            {
-                httpResult = TypedResults.Problem(CreateProblemDetails(
-                    statusCode: StatusCodes.Status409Conflict,
-                    title: "Household already exists.",
-                    detail: createResult.ErrorMessage!,
-                    code: HouseholdErrors.HouseholdNameConflict,
-                    instance: httpContext.Request.Path));
-
-                await httpResult.ExecuteAsync(httpContext);
-                return;
-            }
-
-            httpResult = TypedResults.Problem(CreateProblemDetails(
-                statusCode: StatusCodes.Status400BadRequest,
-                title: "Validation failed.",
-                detail: createResult.ErrorMessage ?? "The request payload is invalid.",
-                code: HouseholdErrors.ValidationError,
-                instance: httpContext.Request.Path));
-
-            await httpResult.ExecuteAsync(httpContext);
-        };
-
-        app.MapPost(
-                "/households",
-                createHouseholdHandler)
+        app.MapPost("/households", CreateHousehold)
             .WithName("CreateHousehold")
             .WithSummary("Create a household.")
-            .WithDescription("Creates a household with a unique case-insensitive name.")
+            .WithDescription("Creates a household owned by the authenticated user.")
             .Accepts<CreateHouseholdRequest>("application/json")
             .Produces<CreateHouseholdResponse>(StatusCodes.Status201Created)
             .ProducesProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status401Unauthorized)
             .ProducesProblem(StatusCodes.Status409Conflict);
 
+        app.MapPost("/households/{householdId:guid}/invite", InviteHouseholdMember)
+            .WithName("InviteHouseholdMember")
+            .WithSummary("Invite a user to a household.")
+            .WithDescription("Only the household owner may issue an invitation token.")
+            .Accepts<InviteHouseholdMemberRequest>("application/json")
+            .Produces<InviteHouseholdMemberResponse>(StatusCodes.Status201Created)
+            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status401Unauthorized)
+            .ProducesProblem(StatusCodes.Status403Forbidden)
+            .ProducesProblem(StatusCodes.Status404NotFound);
+
+        app.MapPost("/households/invitations/{invitationToken}/accept", AcceptHouseholdInvitation)
+            .WithName("AcceptHouseholdInvitation")
+            .WithSummary("Accept a household invitation.")
+            .WithDescription("Adds the authenticated user as a household member.")
+            .Produces(StatusCodes.Status200OK)
+            .ProducesProblem(StatusCodes.Status401Unauthorized)
+            .ProducesProblem(StatusCodes.Status403Forbidden)
+            .ProducesProblem(StatusCodes.Status404NotFound)
+            .ProducesProblem(StatusCodes.Status409Conflict);
+
+        app.MapGet("/households/{householdId:guid}/members", GetHouseholdMembers)
+            .WithName("GetHouseholdMembers")
+            .WithSummary("Get household members.")
+            .WithDescription("Returns all members for an existing household.")
+            .Produces<GetHouseholdMembersResponse>(StatusCodes.Status200OK)
+            .ProducesProblem(StatusCodes.Status401Unauthorized)
+            .ProducesProblem(StatusCodes.Status403Forbidden)
+            .ProducesProblem(StatusCodes.Status404NotFound);
+
         return app;
+    }
+
+    private static async Task CreateHousehold(HttpContext httpContext)
+    {
+        var authResult = await ResolveAuthenticatedUser(httpContext);
+        if (!authResult.Success)
+        {
+            await authResult.Problem!.ExecuteAsync(httpContext);
+            return;
+        }
+
+        var authUser = authResult.Value.AuthenticatedUser;
+        var (isValidRequest, request, parseProblem) = await ReadJsonRequestAsync<CreateHouseholdRequest>(httpContext);
+        if (!isValidRequest)
+        {
+            await parseProblem!.ExecuteAsync(httpContext);
+            return;
+        }
+
+        var handler = httpContext.RequestServices.GetRequiredService<CreateHouseholdHandler>();
+        var result = await handler.HandleAsync(
+            new CreateHouseholdCommand(request!.Name, authUser.UserId),
+            httpContext.RequestAborted);
+
+        if (!result.IsSuccess)
+        {
+            await WriteProblemAsync(
+                httpContext,
+                StatusCodes.Status400BadRequest,
+                "Validation failed.",
+                result.ErrorMessage!,
+                result.ErrorCode,
+                HouseholdErrors.ValidationError);
+            return;
+        }
+
+        var household = result.Household!;
+        var response = new CreateHouseholdResponse(household.Id.Value, household.Name, household.CreatedAtUtc);
+        await TypedResults.Created($"/households/{household.Id.Value}", response).ExecuteAsync(httpContext);
+    }
+
+    private static async Task InviteHouseholdMember(HttpContext httpContext, Guid householdId)
+    {
+        var authResult = await ResolveAuthenticatedUser(httpContext);
+        if (!authResult.Success)
+        {
+            await authResult.Problem!.ExecuteAsync(httpContext);
+            return;
+        }
+
+        var authUser = authResult.Value.AuthenticatedUser;
+        var (isValidRequest, request, parseProblem) = await ReadJsonRequestAsync<InviteHouseholdMemberRequest>(httpContext);
+        if (!isValidRequest)
+        {
+            await parseProblem!.ExecuteAsync(httpContext);
+            return;
+        }
+
+        var handler = httpContext.RequestServices.GetRequiredService<InviteHouseholdMemberHandler>();
+        var result = await handler.HandleAsync(
+            new InviteHouseholdMemberCommand(
+                new HouseholdId(householdId),
+                authUser.UserId,
+                request!.InviteeEmail),
+            httpContext.RequestAborted);
+
+        if (!result.IsSuccess)
+        {
+            var statusCode = result.ErrorCode switch
+            {
+                HouseholdErrors.HouseholdNotFound => StatusCodes.Status404NotFound,
+                HouseholdErrors.HouseholdAccessDenied => StatusCodes.Status403Forbidden,
+                _ => StatusCodes.Status400BadRequest
+            };
+
+            await WriteProblemAsync(
+                httpContext,
+                statusCode,
+                statusCode == StatusCodes.Status403Forbidden ? "Access denied." : "Validation failed.",
+                result.ErrorMessage ?? "Request rejected.",
+                result.ErrorCode!,
+                HouseholdErrors.ValidationError);
+            return;
+        }
+
+        var response = new InviteHouseholdMemberResponse(result.InvitationToken!, result.InvitationExpiresAtUtc!.Value);
+        await TypedResults.Created($"/households/{householdId}/invitations/{result.InvitationToken}", response)
+            .ExecuteAsync(httpContext);
+    }
+
+    private static async Task AcceptHouseholdInvitation(HttpContext httpContext, string invitationToken)
+    {
+        var authResult = await ResolveAuthenticatedUser(httpContext);
+        if (!authResult.Success)
+        {
+            await authResult.Problem!.ExecuteAsync(httpContext);
+            return;
+        }
+
+        var authUser = authResult.Value.AuthenticatedUser;
+        var handler = httpContext.RequestServices.GetRequiredService<AcceptHouseholdInvitationHandler>();
+        var result = await handler.HandleAsync(
+            new AcceptHouseholdInvitationCommand(invitationToken, authUser.UserId, authUser.Email),
+            httpContext.RequestAborted);
+
+        if (!result.IsSuccess)
+        {
+            var statusCode = result.ErrorCode switch
+            {
+                HouseholdErrors.HouseholdInvitationNotFound => StatusCodes.Status404NotFound,
+                HouseholdErrors.HouseholdInvitationEmailMismatch => StatusCodes.Status403Forbidden,
+                HouseholdErrors.HouseholdInvitationExpired => StatusCodes.Status409Conflict,
+                HouseholdErrors.HouseholdInvitationUsed => StatusCodes.Status409Conflict,
+                HouseholdErrors.HouseholdNotFound => StatusCodes.Status404NotFound,
+                _ => StatusCodes.Status409Conflict
+            };
+
+            var title = statusCode == StatusCodes.Status403Forbidden
+                ? "Invitation rejected."
+                : "Invitation could not be accepted.";
+
+            await WriteProblemAsync(
+                httpContext,
+                statusCode,
+                title,
+                result.ErrorMessage!,
+                result.ErrorCode!,
+                HouseholdErrors.ValidationError);
+            return;
+        }
+
+        await TypedResults.Ok().ExecuteAsync(httpContext);
+    }
+
+    private static async Task GetHouseholdMembers(HttpContext httpContext, Guid householdId)
+    {
+        var authResult = await ResolveAuthenticatedUser(httpContext);
+        if (!authResult.Success)
+        {
+            await authResult.Problem!.ExecuteAsync(httpContext);
+            return;
+        }
+
+        var authUser = authResult.Value.AuthenticatedUser;
+        var handler = httpContext.RequestServices.GetRequiredService<GetHouseholdMembersHandler>();
+        var result = await handler.HandleAsync(
+            new GetHouseholdMembersQuery(new HouseholdId(householdId), authUser.UserId),
+            httpContext.RequestAborted);
+
+        if (!result.IsSuccess)
+        {
+            var statusCode = result.ErrorCode switch
+            {
+                HouseholdErrors.HouseholdNotFound => StatusCodes.Status404NotFound,
+                _ => StatusCodes.Status403Forbidden
+            };
+
+            await WriteProblemAsync(
+                httpContext,
+                statusCode,
+                "Request rejected.",
+                result.ErrorMessage ?? "Request rejected.",
+                result.ErrorCode!,
+                HouseholdErrors.ValidationError);
+            return;
+        }
+
+        var response = new GetHouseholdMembersResponse(
+            result.Members!.Select(member => new HouseholdMemberResponse(member.UserId, member.Role)).ToArray());
+        await TypedResults.Ok(response).ExecuteAsync(httpContext);
+    }
+
+    private static async Task<(bool IsValid, TRequest? Request, IResult? Error)> ReadJsonRequestAsync<TRequest>(HttpContext httpContext)
+        where TRequest : class
+    {
+        var contentType = httpContext.Request.ContentType;
+        if (string.IsNullOrWhiteSpace(contentType) || !IsJsonContentType(contentType))
+        {
+            return (false, default, BuildProblemResult(
+                StatusCodes.Status400BadRequest,
+                "Validation failed.",
+                "The request payload is required to be JSON.",
+                HouseholdErrors.ValidationError,
+                httpContext.Request.Path));
+        }
+
+        try
+        {
+            var request = await httpContext.Request.ReadFromJsonAsync<TRequest>(cancellationToken: httpContext.RequestAborted);
+            if (request is null)
+            {
+                return (false, default, BuildProblemResult(
+                    StatusCodes.Status400BadRequest,
+                    "Validation failed.",
+                    "The request payload is invalid.",
+                    HouseholdErrors.ValidationError,
+                    httpContext.Request.Path));
+            }
+
+            return (true, request, null);
+        }
+        catch (JsonException)
+        {
+            return (false, default, BuildProblemResult(
+                StatusCodes.Status400BadRequest,
+                "Validation failed.",
+                "The request payload is invalid.",
+                HouseholdErrors.ValidationError,
+                httpContext.Request.Path));
+        }
+        catch (NotSupportedException)
+        {
+            return (false, default, BuildProblemResult(
+                StatusCodes.Status400BadRequest,
+                "Validation failed.",
+                "The request payload is invalid.",
+                HouseholdErrors.ValidationError,
+                httpContext.Request.Path));
+        }
+        catch (BadHttpRequestException)
+        {
+            return (false, default, BuildProblemResult(
+                StatusCodes.Status400BadRequest,
+                "Validation failed.",
+                "The request payload is invalid.",
+                HouseholdErrors.ValidationError,
+                httpContext.Request.Path));
+        }
+    }
+
+    private static async Task<(bool Success, AuthenticatedUser? AuthenticatedUser, IResult? Problem)> ResolveAuthenticatedUser(HttpContext httpContext)
+    {
+        var token = ExtractBearerToken(httpContext.Request.Headers.Authorization.ToString());
+        var handler = httpContext.RequestServices.GetRequiredService<GetAuthenticatedUserHandler>();
+        var authResult = await handler.HandleAsync(new GetAuthenticatedUserQuery(token), httpContext.RequestAborted);
+
+        if (!authResult.IsSuccess)
+        {
+            var problem = BuildProblemResult(
+                StatusCodes.Status401Unauthorized,
+                "Authentication required.",
+                authResult.ErrorMessage ?? "Authentication required.",
+                authResult.ErrorCode ?? AuthErrors.AccessTokenInvalid,
+                httpContext.Request.Path);
+
+            return (false, null, problem);
+        }
+
+        return (true, new AuthenticatedUser(authResult.UserId, authResult.Email), null);
     }
 
     private static bool IsJsonContentType(string contentType)
@@ -126,7 +325,23 @@ public static class CreateHouseholdEndpoint
         return mediaType.Equals("application/json", StringComparison.OrdinalIgnoreCase);
     }
 
-    private static ProblemDetails CreateProblemDetails(int statusCode, string title, string detail, string code, string instance)
+    private static string? ExtractBearerToken(string? authorizationHeader)
+    {
+        if (string.IsNullOrWhiteSpace(authorizationHeader))
+        {
+            return null;
+        }
+
+        if (!authorizationHeader.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase))
+        {
+            return null;
+        }
+
+        var token = authorizationHeader.Substring("Bearer ".Length).Trim();
+        return string.IsNullOrWhiteSpace(token) ? null : token;
+    }
+
+    private static IResult BuildProblemResult(int statusCode, string title, string detail, string code, string instance)
     {
         var problem = new ProblemDetails
         {
@@ -135,24 +350,37 @@ public static class CreateHouseholdEndpoint
             Detail = detail,
             Instance = instance
         };
-
         problem.Extensions["code"] = code;
-        return problem;
+        return TypedResults.Problem(problem);
     }
 
-    private static async Task WriteValidationProblemAsync(HttpContext httpContext, string detail)
+    private static async Task WriteProblemAsync(
+        HttpContext httpContext,
+        int statusCode,
+        string title,
+        string detail,
+        string? code,
+        string fallbackCode)
     {
-        var malformedPayloadResult = TypedResults.Problem(CreateProblemDetails(
-            statusCode: StatusCodes.Status400BadRequest,
-            title: "Validation failed.",
-            detail: detail,
-            code: HouseholdErrors.ValidationError,
-            instance: httpContext.Request.Path));
-
-        await malformedPayloadResult.ExecuteAsync(httpContext);
+        await BuildProblemResult(
+            statusCode,
+            title,
+            detail,
+            code ?? fallbackCode,
+            httpContext.Request.Path).ExecuteAsync(httpContext);
     }
 }
 
 public sealed record CreateHouseholdRequest(string Name);
 
 public sealed record CreateHouseholdResponse(Guid Id, string Name, DateTimeOffset CreatedAtUtc);
+
+public sealed record InviteHouseholdMemberRequest(string InviteeEmail);
+
+public sealed record InviteHouseholdMemberResponse(string InvitationToken, DateTimeOffset ExpiresAtUtc);
+
+public sealed record HouseholdMemberResponse(Guid UserId, string Role);
+
+public sealed record GetHouseholdMembersResponse(HouseholdMemberResponse[] Members);
+
+internal sealed record AuthenticatedUser(Guid UserId, string Email);

--- a/backend/src/Modules/Households/Presentation/CreateHouseholdEndpoint.cs
+++ b/backend/src/Modules/Households/Presentation/CreateHouseholdEndpoint.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.DependencyInjection;
 using MoneyTracker.Modules.Auth.Application.GetAuthenticatedUser;

--- a/backend/src/Modules/Households/Presentation/CreateHouseholdEndpoint.cs
+++ b/backend/src/Modules/Households/Presentation/CreateHouseholdEndpoint.cs
@@ -79,7 +79,7 @@ public static class CreateHouseholdEndpoint
             return;
         }
 
-        var authUser = authResult.Value.AuthenticatedUser;
+        var authUser = authResult.AuthenticatedUser;
         var (isValidRequest, request, parseProblem) = await ReadJsonRequestAsync<CreateHouseholdRequest>(httpContext);
         if (!isValidRequest)
         {
@@ -118,7 +118,7 @@ public static class CreateHouseholdEndpoint
             return;
         }
 
-        var authUser = authResult.Value.AuthenticatedUser;
+        var authUser = authResult.AuthenticatedUser;
         var (isValidRequest, request, parseProblem) = await ReadJsonRequestAsync<InviteHouseholdMemberRequest>(httpContext);
         if (!isValidRequest)
         {
@@ -167,7 +167,7 @@ public static class CreateHouseholdEndpoint
             return;
         }
 
-        var authUser = authResult.Value.AuthenticatedUser;
+        var authUser = authResult.AuthenticatedUser;
         var handler = httpContext.RequestServices.GetRequiredService<AcceptHouseholdInvitationHandler>();
         var result = await handler.HandleAsync(
             new AcceptHouseholdInvitationCommand(invitationToken, authUser.UserId, authUser.Email),

--- a/backend/src/Modules/Households/Presentation/CreateHouseholdEndpoint.cs
+++ b/backend/src/Modules/Households/Presentation/CreateHouseholdEndpoint.cs
@@ -1,4 +1,6 @@
 using System.Text.Json;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.DependencyInjection;
 using MoneyTracker.Modules.Auth.Application.GetAuthenticatedUser;
@@ -211,7 +213,7 @@ public static class CreateHouseholdEndpoint
             return;
         }
 
-        var authUser = authResult.Value.AuthenticatedUser;
+        var authUser = authResult.AuthenticatedUser;
         var handler = httpContext.RequestServices.GetRequiredService<GetHouseholdMembersHandler>();
         var result = await handler.HandleAsync(
             new GetHouseholdMembersQuery(new HouseholdId(householdId), authUser.UserId),

--- a/backend/src/Modules/Households/Presentation/CreateHouseholdEndpoint.cs
+++ b/backend/src/Modules/Households/Presentation/CreateHouseholdEndpoint.cs
@@ -30,10 +30,15 @@ public static class CreateHouseholdEndpoint
 
     public static IEndpointRouteBuilder MapHouseholdEndpoints(this IEndpointRouteBuilder app)
     {
-        app.MapPost("/households", CreateHousehold)
+        var createHouseholdEndpoint = (RouteHandlerBuilder)app.MapPost("/households", CreateHousehold);
+        createHouseholdEndpoint
             .WithName("CreateHousehold")
             .WithSummary("Create a household.")
-            .WithDescription("Creates a household owned by the authenticated user.");
+            .WithDescription("Creates a household owned by the authenticated user.")
+            .Accepts<CreateHouseholdRequest>("application/json")
+            .Produces<CreateHouseholdResponse>(StatusCodes.Status201Created)
+            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status409Conflict);
 
         app.MapPost("/households/{householdId:guid}/invite", InviteHouseholdMember)
             .WithName("InviteHouseholdMember")
@@ -97,9 +102,15 @@ public static class CreateHouseholdEndpoint
 
         if (!result.IsSuccess)
         {
+            var statusCode = result.ErrorCode switch
+            {
+                HouseholdErrors.HouseholdNameConflict => StatusCodes.Status409Conflict,
+                _ => StatusCodes.Status400BadRequest
+            };
+
             await WriteProblemAsync(
                 httpContext,
-                StatusCodes.Status400BadRequest,
+                statusCode,
                 "Validation failed.",
                 result.ErrorMessage!,
                 result.ErrorCode,

--- a/backend/src/Modules/Households/Presentation/CreateHouseholdEndpoint.cs
+++ b/backend/src/Modules/Households/Presentation/CreateHouseholdEndpoint.cs
@@ -33,42 +33,22 @@ public static class CreateHouseholdEndpoint
         app.MapPost("/households", CreateHousehold)
             .WithName("CreateHousehold")
             .WithSummary("Create a household.")
-            .WithDescription("Creates a household owned by the authenticated user.")
-            .Accepts<CreateHouseholdRequest>("application/json")
-            .Produces<CreateHouseholdResponse>(StatusCodes.Status201Created)
-            .ProducesProblem(StatusCodes.Status400BadRequest)
-            .ProducesProblem(StatusCodes.Status401Unauthorized)
-            .ProducesProblem(StatusCodes.Status409Conflict);
+            .WithDescription("Creates a household owned by the authenticated user.");
 
         app.MapPost("/households/{householdId:guid}/invite", InviteHouseholdMember)
             .WithName("InviteHouseholdMember")
             .WithSummary("Invite a user to a household.")
-            .WithDescription("Only the household owner may issue an invitation token.")
-            .Accepts<InviteHouseholdMemberRequest>("application/json")
-            .Produces<InviteHouseholdMemberResponse>(StatusCodes.Status201Created)
-            .ProducesProblem(StatusCodes.Status400BadRequest)
-            .ProducesProblem(StatusCodes.Status401Unauthorized)
-            .ProducesProblem(StatusCodes.Status403Forbidden)
-            .ProducesProblem(StatusCodes.Status404NotFound);
+            .WithDescription("Only the household owner may issue an invitation token.");
 
         app.MapPost("/households/invitations/{invitationToken}/accept", AcceptHouseholdInvitation)
             .WithName("AcceptHouseholdInvitation")
             .WithSummary("Accept a household invitation.")
-            .WithDescription("Adds the authenticated user as a household member.")
-            .Produces(StatusCodes.Status200OK)
-            .ProducesProblem(StatusCodes.Status401Unauthorized)
-            .ProducesProblem(StatusCodes.Status403Forbidden)
-            .ProducesProblem(StatusCodes.Status404NotFound)
-            .ProducesProblem(StatusCodes.Status409Conflict);
+            .WithDescription("Adds the authenticated user as a household member.");
 
         app.MapGet("/households/{householdId:guid}/members", GetHouseholdMembers)
             .WithName("GetHouseholdMembers")
             .WithSummary("Get household members.")
-            .WithDescription("Returns all members for an existing household.")
-            .Produces<GetHouseholdMembersResponse>(StatusCodes.Status200OK)
-            .ProducesProblem(StatusCodes.Status401Unauthorized)
-            .ProducesProblem(StatusCodes.Status403Forbidden)
-            .ProducesProblem(StatusCodes.Status404NotFound);
+            .WithDescription("Returns all members for an existing household.");
 
         return app;
     }
@@ -83,16 +63,36 @@ public static class CreateHouseholdEndpoint
         }
 
         var authUser = authResult.AuthenticatedUser;
-        var (isValidRequest, request, parseProblem) = await ReadJsonRequestAsync<CreateHouseholdRequest>(httpContext);
-        if (!isValidRequest)
+        if (authUser is null)
         {
-            await parseProblem!.ExecuteAsync(httpContext);
+            await authResult.Problem!.ExecuteAsync(httpContext);
+            return;
+        }
+
+        var (isValidRequest, request, parseProblem) = await ReadJsonRequestAsync<CreateHouseholdRequest>(httpContext);
+        if (!isValidRequest || request is null)
+        {
+            if (parseProblem is not null)
+            {
+                await parseProblem.ExecuteAsync(httpContext);
+            }
+            else
+            {
+                await WriteProblemAsync(
+                    httpContext,
+                    StatusCodes.Status400BadRequest,
+                    "Validation failed.",
+                    "The request payload is required.",
+                    HouseholdErrors.ValidationError,
+                    HouseholdErrors.ValidationError);
+            }
             return;
         }
 
         var handler = httpContext.RequestServices.GetRequiredService<CreateHouseholdHandler>();
+        var householdRequest = request;
         var result = await handler.HandleAsync(
-            new CreateHouseholdCommand(request!.Name, authUser.UserId),
+            new CreateHouseholdCommand(householdRequest.Name, authUser.UserId),
             httpContext.RequestAborted);
 
         if (!result.IsSuccess)
@@ -122,10 +122,29 @@ public static class CreateHouseholdEndpoint
         }
 
         var authUser = authResult.AuthenticatedUser;
-        var (isValidRequest, request, parseProblem) = await ReadJsonRequestAsync<InviteHouseholdMemberRequest>(httpContext);
-        if (!isValidRequest)
+        if (authUser is null)
         {
-            await parseProblem!.ExecuteAsync(httpContext);
+            await authResult.Problem!.ExecuteAsync(httpContext);
+            return;
+        }
+
+        var (isValidRequest, request, parseProblem) = await ReadJsonRequestAsync<InviteHouseholdMemberRequest>(httpContext);
+        if (!isValidRequest || request is null)
+        {
+            if (parseProblem is not null)
+            {
+                await parseProblem.ExecuteAsync(httpContext);
+            }
+            else
+            {
+                await WriteProblemAsync(
+                    httpContext,
+                    StatusCodes.Status400BadRequest,
+                    "Validation failed.",
+                    "The request payload is required.",
+                    HouseholdErrors.ValidationError,
+                    HouseholdErrors.ValidationError);
+            }
             return;
         }
 
@@ -134,7 +153,7 @@ public static class CreateHouseholdEndpoint
             new InviteHouseholdMemberCommand(
                 new HouseholdId(householdId),
                 authUser.UserId,
-                request!.InviteeEmail),
+                request.InviteeEmail),
             httpContext.RequestAborted);
 
         if (!result.IsSuccess)
@@ -171,6 +190,12 @@ public static class CreateHouseholdEndpoint
         }
 
         var authUser = authResult.AuthenticatedUser;
+        if (authUser is null)
+        {
+            await authResult.Problem!.ExecuteAsync(httpContext);
+            return;
+        }
+
         var handler = httpContext.RequestServices.GetRequiredService<AcceptHouseholdInvitationHandler>();
         var result = await handler.HandleAsync(
             new AcceptHouseholdInvitationCommand(invitationToken, authUser.UserId, authUser.Email),
@@ -215,6 +240,12 @@ public static class CreateHouseholdEndpoint
         }
 
         var authUser = authResult.AuthenticatedUser;
+        if (authUser is null)
+        {
+            await authResult.Problem!.ExecuteAsync(httpContext);
+            return;
+        }
+
         var handler = httpContext.RequestServices.GetRequiredService<GetHouseholdMembersHandler>();
         var result = await handler.HandleAsync(
             new GetHouseholdMembersQuery(new HouseholdId(householdId), authUser.UserId),

--- a/backend/src/MoneyTracker.Api/MoneyTracker.Api.csproj
+++ b/backend/src/MoneyTracker.Api/MoneyTracker.Api.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Modules\Households\MoneyTracker.Modules.Households.csproj" />
+    <ProjectReference Include="..\Modules\Auth\MoneyTracker.Modules.Auth.csproj" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.0" />
   </ItemGroup>
 

--- a/backend/src/MoneyTracker.Api/Program.cs
+++ b/backend/src/MoneyTracker.Api/Program.cs
@@ -1,6 +1,7 @@
 using MoneyTracker.Api.Configuration;
 using MoneyTracker.Api.Contracts;
 using MoneyTracker.Api.Diagnostics;
+using MoneyTracker.Modules.Auth.Presentation;
 using MoneyTracker.Modules.Households.Presentation;
 using MoneyTracker.Api.Observability;
 
@@ -10,6 +11,7 @@ builder.Services.AddProblemDetails();
 builder.Services.AddExceptionHandler<GlobalExceptionHandler>();
 builder.Services.AddValidatedConfiguration(builder.Configuration);
 builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddAuthModule();
 builder.Services.AddHouseholdsModule();
 builder.Services.AddOpenApi();
 
@@ -25,6 +27,7 @@ if (app.Environment.IsDevelopment() || app.Environment.IsEnvironment("Testing"))
 
 app.MapGet("/", static () => Results.Ok(new { message = "MoneyTracker API" }));
 app.MapGet("/health", static () => Results.Ok(new HealthResponse("ok")));
+app.MapAuthEndpoints();
 app.MapHouseholdEndpoints();
 
 if (app.Environment.IsEnvironment("Testing"))

--- a/backend/tests/MoneyTracker.Api.Tests/Component/AuthEndpointTests.cs
+++ b/backend/tests/MoneyTracker.Api.Tests/Component/AuthEndpointTests.cs
@@ -1,0 +1,94 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json.Nodes;
+
+namespace MoneyTracker.Api.Tests.Component;
+
+public sealed class AuthEndpointTests : IClassFixture<MoneyTrackerApiFactory>
+{
+    private readonly MoneyTrackerApiFactory _factory;
+
+    public AuthEndpointTests(MoneyTrackerApiFactory factory)
+    {
+        _factory = factory;
+    }
+
+    [Fact]
+    [Trait("Category", "Component")]
+    public async Task PostAuthRequestCode_ReturnsCreated_WithChallengePayload()
+    {
+        using var client = _factory.CreateClient();
+
+        using var response = await client.PostAsJsonAsync("/auth/request-code", new { email = "user-request-code@example.com" });
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+        Assert.Equal("application/json", response.Content.Headers.ContentType?.MediaType);
+
+        var payload = JsonNode.Parse(await response.Content.ReadAsStringAsync())?.AsObject();
+        Assert.NotNull(payload);
+        Assert.False(string.IsNullOrWhiteSpace(payload["challengeToken"]?.GetValue<string>()));
+        Assert.NotNull(payload["expiresAtUtc"]?.GetValue<string>());
+    }
+
+    [Fact]
+    [Trait("Category", "Component")]
+    public async Task PostAuthVerifyCode_ReturnsUnauthorized_WhenCodeIsInvalid()
+    {
+        using var client = _factory.CreateClient();
+
+        using var response = await client.PostAsJsonAsync(
+            "/auth/verify-code",
+            new
+            {
+                email = "invalid-code@example.com",
+                challengeToken = "does-not-exist"
+            });
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+        Assert.Equal("application/problem+json", response.Content.Headers.ContentType?.MediaType);
+
+        var payload = JsonNode.Parse(await response.Content.ReadAsStringAsync())?.AsObject();
+        Assert.NotNull(payload);
+        Assert.Equal("auth_challenge_not_found", payload["code"]?.GetValue<string>());
+    }
+
+    [Fact]
+    [Trait("Category", "Component")]
+    public async Task PostAuthRefresh_ReturnsUnauthorized_WhenRefreshTokenInvalid()
+    {
+        using var client = _factory.CreateClient();
+
+        using var response = await client.PostAsJsonAsync("/auth/refresh", new { refreshToken = "invalid-refresh-token" });
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+        Assert.Equal("application/problem+json", response.Content.Headers.ContentType?.MediaType);
+
+        var payload = JsonNode.Parse(await response.Content.ReadAsStringAsync())?.AsObject();
+        Assert.NotNull(payload);
+        Assert.Equal("auth_refresh_token_invalid", payload["code"]?.GetValue<string>());
+    }
+
+    [Fact]
+    [Trait("Category", "Component")]
+    public async Task PostAuthVerifyCode_ReturnsTokens_WhenCodeIsValid()
+    {
+        using var client = _factory.CreateClient();
+        var email = $"{Guid.NewGuid():N}@example.com";
+        using var requestCode = await client.PostAsJsonAsync("/auth/request-code", new { email });
+        requestCode.EnsureSuccessStatusCode();
+        var challengePayload = JsonNode.Parse(await requestCode.Content.ReadAsStringAsync())?.AsObject();
+        Assert.NotNull(challengePayload);
+
+        var challengeToken = challengePayload["challengeToken"]?.GetValue<string>();
+        Assert.False(string.IsNullOrWhiteSpace(challengeToken));
+
+        using var response = await client.PostAsJsonAsync(
+            "/auth/verify-code",
+            new { email, challengeToken = challengeToken });
+        response.EnsureSuccessStatusCode();
+
+        var payload = JsonNode.Parse(await response.Content.ReadAsStringAsync())?.AsObject();
+        Assert.NotNull(payload);
+        Assert.False(string.IsNullOrWhiteSpace(payload["accessToken"]?.GetValue<string>()));
+        Assert.False(string.IsNullOrWhiteSpace(payload["refreshToken"]?.GetValue<string>()));
+    }
+}

--- a/backend/tests/MoneyTracker.Api.Tests/Component/AuthTestHelpers.cs
+++ b/backend/tests/MoneyTracker.Api.Tests/Component/AuthTestHelpers.cs
@@ -1,0 +1,47 @@
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+
+namespace MoneyTracker.Api.Tests.Component;
+
+internal static class AuthTestHelpers
+{
+    public static async Task<string> GetAccessTokenAsync(HttpClient client, string email)
+    {
+        var requestCode = await client.PostAsJsonAsync("/auth/request-code", new { email });
+        requestCode.EnsureSuccessStatusCode();
+
+        var requestCodePayload = await requestCode.Content.ReadFromJsonAsync<AuthChallengeResponse>();
+        if (requestCodePayload is null || string.IsNullOrWhiteSpace(requestCodePayload.ChallengeToken))
+        {
+            throw new InvalidOperationException("Request-code did not return a challenge token.");
+        }
+
+        var verifyRequest = await client.PostAsJsonAsync(
+            "/auth/verify-code",
+            new { email, challengeToken = requestCodePayload.ChallengeToken });
+        verifyRequest.EnsureSuccessStatusCode();
+
+        var verifyPayload = await verifyRequest.Content.ReadFromJsonAsync<AuthVerifyResponse>();
+        if (verifyPayload is null || string.IsNullOrWhiteSpace(verifyPayload.AccessToken))
+        {
+            throw new InvalidOperationException("Verify-code did not return an access token.");
+        }
+
+        return verifyPayload.AccessToken;
+    }
+
+    public static void SetBearer(HttpClient client, string accessToken)
+    {
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
+    }
+
+    private sealed record AuthChallengeResponse(string ChallengeToken, DateTimeOffset ExpiresAtUtc);
+
+    private sealed record AuthVerifyResponse(
+        Guid UserId,
+        string Email,
+        string AccessToken,
+        DateTimeOffset AccessTokenExpiresAtUtc,
+        string RefreshToken,
+        DateTimeOffset RefreshTokenExpiresAtUtc);
+}

--- a/backend/tests/MoneyTracker.Api.Tests/Component/CreateHouseholdEndpointTests.cs
+++ b/backend/tests/MoneyTracker.Api.Tests/Component/CreateHouseholdEndpointTests.cs
@@ -16,9 +16,35 @@ public sealed class CreateHouseholdEndpointTests : IClassFixture<MoneyTrackerApi
 
     [Fact]
     [Trait("Category", "Component")]
-    public async Task PostHouseholds_ReturnsCreatedResponseAndLocation()
+    public async Task PostHouseholds_RequiresAuthentication()
     {
         using var client = _factory.CreateClient();
+        var request = new { name = $"Family-{Guid.NewGuid():N}" };
+
+        using var response = await client.PostAsJsonAsync("/households", request);
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+        Assert.Equal("application/problem+json", response.Content.Headers.ContentType?.MediaType);
+
+        var payload = JsonNode.Parse(await response.Content.ReadAsStringAsync())?.AsObject();
+        Assert.NotNull(payload);
+        var code = payload["code"]?.GetValue<string>();
+        Assert.NotNull(code);
+        Assert.Contains(code, new[]
+        {
+            "auth_access_token_missing",
+            "auth_access_token_invalid"
+        });
+    }
+
+    [Fact]
+    [Trait("Category", "Component")]
+    public async Task PostHouseholds_ReturnsCreatedResponseAndLocation_WhenAuthenticated()
+    {
+        using var client = _factory.CreateClient();
+        var accessToken = await AuthTestHelpers.GetAccessTokenAsync(client, $"{Guid.NewGuid():N}@example.com");
+        AuthTestHelpers.SetBearer(client, accessToken);
+
         var request = new { name = $"Family-{Guid.NewGuid():N}" };
 
         using var response = await client.PostAsJsonAsync("/households", request);
@@ -41,6 +67,8 @@ public sealed class CreateHouseholdEndpointTests : IClassFixture<MoneyTrackerApi
     public async Task PostHouseholds_ReturnsBadRequest_WhenNameInvalid()
     {
         using var client = _factory.CreateClient();
+        var accessToken = await AuthTestHelpers.GetAccessTokenAsync(client, $"{Guid.NewGuid():N}@example.com");
+        AuthTestHelpers.SetBearer(client, accessToken);
 
         using var response = await client.PostAsJsonAsync("/households", new { name = "   " });
 
@@ -58,6 +86,9 @@ public sealed class CreateHouseholdEndpointTests : IClassFixture<MoneyTrackerApi
     {
         using var client = _factory.CreateClient();
         var baseName = $"Shared-{Guid.NewGuid():N}";
+        var ownerEmail = $"{Guid.NewGuid():N}@example.com";
+        var accessToken = await AuthTestHelpers.GetAccessTokenAsync(client, ownerEmail);
+        AuthTestHelpers.SetBearer(client, accessToken);
 
         using var firstResponse = await client.PostAsJsonAsync("/households", new { name = baseName });
         Assert.Equal(HttpStatusCode.Created, firstResponse.StatusCode);
@@ -77,6 +108,9 @@ public sealed class CreateHouseholdEndpointTests : IClassFixture<MoneyTrackerApi
     public async Task PostHouseholds_ReturnsBadRequest_WhenBodyIsEmpty()
     {
         using var client = _factory.CreateClient();
+        var accessToken = await AuthTestHelpers.GetAccessTokenAsync(client, $"{Guid.NewGuid():N}@example.com");
+        AuthTestHelpers.SetBearer(client, accessToken);
+
         using var emptyBodyContent = new StringContent(string.Empty, Encoding.UTF8, "application/json");
 
         using var response = await client.PostAsync("/households", emptyBodyContent);

--- a/backend/tests/MoneyTracker.Api.Tests/Component/HouseholdAccessEndpointTests.cs
+++ b/backend/tests/MoneyTracker.Api.Tests/Component/HouseholdAccessEndpointTests.cs
@@ -1,0 +1,136 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Linq;
+using System.Text.Json.Nodes;
+using MoneyTracker.Modules.Households.Domain;
+
+namespace MoneyTracker.Api.Tests.Component;
+
+public sealed class HouseholdAccessEndpointTests : IClassFixture<MoneyTrackerApiFactory>
+{
+    private readonly MoneyTrackerApiFactory _factory;
+
+    public HouseholdAccessEndpointTests(MoneyTrackerApiFactory factory)
+    {
+        _factory = factory;
+    }
+
+    [Fact]
+    [Trait("Category", "Component")]
+    public async Task PostInviteMembers_AndAccept_HaveHouseholdMembershipEffects()
+    {
+        using var client = _factory.CreateClient();
+        var ownerEmail = $"{Guid.NewGuid():N}@example.com";
+        var memberEmail = $"{Guid.NewGuid():N}@example.com";
+
+        var ownerToken = await AuthTestHelpers.GetAccessTokenAsync(client, ownerEmail);
+        AuthTestHelpers.SetBearer(client, ownerToken);
+
+        var createHousehold = await client.PostAsJsonAsync("/households", new { name = $"Family-{Guid.NewGuid():N}" });
+        createHousehold.EnsureSuccessStatusCode();
+        var createPayload = JsonNode.Parse(await createHousehold.Content.ReadAsStringAsync())?.AsObject();
+        Assert.NotNull(createPayload);
+        var householdId = createPayload["id"]?.GetValue<string>();
+        Assert.False(string.IsNullOrWhiteSpace(householdId));
+
+        var inviteResponse = await client.PostAsJsonAsync($"/households/{householdId}/invite", new { inviteeEmail = memberEmail });
+        inviteResponse.EnsureSuccessStatusCode();
+        var invitePayload = JsonNode.Parse(await inviteResponse.Content.ReadAsStringAsync())?.AsObject();
+        Assert.NotNull(invitePayload);
+        var invitationToken = invitePayload["invitationToken"]?.GetValue<string>();
+        Assert.False(string.IsNullOrWhiteSpace(invitationToken));
+
+        var memberToken = await AuthTestHelpers.GetAccessTokenAsync(client, memberEmail);
+        AuthTestHelpers.SetBearer(client, memberToken);
+        using var acceptResponse = await client.PostAsync($"/households/invitations/{invitationToken}/accept", null);
+        acceptResponse.EnsureSuccessStatusCode();
+
+        using var membersResponse = await client.GetAsync($"/households/{householdId}/members");
+        membersResponse.EnsureSuccessStatusCode();
+        var membersPayload = JsonNode.Parse(await membersResponse.Content.ReadAsStringAsync())?.AsObject();
+        Assert.NotNull(membersPayload);
+
+        var members = membersPayload["members"]?.AsArray();
+        Assert.NotNull(members);
+        Assert.Equal(2, members.Count);
+        var roles = members.Select(member => member?["role"]?.GetValue<string>()).ToArray();
+        Assert.Contains(HouseholdRole.Owner, roles);
+        Assert.Contains(HouseholdRole.Member, roles);
+    }
+
+    [Fact]
+    [Trait("Category", "Component")]
+    public async Task PostHouseholdInvitation_ReturnsForbidden_WhenRequestingUserIsNotOwner()
+    {
+        using var client = _factory.CreateClient();
+        var ownerEmail = $"{Guid.NewGuid():N}@example.com";
+        var ownerToken = await AuthTestHelpers.GetAccessTokenAsync(client, ownerEmail);
+
+        AuthTestHelpers.SetBearer(client, ownerToken);
+        var createHousehold = await client.PostAsJsonAsync("/households", new { name = $"Family-{Guid.NewGuid():N}" });
+        createHousehold.EnsureSuccessStatusCode();
+        var createPayload = JsonNode.Parse(await createHousehold.Content.ReadAsStringAsync())?.AsObject();
+        Assert.NotNull(createPayload);
+        var householdId = createPayload["id"]?.GetValue<string>();
+        Assert.False(string.IsNullOrWhiteSpace(householdId));
+
+        var nonOwnerEmail = $"{Guid.NewGuid():N}@example.com";
+        var nonOwnerToken = await AuthTestHelpers.GetAccessTokenAsync(client, nonOwnerEmail);
+        AuthTestHelpers.SetBearer(client, nonOwnerToken);
+        using var inviteResponse = await client.PostAsJsonAsync(
+            $"/households/{householdId}/invite",
+            new { inviteeEmail = $"{Guid.NewGuid():N}@example.com" });
+
+        Assert.Equal(HttpStatusCode.Forbidden, inviteResponse.StatusCode);
+
+        var payload = JsonNode.Parse(await inviteResponse.Content.ReadAsStringAsync())?.AsObject();
+        Assert.NotNull(payload);
+        Assert.Equal("household_access_denied", payload["code"]?.GetValue<string>());
+    }
+
+    [Fact]
+    [Trait("Category", "Component")]
+    public async Task PostHouseholdInvitation_RejectsAlreadyUsedInvitationOnSecondAcceptance()
+    {
+        using var client = _factory.CreateClient();
+        var ownerEmail = $"{Guid.NewGuid():N}@example.com";
+        var memberEmail = $"{Guid.NewGuid():N}@example.com";
+
+        var ownerToken = await AuthTestHelpers.GetAccessTokenAsync(client, ownerEmail);
+        AuthTestHelpers.SetBearer(client, ownerToken);
+
+        var createHousehold = await client.PostAsJsonAsync("/households", new { name = $"Family-{Guid.NewGuid():N}" });
+        createHousehold.EnsureSuccessStatusCode();
+        var createPayload = JsonNode.Parse(await createHousehold.Content.ReadAsStringAsync())?.AsObject();
+        Assert.NotNull(createPayload);
+        var householdId = createPayload["id"]?.GetValue<string>();
+        Assert.False(string.IsNullOrWhiteSpace(householdId));
+
+        var inviteResponse = await client.PostAsJsonAsync($"/households/{householdId}/invite", new { inviteeEmail = memberEmail });
+        inviteResponse.EnsureSuccessStatusCode();
+        var invitePayload = JsonNode.Parse(await inviteResponse.Content.ReadAsStringAsync())?.AsObject();
+        Assert.NotNull(invitePayload);
+        var invitationToken = invitePayload["invitationToken"]?.GetValue<string>();
+        Assert.False(string.IsNullOrWhiteSpace(invitationToken));
+
+        var memberToken = await AuthTestHelpers.GetAccessTokenAsync(client, memberEmail);
+        AuthTestHelpers.SetBearer(client, memberToken);
+        using var firstAccept = await client.PostAsync($"/households/invitations/{invitationToken}/accept", null);
+        firstAccept.EnsureSuccessStatusCode();
+
+        using var secondAccept = await client.PostAsync($"/households/invitations/{invitationToken}/accept", null);
+        Assert.Equal(HttpStatusCode.Conflict, secondAccept.StatusCode);
+        var secondPayload = JsonNode.Parse(await secondAccept.Content.ReadAsStringAsync())?.AsObject();
+        Assert.NotNull(secondPayload);
+        Assert.Equal("household_invitation_used", secondPayload["code"]?.GetValue<string>());
+    }
+
+    [Fact]
+    [Trait("Category", "Component")]
+    public async Task GetHouseholdMembers_ReturnsUnauthorized_WhenTokenMissing()
+    {
+        using var client = _factory.CreateClient();
+        using var response = await client.GetAsync($"/households/{Guid.NewGuid()}/members");
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+}

--- a/backend/tests/MoneyTracker.Modules.Households.Tests/Application/CreateHouseholdHandlerTests.cs
+++ b/backend/tests/MoneyTracker.Modules.Households.Tests/Application/CreateHouseholdHandlerTests.cs
@@ -5,6 +5,8 @@ namespace MoneyTracker.Modules.Households.Tests.Application;
 
 public sealed class CreateHouseholdHandlerTests
 {
+    private static readonly Guid OwnerUserId = Guid.NewGuid();
+
     [Fact]
     [Trait("Category", "Unit")]
     public async Task HandleAsync_PersistsHousehold_WhenNameIsUnique()
@@ -13,12 +15,15 @@ public sealed class CreateHouseholdHandlerTests
         var expectedCreatedAtUtc = DateTimeOffset.Parse("2026-02-03T04:05:06Z");
         var handler = new CreateHouseholdHandler(repository, new FakeTimeProvider(expectedCreatedAtUtc));
 
-        var result = await handler.HandleAsync(new CreateHouseholdCommand("Primary Home"), CancellationToken.None);
+        var result = await handler.HandleAsync(new CreateHouseholdCommand("Primary Home", OwnerUserId), CancellationToken.None);
 
         Assert.True(result.IsSuccess);
         Assert.NotNull(result.Household);
         Assert.Equal("Primary Home", result.Household!.Name);
         Assert.Equal(expectedCreatedAtUtc, result.Household.CreatedAtUtc);
+        Assert.Equal(OwnerUserId, result.Household.OwnerUserId);
+        Assert.Equal(OwnerUserId, result.Household.Members.Single().UserId);
+        Assert.Equal(HouseholdRole.Owner, result.Household.Members.Single().Role);
         Assert.Equal(1, repository.AddIfNotExistsCalls);
         Assert.Equal(expectedCreatedAtUtc, repository.LastAddedHousehold?.CreatedAtUtc);
     }
@@ -30,7 +35,7 @@ public sealed class CreateHouseholdHandlerTests
         var repository = new FakeHouseholdRepository(addSucceeds: true, existingName: " Shared ");
         var handler = new CreateHouseholdHandler(repository, TimeProvider.System);
 
-        var result = await handler.HandleAsync(new CreateHouseholdCommand("sHaReD"), CancellationToken.None);
+        var result = await handler.HandleAsync(new CreateHouseholdCommand("sHaReD", OwnerUserId), CancellationToken.None);
 
         Assert.False(result.IsSuccess);
         Assert.Equal(HouseholdErrors.HouseholdNameConflict, result.ErrorCode);
@@ -44,7 +49,7 @@ public sealed class CreateHouseholdHandlerTests
         var repository = new FakeHouseholdRepository(addSucceeds: true);
         var handler = new CreateHouseholdHandler(repository, TimeProvider.System);
 
-        var result = await handler.HandleAsync(new CreateHouseholdCommand("   "), CancellationToken.None);
+        var result = await handler.HandleAsync(new CreateHouseholdCommand("   ", OwnerUserId), CancellationToken.None);
 
         Assert.False(result.IsSuccess);
         Assert.Equal(HouseholdErrors.ValidationError, result.ErrorCode);
@@ -77,6 +82,40 @@ internal sealed class FakeHouseholdRepository(bool addSucceeds, string? existing
         }
 
         return Task.FromResult(addSucceeds);
+    }
+
+    public Task<Household?> GetByIdAsync(HouseholdId householdId, CancellationToken cancellationToken)
+    {
+        return Task.FromResult<Household?>(null);
+    }
+
+    public Task<bool> IsMemberAsync(HouseholdId householdId, Guid userId, CancellationToken cancellationToken)
+    {
+        return Task.FromResult(false);
+    }
+
+    public Task<bool> AddMemberAsync(HouseholdId householdId, Guid userId, string role, CancellationToken cancellationToken)
+    {
+        return Task.FromResult(false);
+    }
+
+    public Task<bool> AddInvitationAsync(HouseholdInvitation invitation, CancellationToken cancellationToken)
+    {
+        return Task.FromResult(false);
+    }
+
+    public Task<HouseholdInvitation?> GetInvitationAsync(string invitationToken, CancellationToken cancellationToken)
+    {
+        return Task.FromResult<HouseholdInvitation?>(null);
+    }
+
+    public Task<bool> MarkInvitationUsedAsync(
+        string invitationToken,
+        Guid acceptingUserId,
+        DateTimeOffset nowUtc,
+        CancellationToken cancellationToken)
+    {
+        return Task.FromResult(false);
     }
 }
 

--- a/backend/tests/MoneyTracker.Modules.Households.Tests/Domain/HouseholdTests.cs
+++ b/backend/tests/MoneyTracker.Modules.Households.Tests/Domain/HouseholdTests.cs
@@ -8,9 +8,10 @@ public sealed class HouseholdTests
     [Trait("Category", "Unit")]
     public void Create_TrimsNameAndSetsStableFields()
     {
+        var ownerUserId = Guid.NewGuid();
         var now = DateTimeOffset.Parse("2026-01-02T03:04:05Z");
 
-        var household = Household.Create("  Family Budget  ", now);
+        var household = Household.Create("  Family Budget  ", ownerUserId, now);
 
         Assert.Equal("Family Budget", household.Name);
         Assert.Equal(now, household.CreatedAtUtc);
@@ -21,7 +22,7 @@ public sealed class HouseholdTests
     [Trait("Category", "Unit")]
     public void Create_ThrowsValidationError_WhenNameIsBlank()
     {
-        var exception = Assert.Throws<HouseholdDomainException>(() => Household.Create("   ", DateTimeOffset.UtcNow));
+        var exception = Assert.Throws<HouseholdDomainException>(() => Household.Create("   ", Guid.NewGuid(), DateTimeOffset.UtcNow));
 
         Assert.Equal(HouseholdErrors.ValidationError, exception.Code);
     }
@@ -32,7 +33,7 @@ public sealed class HouseholdTests
     {
         var longName = new string('a', Household.MaxNameLength + 1);
 
-        var exception = Assert.Throws<HouseholdDomainException>(() => Household.Create(longName, DateTimeOffset.UtcNow));
+        var exception = Assert.Throws<HouseholdDomainException>(() => Household.Create(longName, Guid.NewGuid(), DateTimeOffset.UtcNow));
 
         Assert.Equal(HouseholdErrors.ValidationError, exception.Code);
     }
@@ -43,7 +44,7 @@ public sealed class HouseholdTests
     {
         var boundaryLengthName = new string('a', Household.MaxNameLength);
 
-        var household = Household.Create(boundaryLengthName, DateTimeOffset.UtcNow);
+        var household = Household.Create(boundaryLengthName, Guid.NewGuid(), DateTimeOffset.UtcNow);
 
         Assert.Equal(boundaryLengthName, household.Name);
     }


### PR DESCRIPTION
## Summary
- What changed: implemented issue #52 by introducing auth module endpoints for code request/verification/session introspection/logout/refresh and adding household invitation/member-access workflows with owner/member domain modeling.
- Why this change was needed: household creation and sharing now require proper actor context and explicit access control, which was missing from previous household flows.

## Behavior Changes
- User-visible:
  - Added `/api/auth/request-code`, `/api/auth/verify-code`, `/api/auth/me`, `/api/auth/refresh`, `/api/auth/logout` endpoints.
  - Added `/api/households/{householdId}/members` and `/api/households/{householdId}/invite` and `/api/households/{householdId}/accept` flows.
- API/contract:
  - Household creation and new invitation/member endpoints now require `Authorization` header and emit problem details with `x-error-code`.
  - New behavior prevents non-owners from inviting or accepting on behalf of others and blocks access checks against non-members.
- Internal only:
  - Added auth module (domain/application/infrastructure/presentation) and integrated it into the API composition root.
  - Extended household repository contract and in-memory implementation with members/invitations.

## Risk Assessment
- High risk areas:
  - New auth/session state model is intentionally mock/in-memory and may differ from production token strategy.
  - New authorization checks affect existing household endpoint behavior and may reject previously permissive requests.
- Failure modes:
  - Invalid `Authorization` formats and stale invites could lead to `401/403/404` paths if clients are not updated.
- Mitigations:
  - Explicit domain/service validation and dedicated error codes for each failure path.

## Testing Evidence
- Unit:
  - `backend/tests/MoneyTracker.Modules.Households.Tests/Application/CreateHouseholdHandlerTests.cs` updated for authenticated owner semantics.
- Integration:
  - New/updated component tests in `backend/tests/MoneyTracker.Api.Tests/Component/*` cover auth-protected household flows.
- E2E:
  - Not run.
- Manual verification:
  - Not run.
- Known untested paths:
  - No runtime verification for token expiration or repository persistence beyond in-memory behavior.

## Migration and Rollout
- DB or data migration: none (in-memory persistence model in this repo context).
- Feature flag plan: none.
- Rollback approach: revert PR.

## Reviewer Guidance
- Start files:
  - `backend/src/Modules/Auth/Presentation/AuthEndpoint.cs`
  - `backend/src/Modules/Households/Application/InviteHouseholdMember/InviteHouseholdMemberHandler.cs`
  - `backend/src/Modules/Households/Domain/Household.cs`
  - `backend/src/Modules/Households/Infrastructure/InMemoryHouseholdRepository.cs`
  - `backend/src/Modules/Households/Presentation/CreateHouseholdEndpoint.cs`
- Critical code paths:
  - Auth principal resolution in `AuthTokenProvider`-style command handlers.
  - Member/invitation lifecycle checks in invitation acceptance and membership listing endpoints.
- Questions for reviewers:
  - Is in-memory auth/session lifecycle acceptable for current stage?
  - Are invitation and member IDs stable for future persistence migration?

## Post-Merge Checks
- Monitoring to watch: API error-rate regressions on household endpoints and new auth endpoints.
- Follow-up tasks:
  - Replace mock auth token strategy with durable store + expiry model.
  - Add explicit DB-backed repositories for auth and invitations.

## Merge-readiness notes
- PR includes references to issue 52 and PR description content expected by workflow.

Closes #52

## Summary by Sourcery

Introduce an in-memory auth module and secure household workflows with authenticated ownership and membership semantics.

New Features:
- Add an auth module with endpoints for requesting and verifying login codes, refreshing sessions, and logging out using in-memory challenges and sessions.
- Add household invitation and membership endpoints to invite users, accept invitations, and list household members with role information.

Enhancements:
- Update household creation to associate an owner user and track members with roles, enforcing access control based on ownership and membership.
- Extend the household domain and repository to support lookup by ID, membership checks, and invitation lifecycle management with structured error codes.
- Standardize JSON request validation and problem-detail responses with module-specific error codes across auth and household endpoints.

Tests:
- Add component tests covering auth flows, household creation under authentication, invitation/acceptance lifecycles, and membership access control behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added email-based authentication with code verification and token-based session management
  * Implemented access and refresh token issuance with automatic expiration
  * Added session refresh and logout capabilities
  * Introduced household ownership and member management system
  * Added member invitation workflow with token-based acceptance
  * Enabled household member listing and access control

<!-- end of auto-generated comment: release notes by coderabbit.ai -->