### PR TITLE
Add manual transactions and category budgets (#53)

### DIFF
--- a/backend/MoneyTracker.slnx
+++ b/backend/MoneyTracker.slnx
@@ -3,9 +3,14 @@
     <Project Path="src/MoneyTracker.Api/MoneyTracker.Api.csproj" />
     <Project Path="src/Modules/Households/MoneyTracker.Modules.Households.csproj" />
     <Project Path="src/Modules/Auth/MoneyTracker.Modules.Auth.csproj" />
+    <Project Path="src/Modules/SharedKernel/MoneyTracker.Modules.SharedKernel.csproj" />
+    <Project Path="src/Modules/Budgets/MoneyTracker.Modules.Budgets.csproj" />
+    <Project Path="src/Modules/Transactions/MoneyTracker.Modules.Transactions.csproj" />
   </Folder>
   <Folder Name="/tests/">
     <Project Path="tests/MoneyTracker.Api.Tests/MoneyTracker.Api.Tests.csproj" />
     <Project Path="tests/MoneyTracker.Modules.Households.Tests/MoneyTracker.Modules.Households.Tests.csproj" />
+    <Project Path="tests/MoneyTracker.Modules.Budgets.Tests/MoneyTracker.Modules.Budgets.Tests.csproj" />
+    <Project Path="tests/MoneyTracker.Modules.Transactions.Tests/MoneyTracker.Modules.Transactions.Tests.csproj" />
   </Folder>
 </Solution>

--- a/backend/src/Modules/Budgets/Application/CreateBudgetCategory/CreateBudgetCategoryCommand.cs
+++ b/backend/src/Modules/Budgets/Application/CreateBudgetCategory/CreateBudgetCategoryCommand.cs
@@ -1,0 +1,6 @@
+namespace MoneyTracker.Modules.Budgets.Application.CreateBudgetCategory;
+
+public sealed record CreateBudgetCategoryCommand(
+    Guid HouseholdId,
+    string Name,
+    Guid RequestingUserId);

--- a/backend/src/Modules/Budgets/Application/CreateBudgetCategory/CreateBudgetCategoryHandler.cs
+++ b/backend/src/Modules/Budgets/Application/CreateBudgetCategory/CreateBudgetCategoryHandler.cs
@@ -1,0 +1,51 @@
+using MoneyTracker.Modules.Budgets.Domain;
+using MoneyTracker.Modules.SharedKernel.Households;
+
+namespace MoneyTracker.Modules.Budgets.Application.CreateBudgetCategory;
+
+public sealed class CreateBudgetCategoryHandler(
+    IBudgetRepository repository,
+    IHouseholdAccessService householdAccessService,
+    TimeProvider timeProvider)
+{
+    public async Task<CreateBudgetCategoryResult> HandleAsync(
+        CreateBudgetCategoryCommand command,
+        CancellationToken cancellationToken)
+    {
+        var access = await householdAccessService.CheckMemberAsync(
+            command.HouseholdId,
+            command.RequestingUserId,
+            cancellationToken);
+        if (!access.HouseholdExists)
+        {
+            return CreateBudgetCategoryResult.HouseholdNotFound();
+        }
+
+        if (!access.IsMember)
+        {
+            return CreateBudgetCategoryResult.AccessDenied();
+        }
+
+        BudgetCategory category;
+        try
+        {
+            category = BudgetCategory.Create(
+                command.HouseholdId,
+                command.Name,
+                command.RequestingUserId,
+                timeProvider.GetUtcNow());
+        }
+        catch (BudgetDomainException exception)
+        {
+            return CreateBudgetCategoryResult.Validation(exception.Code, exception.Message);
+        }
+
+        var added = await repository.AddCategoryAsync(category, cancellationToken);
+        if (!added)
+        {
+            return CreateBudgetCategoryResult.Conflict();
+        }
+
+        return CreateBudgetCategoryResult.Success(category);
+    }
+}

--- a/backend/src/Modules/Budgets/Application/CreateBudgetCategory/CreateBudgetCategoryResult.cs
+++ b/backend/src/Modules/Budgets/Application/CreateBudgetCategory/CreateBudgetCategoryResult.cs
@@ -1,0 +1,55 @@
+using MoneyTracker.Modules.Budgets.Domain;
+
+namespace MoneyTracker.Modules.Budgets.Application.CreateBudgetCategory;
+
+public sealed class CreateBudgetCategoryResult
+{
+    private CreateBudgetCategoryResult(BudgetCategory? category, string? errorCode, string? errorMessage)
+    {
+        Category = category;
+        ErrorCode = errorCode;
+        ErrorMessage = errorMessage;
+    }
+
+    public BudgetCategory? Category { get; }
+
+    public string? ErrorCode { get; }
+
+    public string? ErrorMessage { get; }
+
+    public bool IsSuccess => Category is not null;
+
+    public static CreateBudgetCategoryResult Success(BudgetCategory category)
+    {
+        return new CreateBudgetCategoryResult(category, errorCode: null, errorMessage: null);
+    }
+
+    public static CreateBudgetCategoryResult Conflict()
+    {
+        return new CreateBudgetCategoryResult(
+            category: null,
+            BudgetErrors.BudgetCategoryNameConflict,
+            "A category with this name already exists.");
+    }
+
+    public static CreateBudgetCategoryResult Validation(string code, string message)
+    {
+        return new CreateBudgetCategoryResult(category: null, code, message);
+    }
+
+    public static CreateBudgetCategoryResult AccessDenied()
+    {
+        return new CreateBudgetCategoryResult(
+            category: null,
+            BudgetErrors.BudgetAccessDenied,
+            "User is not a member of this household.");
+    }
+
+    public static CreateBudgetCategoryResult HouseholdNotFound()
+    {
+        return new CreateBudgetCategoryResult(
+            category: null,
+            BudgetErrors.BudgetHouseholdNotFound,
+            "Household not found.");
+    }
+}

--- a/backend/src/Modules/Budgets/Application/GetBudgetCategories/GetBudgetCategoriesHandler.cs
+++ b/backend/src/Modules/Budgets/Application/GetBudgetCategories/GetBudgetCategoriesHandler.cs
@@ -1,0 +1,32 @@
+using MoneyTracker.Modules.Budgets.Domain;
+using MoneyTracker.Modules.SharedKernel.Households;
+
+namespace MoneyTracker.Modules.Budgets.Application.GetBudgetCategories;
+
+public sealed class GetBudgetCategoriesHandler(
+    IBudgetRepository repository,
+    IHouseholdAccessService householdAccessService)
+{
+    public async Task<GetBudgetCategoriesResult> HandleAsync(
+        GetBudgetCategoriesQuery query,
+        CancellationToken cancellationToken)
+    {
+        var access = await householdAccessService.CheckMemberAsync(
+            query.HouseholdId,
+            query.RequestingUserId,
+            cancellationToken);
+        if (!access.HouseholdExists)
+        {
+            return GetBudgetCategoriesResult.HouseholdNotFound();
+        }
+
+        if (!access.IsMember)
+        {
+            return GetBudgetCategoriesResult.AccessDenied();
+        }
+
+        var categories = await repository.GetCategoriesAsync(query.HouseholdId, cancellationToken);
+        var ordered = categories.OrderBy(category => category.Name, StringComparer.OrdinalIgnoreCase).ToArray();
+        return GetBudgetCategoriesResult.Success(ordered);
+    }
+}

--- a/backend/src/Modules/Budgets/Application/GetBudgetCategories/GetBudgetCategoriesQuery.cs
+++ b/backend/src/Modules/Budgets/Application/GetBudgetCategories/GetBudgetCategoriesQuery.cs
@@ -1,0 +1,3 @@
+namespace MoneyTracker.Modules.Budgets.Application.GetBudgetCategories;
+
+public sealed record GetBudgetCategoriesQuery(Guid HouseholdId, Guid RequestingUserId);

--- a/backend/src/Modules/Budgets/Application/GetBudgetCategories/GetBudgetCategoriesResult.cs
+++ b/backend/src/Modules/Budgets/Application/GetBudgetCategories/GetBudgetCategoriesResult.cs
@@ -1,0 +1,45 @@
+using MoneyTracker.Modules.Budgets.Domain;
+
+namespace MoneyTracker.Modules.Budgets.Application.GetBudgetCategories;
+
+public sealed class GetBudgetCategoriesResult
+{
+    private GetBudgetCategoriesResult(
+        IReadOnlyCollection<BudgetCategory>? categories,
+        string? errorCode,
+        string? errorMessage)
+    {
+        Categories = categories;
+        ErrorCode = errorCode;
+        ErrorMessage = errorMessage;
+    }
+
+    public IReadOnlyCollection<BudgetCategory>? Categories { get; }
+
+    public string? ErrorCode { get; }
+
+    public string? ErrorMessage { get; }
+
+    public bool IsSuccess => Categories is not null;
+
+    public static GetBudgetCategoriesResult Success(IReadOnlyCollection<BudgetCategory> categories)
+    {
+        return new GetBudgetCategoriesResult(categories, errorCode: null, errorMessage: null);
+    }
+
+    public static GetBudgetCategoriesResult AccessDenied()
+    {
+        return new GetBudgetCategoriesResult(
+            categories: null,
+            BudgetErrors.BudgetAccessDenied,
+            "User is not a member of this household.");
+    }
+
+    public static GetBudgetCategoriesResult HouseholdNotFound()
+    {
+        return new GetBudgetCategoriesResult(
+            categories: null,
+            BudgetErrors.BudgetHouseholdNotFound,
+            "Household not found.");
+    }
+}

--- a/backend/src/Modules/Budgets/Application/GetBudgetCategories/GetBudgetCategoriesResult.cs
+++ b/backend/src/Modules/Budgets/Application/GetBudgetCategories/GetBudgetCategoriesResult.cs
@@ -24,7 +24,8 @@ public sealed class GetBudgetCategoriesResult
 
     public static GetBudgetCategoriesResult Success(IReadOnlyCollection<BudgetCategory> categories)
     {
-        return new GetBudgetCategoriesResult(categories, errorCode: null, errorMessage: null);
+        ArgumentNullException.ThrowIfNull(categories);
+        return new GetBudgetCategoriesResult(categories.ToArray(), errorCode: null, errorMessage: null);
     }
 
     public static GetBudgetCategoriesResult AccessDenied()

--- a/backend/src/Modules/Budgets/Application/UpsertBudgetAllocation/UpsertBudgetAllocationCommand.cs
+++ b/backend/src/Modules/Budgets/Application/UpsertBudgetAllocation/UpsertBudgetAllocationCommand.cs
@@ -1,0 +1,8 @@
+namespace MoneyTracker.Modules.Budgets.Application.UpsertBudgetAllocation;
+
+public sealed record UpsertBudgetAllocationCommand(
+    Guid HouseholdId,
+    Guid CategoryId,
+    decimal Amount,
+    DateTimeOffset? PeriodStartUtc,
+    Guid RequestingUserId);

--- a/backend/src/Modules/Budgets/Application/UpsertBudgetAllocation/UpsertBudgetAllocationHandler.cs
+++ b/backend/src/Modules/Budgets/Application/UpsertBudgetAllocation/UpsertBudgetAllocationHandler.cs
@@ -1,0 +1,82 @@
+using MoneyTracker.Modules.Budgets.Domain;
+using MoneyTracker.Modules.SharedKernel.Households;
+
+namespace MoneyTracker.Modules.Budgets.Application.UpsertBudgetAllocation;
+
+public sealed class UpsertBudgetAllocationHandler(
+    IBudgetRepository repository,
+    IHouseholdAccessService householdAccessService,
+    TimeProvider timeProvider)
+{
+    public async Task<UpsertBudgetAllocationResult> HandleAsync(
+        UpsertBudgetAllocationCommand command,
+        CancellationToken cancellationToken)
+    {
+        var access = await householdAccessService.CheckMemberAsync(
+            command.HouseholdId,
+            command.RequestingUserId,
+            cancellationToken);
+        if (!access.HouseholdExists)
+        {
+            return UpsertBudgetAllocationResult.HouseholdNotFound();
+        }
+
+        if (!access.IsMember)
+        {
+            return UpsertBudgetAllocationResult.AccessDenied();
+        }
+
+        var categoryId = new BudgetCategoryId(command.CategoryId);
+        var category = await repository.GetCategoryAsync(command.HouseholdId, categoryId, cancellationToken);
+        if (category is null)
+        {
+            return UpsertBudgetAllocationResult.CategoryNotFound();
+        }
+
+        var nowUtc = timeProvider.GetUtcNow();
+        var periodStartUtc = command.PeriodStartUtc?.ToUniversalTime() ?? BudgetPeriod.GetPeriodStart(nowUtc);
+        if (!BudgetPeriod.IsPeriodStart(periodStartUtc))
+        {
+            periodStartUtc = BudgetPeriod.GetPeriodStart(periodStartUtc);
+        }
+
+        if (periodStartUtc < nowUtc.AddMonths(-12) || periodStartUtc > nowUtc.AddMonths(12))
+        {
+            return UpsertBudgetAllocationResult.Validation(
+                BudgetErrors.BudgetPeriodInvalid,
+                "Budget period must be within 12 months of the current date.");
+        }
+
+        BudgetAllocation allocation;
+        try
+        {
+            var existing = await repository.GetAllocationAsync(
+                command.HouseholdId,
+                categoryId,
+                periodStartUtc,
+                cancellationToken);
+            if (existing is not null)
+            {
+                existing.UpdateAmount(command.Amount, nowUtc);
+                allocation = existing;
+            }
+            else
+            {
+                allocation = BudgetAllocation.Create(
+                    command.HouseholdId,
+                    categoryId,
+                    command.Amount,
+                    periodStartUtc,
+                    command.RequestingUserId,
+                    nowUtc);
+            }
+        }
+        catch (BudgetDomainException exception)
+        {
+            return UpsertBudgetAllocationResult.Validation(exception.Code, exception.Message);
+        }
+
+        var saved = await repository.UpsertAllocationAsync(allocation, cancellationToken);
+        return UpsertBudgetAllocationResult.Success(saved);
+    }
+}

--- a/backend/src/Modules/Budgets/Application/UpsertBudgetAllocation/UpsertBudgetAllocationResult.cs
+++ b/backend/src/Modules/Budgets/Application/UpsertBudgetAllocation/UpsertBudgetAllocationResult.cs
@@ -1,0 +1,58 @@
+using MoneyTracker.Modules.Budgets.Domain;
+
+namespace MoneyTracker.Modules.Budgets.Application.UpsertBudgetAllocation;
+
+public sealed class UpsertBudgetAllocationResult
+{
+    private UpsertBudgetAllocationResult(
+        BudgetAllocation? allocation,
+        string? errorCode,
+        string? errorMessage)
+    {
+        Allocation = allocation;
+        ErrorCode = errorCode;
+        ErrorMessage = errorMessage;
+    }
+
+    public BudgetAllocation? Allocation { get; }
+
+    public string? ErrorCode { get; }
+
+    public string? ErrorMessage { get; }
+
+    public bool IsSuccess => Allocation is not null;
+
+    public static UpsertBudgetAllocationResult Success(BudgetAllocation allocation)
+    {
+        return new UpsertBudgetAllocationResult(allocation, errorCode: null, errorMessage: null);
+    }
+
+    public static UpsertBudgetAllocationResult Validation(string code, string message)
+    {
+        return new UpsertBudgetAllocationResult(allocation: null, code, message);
+    }
+
+    public static UpsertBudgetAllocationResult CategoryNotFound()
+    {
+        return new UpsertBudgetAllocationResult(
+            allocation: null,
+            BudgetErrors.BudgetCategoryNotFound,
+            "Category not found.");
+    }
+
+    public static UpsertBudgetAllocationResult AccessDenied()
+    {
+        return new UpsertBudgetAllocationResult(
+            allocation: null,
+            BudgetErrors.BudgetAccessDenied,
+            "User is not a member of this household.");
+    }
+
+    public static UpsertBudgetAllocationResult HouseholdNotFound()
+    {
+        return new UpsertBudgetAllocationResult(
+            allocation: null,
+            BudgetErrors.BudgetHouseholdNotFound,
+            "Household not found.");
+    }
+}

--- a/backend/src/Modules/Budgets/Domain/BudgetAllocation.cs
+++ b/backend/src/Modules/Budgets/Domain/BudgetAllocation.cs
@@ -1,0 +1,78 @@
+namespace MoneyTracker.Modules.Budgets.Domain;
+
+public sealed class BudgetAllocation
+{
+    public BudgetAllocationId Id { get; }
+    public Guid HouseholdId { get; }
+    public BudgetCategoryId CategoryId { get; }
+    public decimal Amount { get; private set; }
+    public DateTimeOffset PeriodStartUtc { get; }
+    public Guid CreatedByUserId { get; }
+    public DateTimeOffset CreatedAtUtc { get; }
+    public DateTimeOffset UpdatedAtUtc { get; private set; }
+
+    private BudgetAllocation(
+        BudgetAllocationId id,
+        Guid householdId,
+        BudgetCategoryId categoryId,
+        decimal amount,
+        DateTimeOffset periodStartUtc,
+        Guid createdByUserId,
+        DateTimeOffset createdAtUtc,
+        DateTimeOffset updatedAtUtc)
+    {
+        Id = id;
+        HouseholdId = householdId;
+        CategoryId = categoryId;
+        Amount = amount;
+        PeriodStartUtc = periodStartUtc;
+        CreatedByUserId = createdByUserId;
+        CreatedAtUtc = createdAtUtc;
+        UpdatedAtUtc = updatedAtUtc;
+    }
+
+    public static BudgetAllocation Create(
+        Guid householdId,
+        BudgetCategoryId categoryId,
+        decimal amount,
+        DateTimeOffset periodStartUtc,
+        Guid createdByUserId,
+        DateTimeOffset nowUtc)
+    {
+        ValidateAmount(amount);
+
+        if (!BudgetPeriod.IsPeriodStart(periodStartUtc))
+        {
+            throw new BudgetDomainException(
+                BudgetErrors.BudgetPeriodInvalid,
+                "Budget period must start at the beginning of a calendar month in UTC.");
+        }
+
+        return new BudgetAllocation(
+            BudgetAllocationId.New(),
+            householdId,
+            categoryId,
+            amount,
+            periodStartUtc,
+            createdByUserId,
+            nowUtc,
+            nowUtc);
+    }
+
+    public void UpdateAmount(decimal amount, DateTimeOffset nowUtc)
+    {
+        ValidateAmount(amount);
+        Amount = amount;
+        UpdatedAtUtc = nowUtc;
+    }
+
+    private static void ValidateAmount(decimal amount)
+    {
+        if (amount < 0)
+        {
+            throw new BudgetDomainException(
+                BudgetErrors.BudgetAllocationAmountInvalid,
+                "Budget allocation amount must be zero or greater.");
+        }
+    }
+}

--- a/backend/src/Modules/Budgets/Domain/BudgetAllocationId.cs
+++ b/backend/src/Modules/Budgets/Domain/BudgetAllocationId.cs
@@ -1,0 +1,6 @@
+namespace MoneyTracker.Modules.Budgets.Domain;
+
+public readonly record struct BudgetAllocationId(Guid Value)
+{
+    public static BudgetAllocationId New() => new(Guid.NewGuid());
+}

--- a/backend/src/Modules/Budgets/Domain/BudgetCategory.cs
+++ b/backend/src/Modules/Budgets/Domain/BudgetCategory.cs
@@ -1,0 +1,69 @@
+namespace MoneyTracker.Modules.Budgets.Domain;
+
+public sealed class BudgetCategory
+{
+    public const int MaxNameLength = 80;
+
+    public BudgetCategoryId Id { get; }
+    public Guid HouseholdId { get; }
+    public string Name { get; }
+    public string NormalizedName { get; }
+    public Guid CreatedByUserId { get; }
+    public DateTimeOffset CreatedAtUtc { get; }
+
+    private BudgetCategory(
+        BudgetCategoryId id,
+        Guid householdId,
+        string name,
+        string normalizedName,
+        Guid createdByUserId,
+        DateTimeOffset createdAtUtc)
+    {
+        Id = id;
+        HouseholdId = householdId;
+        Name = name;
+        NormalizedName = normalizedName;
+        CreatedByUserId = createdByUserId;
+        CreatedAtUtc = createdAtUtc;
+    }
+
+    public static BudgetCategory Create(
+        Guid householdId,
+        string? name,
+        Guid createdByUserId,
+        DateTimeOffset nowUtc)
+    {
+        var trimmed = NormalizeName(name);
+        if (trimmed.Length == 0)
+        {
+            throw new BudgetDomainException(
+                BudgetErrors.BudgetCategoryNameRequired,
+                "Category name is required.");
+        }
+
+        if (trimmed.Length > MaxNameLength)
+        {
+            throw new BudgetDomainException(
+                BudgetErrors.ValidationError,
+                $"Category name must be {MaxNameLength} characters or fewer.");
+        }
+
+        return new BudgetCategory(
+            BudgetCategoryId.New(),
+            householdId,
+            trimmed,
+            NormalizeKey(trimmed),
+            createdByUserId,
+            nowUtc);
+    }
+
+    public static string NormalizeName(string? name)
+    {
+        return name?.Trim() ?? string.Empty;
+    }
+
+    public static string NormalizeKey(string name)
+    {
+        return name.Trim().ToUpperInvariant();
+    }
+}

--- a/backend/src/Modules/Budgets/Domain/BudgetCategoryId.cs
+++ b/backend/src/Modules/Budgets/Domain/BudgetCategoryId.cs
@@ -1,0 +1,6 @@
+namespace MoneyTracker.Modules.Budgets.Domain;
+
+public readonly record struct BudgetCategoryId(Guid Value)
+{
+    public static BudgetCategoryId New() => new(Guid.NewGuid());
+}

--- a/backend/src/Modules/Budgets/Domain/BudgetDomainException.cs
+++ b/backend/src/Modules/Budgets/Domain/BudgetDomainException.cs
@@ -1,0 +1,6 @@
+namespace MoneyTracker.Modules.Budgets.Domain;
+
+public sealed class BudgetDomainException(string code, string message) : InvalidOperationException(message)
+{
+    public string Code { get; } = code;
+}

--- a/backend/src/Modules/Budgets/Domain/BudgetErrors.cs
+++ b/backend/src/Modules/Budgets/Domain/BudgetErrors.cs
@@ -1,0 +1,13 @@
+namespace MoneyTracker.Modules.Budgets.Domain;
+
+public static class BudgetErrors
+{
+    public const string ValidationError = "validation_error";
+    public const string BudgetCategoryNameRequired = "budget_category_name_required";
+    public const string BudgetCategoryNameConflict = "budget_category_name_conflict";
+    public const string BudgetCategoryNotFound = "budget_category_not_found";
+    public const string BudgetAllocationAmountInvalid = "budget_allocation_amount_invalid";
+    public const string BudgetPeriodInvalid = "budget_period_invalid";
+    public const string BudgetHouseholdNotFound = "budget_household_not_found";
+    public const string BudgetAccessDenied = "budget_access_denied";
+}

--- a/backend/src/Modules/Budgets/Domain/BudgetPeriod.cs
+++ b/backend/src/Modules/Budgets/Domain/BudgetPeriod.cs
@@ -1,0 +1,22 @@
+namespace MoneyTracker.Modules.Budgets.Domain;
+
+public static class BudgetPeriod
+{
+    public static DateTimeOffset GetPeriodStart(DateTimeOffset nowUtc)
+    {
+        var utc = nowUtc.ToUniversalTime();
+        return new DateTimeOffset(
+            new DateTime(utc.Year, utc.Month, 1, 0, 0, 0, DateTimeKind.Utc));
+    }
+
+    public static DateTimeOffset GetPeriodEnd(DateTimeOffset periodStartUtc)
+    {
+        return periodStartUtc.AddMonths(1);
+    }
+
+    public static bool IsPeriodStart(DateTimeOffset periodStartUtc)
+    {
+        var utc = periodStartUtc.ToUniversalTime();
+        return utc.Day == 1 && utc.TimeOfDay == TimeSpan.Zero;
+    }
+}

--- a/backend/src/Modules/Budgets/Domain/IBudgetRepository.cs
+++ b/backend/src/Modules/Budgets/Domain/IBudgetRepository.cs
@@ -1,0 +1,30 @@
+namespace MoneyTracker.Modules.Budgets.Domain;
+
+public interface IBudgetRepository
+{
+    Task<bool> AddCategoryAsync(BudgetCategory category, CancellationToken cancellationToken);
+    Task<BudgetCategory?> GetCategoryAsync(
+        Guid householdId,
+        BudgetCategoryId categoryId,
+        CancellationToken cancellationToken);
+    Task<BudgetCategory?> GetCategoryByNameAsync(
+        Guid householdId,
+        string normalizedName,
+        CancellationToken cancellationToken);
+    Task<IReadOnlyCollection<BudgetCategory>> GetCategoriesAsync(
+        Guid householdId,
+        CancellationToken cancellationToken);
+
+    Task<BudgetAllocation?> GetAllocationAsync(
+        Guid householdId,
+        BudgetCategoryId categoryId,
+        DateTimeOffset periodStartUtc,
+        CancellationToken cancellationToken);
+    Task<IReadOnlyCollection<BudgetAllocation>> GetAllocationsAsync(
+        Guid householdId,
+        DateTimeOffset periodStartUtc,
+        CancellationToken cancellationToken);
+    Task<BudgetAllocation> UpsertAllocationAsync(
+        BudgetAllocation allocation,
+        CancellationToken cancellationToken);
+}

--- a/backend/src/Modules/Budgets/Infrastructure/InMemoryBudgetRepository.cs
+++ b/backend/src/Modules/Budgets/Infrastructure/InMemoryBudgetRepository.cs
@@ -1,0 +1,174 @@
+using MoneyTracker.Modules.Budgets.Domain;
+
+namespace MoneyTracker.Modules.Budgets.Infrastructure;
+
+public sealed class InMemoryBudgetRepository : IBudgetRepository
+{
+    private readonly object _sync = new();
+    private readonly Dictionary<Guid, Dictionary<string, BudgetCategory>> _categoriesByHouseholdName =
+        new();
+    private readonly Dictionary<Guid, Dictionary<BudgetCategoryId, BudgetCategory>> _categoriesByHouseholdId =
+        new();
+    private readonly Dictionary<Guid, Dictionary<(BudgetCategoryId, DateTimeOffset), BudgetAllocation>>
+        _allocationsByHousehold = new();
+
+    public Task<bool> AddCategoryAsync(BudgetCategory category, CancellationToken cancellationToken)
+    {
+        if (cancellationToken.IsCancellationRequested)
+        {
+            return Task.FromCanceled<bool>(cancellationToken);
+        }
+
+        lock (_sync)
+        {
+            var nameLookup = GetCategoryNameLookup(category.HouseholdId);
+            if (nameLookup.ContainsKey(category.NormalizedName))
+            {
+                return Task.FromResult(false);
+            }
+
+            nameLookup[category.NormalizedName] = category;
+            var idLookup = GetCategoryIdLookup(category.HouseholdId);
+            idLookup[category.Id] = category;
+            return Task.FromResult(true);
+        }
+    }
+
+    public Task<BudgetCategory?> GetCategoryAsync(
+        Guid householdId,
+        BudgetCategoryId categoryId,
+        CancellationToken cancellationToken)
+    {
+        if (cancellationToken.IsCancellationRequested)
+        {
+            return Task.FromCanceled<BudgetCategory?>(cancellationToken);
+        }
+
+        lock (_sync)
+        {
+            var idLookup = GetCategoryIdLookup(householdId);
+            return Task.FromResult<BudgetCategory?>(idLookup.GetValueOrDefault(categoryId));
+        }
+    }
+
+    public Task<BudgetCategory?> GetCategoryByNameAsync(
+        Guid householdId,
+        string normalizedName,
+        CancellationToken cancellationToken)
+    {
+        if (cancellationToken.IsCancellationRequested)
+        {
+            return Task.FromCanceled<BudgetCategory?>(cancellationToken);
+        }
+
+        lock (_sync)
+        {
+            var nameLookup = GetCategoryNameLookup(householdId);
+            return Task.FromResult<BudgetCategory?>(nameLookup.GetValueOrDefault(normalizedName));
+        }
+    }
+
+    public Task<IReadOnlyCollection<BudgetCategory>> GetCategoriesAsync(
+        Guid householdId,
+        CancellationToken cancellationToken)
+    {
+        if (cancellationToken.IsCancellationRequested)
+        {
+            return Task.FromCanceled<IReadOnlyCollection<BudgetCategory>>(cancellationToken);
+        }
+
+        lock (_sync)
+        {
+            var idLookup = GetCategoryIdLookup(householdId);
+            return Task.FromResult<IReadOnlyCollection<BudgetCategory>>(idLookup.Values.ToArray());
+        }
+    }
+
+    public Task<BudgetAllocation?> GetAllocationAsync(
+        Guid householdId,
+        BudgetCategoryId categoryId,
+        DateTimeOffset periodStartUtc,
+        CancellationToken cancellationToken)
+    {
+        if (cancellationToken.IsCancellationRequested)
+        {
+            return Task.FromCanceled<BudgetAllocation?>(cancellationToken);
+        }
+
+        lock (_sync)
+        {
+            var allocations = GetAllocationLookup(householdId);
+            return Task.FromResult<BudgetAllocation?>(allocations.GetValueOrDefault((categoryId, periodStartUtc)));
+        }
+    }
+
+    public Task<IReadOnlyCollection<BudgetAllocation>> GetAllocationsAsync(
+        Guid householdId,
+        DateTimeOffset periodStartUtc,
+        CancellationToken cancellationToken)
+    {
+        if (cancellationToken.IsCancellationRequested)
+        {
+            return Task.FromCanceled<IReadOnlyCollection<BudgetAllocation>>(cancellationToken);
+        }
+
+        lock (_sync)
+        {
+            var allocations = GetAllocationLookup(householdId);
+            var results = allocations.Values
+                .Where(allocation => allocation.PeriodStartUtc == periodStartUtc)
+                .ToArray();
+            return Task.FromResult<IReadOnlyCollection<BudgetAllocation>>(results);
+        }
+    }
+
+    public Task<BudgetAllocation> UpsertAllocationAsync(
+        BudgetAllocation allocation,
+        CancellationToken cancellationToken)
+    {
+        if (cancellationToken.IsCancellationRequested)
+        {
+            return Task.FromCanceled<BudgetAllocation>(cancellationToken);
+        }
+
+        lock (_sync)
+        {
+            var allocations = GetAllocationLookup(allocation.HouseholdId);
+            allocations[(allocation.CategoryId, allocation.PeriodStartUtc)] = allocation;
+            return Task.FromResult(allocation);
+        }
+    }
+
+    private Dictionary<string, BudgetCategory> GetCategoryNameLookup(Guid householdId)
+    {
+        if (!_categoriesByHouseholdName.TryGetValue(householdId, out var lookup))
+        {
+            lookup = new Dictionary<string, BudgetCategory>(StringComparer.OrdinalIgnoreCase);
+            _categoriesByHouseholdName[householdId] = lookup;
+        }
+
+        return lookup;
+    }
+
+    private Dictionary<BudgetCategoryId, BudgetCategory> GetCategoryIdLookup(Guid householdId)
+    {
+        if (!_categoriesByHouseholdId.TryGetValue(householdId, out var lookup))
+        {
+            lookup = new Dictionary<BudgetCategoryId, BudgetCategory>();
+            _categoriesByHouseholdId[householdId] = lookup;
+        }
+
+        return lookup;
+    }
+
+    private Dictionary<(BudgetCategoryId, DateTimeOffset), BudgetAllocation> GetAllocationLookup(Guid householdId)
+    {
+        if (!_allocationsByHousehold.TryGetValue(householdId, out var lookup))
+        {
+            lookup = new Dictionary<(BudgetCategoryId, DateTimeOffset), BudgetAllocation>();
+            _allocationsByHousehold[householdId] = lookup;
+        }
+
+        return lookup;
+    }
+}

--- a/backend/src/Modules/Budgets/MoneyTracker.Modules.Budgets.csproj
+++ b/backend/src/Modules/Budgets/MoneyTracker.Modules.Budgets.csproj
@@ -9,9 +9,7 @@
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <ProjectReference Include="..\\Auth\\MoneyTracker.Modules.Auth.csproj" />
-    <ProjectReference Include="..\\Budgets\\MoneyTracker.Modules.Budgets.csproj" />
     <ProjectReference Include="..\\SharedKernel\\MoneyTracker.Modules.SharedKernel.csproj" />
-    <ProjectReference Include="..\\Transactions\\MoneyTracker.Modules.Transactions.csproj" />
   </ItemGroup>
 
 </Project>

--- a/backend/src/Modules/Budgets/Presentation/BudgetEndpoints.cs
+++ b/backend/src/Modules/Budgets/Presentation/BudgetEndpoints.cs
@@ -1,0 +1,410 @@
+using System.Text.Json;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using MoneyTracker.Modules.Auth.Application.GetAuthenticatedUser;
+using MoneyTracker.Modules.Auth.Domain;
+using MoneyTracker.Modules.Budgets.Application.CreateBudgetCategory;
+using MoneyTracker.Modules.Budgets.Application.GetBudgetCategories;
+using MoneyTracker.Modules.Budgets.Application.UpsertBudgetAllocation;
+using MoneyTracker.Modules.Budgets.Domain;
+
+namespace MoneyTracker.Modules.Budgets.Presentation;
+
+public static class BudgetEndpoints
+{
+    public static IServiceCollection AddBudgetsModule(this IServiceCollection services)
+    {
+        services.AddSingleton<IBudgetRepository, Infrastructure.InMemoryBudgetRepository>();
+        services.AddSingleton(TimeProvider.System);
+        services.AddScoped<CreateBudgetCategoryHandler>();
+        services.AddScoped<GetBudgetCategoriesHandler>();
+        services.AddScoped<UpsertBudgetAllocationHandler>();
+
+        return services;
+    }
+
+    public static IEndpointRouteBuilder MapBudgetEndpoints(this IEndpointRouteBuilder app)
+    {
+        var createCategoryEndpoint = (RouteHandlerBuilder)app.MapPost("/budgets/categories", CreateBudgetCategory);
+        createCategoryEndpoint
+            .WithName("CreateBudgetCategory")
+            .WithSummary("Create a budget category.")
+            .WithDescription("Creates a household-scoped budget category.")
+            .Accepts<CreateBudgetCategoryRequest>("application/json")
+            .Produces<BudgetCategoryResponse>(StatusCodes.Status201Created)
+            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status403Forbidden)
+            .ProducesProblem(StatusCodes.Status404NotFound)
+            .ProducesProblem(StatusCodes.Status409Conflict);
+
+        app.MapGet("/budgets/categories", GetBudgetCategories)
+            .WithName("GetBudgetCategories")
+            .WithSummary("List budget categories.")
+            .WithDescription("Returns household-scoped budget categories.");
+
+        var upsertAllocationEndpoint = (RouteHandlerBuilder)app.MapPost("/budgets", UpsertBudgetAllocation);
+        upsertAllocationEndpoint
+            .WithName("UpsertBudgetAllocation")
+            .WithSummary("Create or update a budget allocation.")
+            .WithDescription("Creates or updates a monthly budget allocation for a category.")
+            .Accepts<UpsertBudgetAllocationRequest>("application/json")
+            .Produces<BudgetAllocationResponse>(StatusCodes.Status200OK)
+            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status403Forbidden)
+            .ProducesProblem(StatusCodes.Status404NotFound);
+
+        return app;
+    }
+
+    private static async Task CreateBudgetCategory(HttpContext httpContext)
+    {
+        var authResult = await ResolveAuthenticatedUser(httpContext);
+        if (!authResult.Success)
+        {
+            await authResult.Problem!.ExecuteAsync(httpContext);
+            return;
+        }
+
+        var (isValidRequest, request, parseProblem) =
+            await ReadJsonRequestAsync<CreateBudgetCategoryRequest>(httpContext);
+        if (!isValidRequest || request is null)
+        {
+            if (parseProblem is not null)
+            {
+                await parseProblem.ExecuteAsync(httpContext);
+            }
+            else
+            {
+                await WriteProblemAsync(
+                    httpContext,
+                    StatusCodes.Status400BadRequest,
+                    "Validation failed.",
+                    "The request payload is required.",
+                    BudgetErrors.ValidationError,
+                    BudgetErrors.ValidationError);
+            }
+            return;
+        }
+
+        var handler = httpContext.RequestServices.GetRequiredService<CreateBudgetCategoryHandler>();
+        var result = await handler.HandleAsync(
+            new CreateBudgetCategoryCommand(
+                request.HouseholdId,
+                request.Name,
+                authResult.AuthenticatedUser!.UserId),
+            httpContext.RequestAborted);
+
+        if (!result.IsSuccess)
+        {
+            var statusCode = result.ErrorCode switch
+            {
+                BudgetErrors.BudgetHouseholdNotFound => StatusCodes.Status404NotFound,
+                BudgetErrors.BudgetAccessDenied => StatusCodes.Status403Forbidden,
+                BudgetErrors.BudgetCategoryNameConflict => StatusCodes.Status409Conflict,
+                _ => StatusCodes.Status400BadRequest
+            };
+
+            await WriteProblemAsync(
+                httpContext,
+                statusCode,
+                statusCode == StatusCodes.Status403Forbidden ? "Access denied." : "Validation failed.",
+                result.ErrorMessage ?? "Request rejected.",
+                result.ErrorCode,
+                BudgetErrors.ValidationError);
+            return;
+        }
+
+        var category = result.Category!;
+        var response = new BudgetCategoryResponse(category.Id.Value, category.Name, category.CreatedAtUtc);
+        await TypedResults.Created($"/budgets/categories/{category.Id.Value}", response)
+            .ExecuteAsync(httpContext);
+    }
+
+    private static async Task GetBudgetCategories(HttpContext httpContext)
+    {
+        var authResult = await ResolveAuthenticatedUser(httpContext);
+        if (!authResult.Success)
+        {
+            await authResult.Problem!.ExecuteAsync(httpContext);
+            return;
+        }
+
+        if (!TryGetGuidQuery(httpContext, "householdId", out var householdId))
+        {
+            await WriteProblemAsync(
+                httpContext,
+                StatusCodes.Status400BadRequest,
+                "Validation failed.",
+                "householdId query parameter is required.",
+                BudgetErrors.ValidationError,
+                BudgetErrors.ValidationError);
+            return;
+        }
+
+        var handler = httpContext.RequestServices.GetRequiredService<GetBudgetCategoriesHandler>();
+        var result = await handler.HandleAsync(
+            new GetBudgetCategoriesQuery(householdId, authResult.AuthenticatedUser!.UserId),
+            httpContext.RequestAborted);
+
+        if (!result.IsSuccess)
+        {
+            var statusCode = result.ErrorCode switch
+            {
+                BudgetErrors.BudgetHouseholdNotFound => StatusCodes.Status404NotFound,
+                BudgetErrors.BudgetAccessDenied => StatusCodes.Status403Forbidden,
+                _ => StatusCodes.Status400BadRequest
+            };
+
+            await WriteProblemAsync(
+                httpContext,
+                statusCode,
+                statusCode == StatusCodes.Status403Forbidden ? "Access denied." : "Validation failed.",
+                result.ErrorMessage ?? "Request rejected.",
+                result.ErrorCode,
+                BudgetErrors.ValidationError);
+            return;
+        }
+
+        var response = new BudgetCategoriesResponse(
+            result.Categories!
+                .Select(category => new BudgetCategoryResponse(
+                    category.Id.Value,
+                    category.Name,
+                    category.CreatedAtUtc))
+                .ToArray());
+        await TypedResults.Ok(response).ExecuteAsync(httpContext);
+    }
+
+    private static async Task UpsertBudgetAllocation(HttpContext httpContext)
+    {
+        var authResult = await ResolveAuthenticatedUser(httpContext);
+        if (!authResult.Success)
+        {
+            await authResult.Problem!.ExecuteAsync(httpContext);
+            return;
+        }
+
+        var (isValidRequest, request, parseProblem) =
+            await ReadJsonRequestAsync<UpsertBudgetAllocationRequest>(httpContext);
+        if (!isValidRequest || request is null)
+        {
+            if (parseProblem is not null)
+            {
+                await parseProblem.ExecuteAsync(httpContext);
+            }
+            else
+            {
+                await WriteProblemAsync(
+                    httpContext,
+                    StatusCodes.Status400BadRequest,
+                    "Validation failed.",
+                    "The request payload is required.",
+                    BudgetErrors.ValidationError,
+                    BudgetErrors.ValidationError);
+            }
+            return;
+        }
+
+        var handler = httpContext.RequestServices.GetRequiredService<UpsertBudgetAllocationHandler>();
+        var result = await handler.HandleAsync(
+            new UpsertBudgetAllocationCommand(
+                request.HouseholdId,
+                request.CategoryId,
+                request.Amount,
+                request.PeriodStartUtc,
+                authResult.AuthenticatedUser!.UserId),
+            httpContext.RequestAborted);
+
+        if (!result.IsSuccess)
+        {
+            var statusCode = result.ErrorCode switch
+            {
+                BudgetErrors.BudgetHouseholdNotFound => StatusCodes.Status404NotFound,
+                BudgetErrors.BudgetAccessDenied => StatusCodes.Status403Forbidden,
+                BudgetErrors.BudgetCategoryNotFound => StatusCodes.Status404NotFound,
+                _ => StatusCodes.Status400BadRequest
+            };
+
+            await WriteProblemAsync(
+                httpContext,
+                statusCode,
+                statusCode == StatusCodes.Status403Forbidden ? "Access denied." : "Validation failed.",
+                result.ErrorMessage ?? "Request rejected.",
+                result.ErrorCode,
+                BudgetErrors.ValidationError);
+            return;
+        }
+
+        var allocation = result.Allocation!;
+        var response = new BudgetAllocationResponse(
+            allocation.Id.Value,
+            allocation.CategoryId.Value,
+            allocation.Amount,
+            allocation.PeriodStartUtc,
+            allocation.CreatedAtUtc,
+            allocation.UpdatedAtUtc);
+        await TypedResults.Ok(response).ExecuteAsync(httpContext);
+    }
+
+    private static async Task<(bool Success, AuthenticatedUser? AuthenticatedUser, IResult? Problem)> ResolveAuthenticatedUser(HttpContext httpContext)
+    {
+        var token = ExtractBearerToken(httpContext.Request.Headers.Authorization.ToString());
+        var handler = httpContext.RequestServices.GetRequiredService<GetAuthenticatedUserHandler>();
+        var authResult = await handler.HandleAsync(new GetAuthenticatedUserQuery(token), httpContext.RequestAborted);
+
+        if (!authResult.IsSuccess)
+        {
+            var problem = BuildProblemResult(
+                StatusCodes.Status401Unauthorized,
+                "Authentication required.",
+                authResult.ErrorMessage ?? "Authentication required.",
+                authResult.ErrorCode ?? AuthErrors.AccessTokenInvalid,
+                httpContext.Request.Path);
+
+            return (false, null, problem);
+        }
+
+        return (true, new AuthenticatedUser(authResult.UserId, authResult.Email), null);
+    }
+
+    private static string? ExtractBearerToken(string? authorizationHeader)
+    {
+        if (string.IsNullOrWhiteSpace(authorizationHeader))
+        {
+            return null;
+        }
+
+        if (!authorizationHeader.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase))
+        {
+            return null;
+        }
+
+        var token = authorizationHeader.Substring("Bearer ".Length).Trim();
+        return string.IsNullOrWhiteSpace(token) ? null : token;
+    }
+
+    private static async Task<(bool IsValid, TRequest? Request, IResult? Error)> ReadJsonRequestAsync<TRequest>(HttpContext httpContext)
+        where TRequest : class
+    {
+        var contentType = httpContext.Request.ContentType;
+        if (string.IsNullOrWhiteSpace(contentType) || !IsJsonContentType(contentType))
+        {
+            return (false, default, BuildProblemResult(
+                StatusCodes.Status400BadRequest,
+                "Validation failed.",
+                "The request payload is required to be JSON.",
+                BudgetErrors.ValidationError,
+                httpContext.Request.Path));
+        }
+
+        try
+        {
+            var request = await httpContext.Request.ReadFromJsonAsync<TRequest>(cancellationToken: httpContext.RequestAborted);
+            if (request is null)
+            {
+                return (false, default, BuildProblemResult(
+                    StatusCodes.Status400BadRequest,
+                    "Validation failed.",
+                    "The request payload is invalid.",
+                    BudgetErrors.ValidationError,
+                    httpContext.Request.Path));
+            }
+
+            return (true, request, null);
+        }
+        catch (JsonException)
+        {
+            return (false, default, BuildProblemResult(
+                StatusCodes.Status400BadRequest,
+                "Validation failed.",
+                "The request payload is invalid.",
+                BudgetErrors.ValidationError,
+                httpContext.Request.Path));
+        }
+        catch (NotSupportedException)
+        {
+            return (false, default, BuildProblemResult(
+                StatusCodes.Status400BadRequest,
+                "Validation failed.",
+                "The request payload is invalid.",
+                BudgetErrors.ValidationError,
+                httpContext.Request.Path));
+        }
+        catch (BadHttpRequestException)
+        {
+            return (false, default, BuildProblemResult(
+                StatusCodes.Status400BadRequest,
+                "Validation failed.",
+                "The request payload is invalid.",
+                BudgetErrors.ValidationError,
+                httpContext.Request.Path));
+        }
+    }
+
+    private static bool IsJsonContentType(string contentType)
+    {
+        var mediaType = contentType.Split(';')[0].Trim();
+        return mediaType.Equals("application/json", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool TryGetGuidQuery(HttpContext httpContext, string key, out Guid value)
+    {
+        value = Guid.Empty;
+        var raw = httpContext.Request.Query[key].FirstOrDefault();
+        return raw is not null && Guid.TryParse(raw, out value);
+    }
+
+    private static IResult BuildProblemResult(int statusCode, string title, string detail, string code, string instance)
+    {
+        var problem = new ProblemDetails
+        {
+            Status = statusCode,
+            Title = title,
+            Detail = detail,
+            Instance = instance
+        };
+        problem.Extensions["code"] = code;
+        return TypedResults.Problem(problem);
+    }
+
+    private static async Task WriteProblemAsync(
+        HttpContext httpContext,
+        int statusCode,
+        string title,
+        string detail,
+        string? code,
+        string fallbackCode)
+    {
+        await BuildProblemResult(
+            statusCode,
+            title,
+            detail,
+            code ?? fallbackCode,
+            httpContext.Request.Path).ExecuteAsync(httpContext);
+    }
+}
+
+public sealed record CreateBudgetCategoryRequest(Guid HouseholdId, string Name);
+
+public sealed record BudgetCategoryResponse(Guid Id, string Name, DateTimeOffset CreatedAtUtc);
+
+public sealed record BudgetCategoriesResponse(BudgetCategoryResponse[] Categories);
+
+public sealed record UpsertBudgetAllocationRequest(
+    Guid HouseholdId,
+    Guid CategoryId,
+    decimal Amount,
+    DateTimeOffset? PeriodStartUtc);
+
+public sealed record BudgetAllocationResponse(
+    Guid Id,
+    Guid CategoryId,
+    decimal Amount,
+    DateTimeOffset PeriodStartUtc,
+    DateTimeOffset CreatedAtUtc,
+    DateTimeOffset UpdatedAtUtc);
+
+internal sealed record AuthenticatedUser(Guid UserId, string Email);

--- a/backend/src/Modules/Households/Application/GetCurrentBudgetSnapshot/GetCurrentBudgetSnapshotHandler.cs
+++ b/backend/src/Modules/Households/Application/GetCurrentBudgetSnapshot/GetCurrentBudgetSnapshotHandler.cs
@@ -1,0 +1,79 @@
+using MoneyTracker.Modules.Budgets.Domain;
+using MoneyTracker.Modules.SharedKernel.Households;
+using MoneyTracker.Modules.Transactions.Domain;
+
+namespace MoneyTracker.Modules.Households.Application.GetCurrentBudgetSnapshot;
+
+public sealed class GetCurrentBudgetSnapshotHandler(
+    IBudgetRepository budgetRepository,
+    ITransactionRepository transactionRepository,
+    IHouseholdAccessService householdAccessService,
+    TimeProvider timeProvider)
+{
+    public async Task<GetCurrentBudgetSnapshotResult> HandleAsync(
+        GetCurrentBudgetSnapshotQuery query,
+        CancellationToken cancellationToken)
+    {
+        var access = await householdAccessService.CheckMemberAsync(
+            query.HouseholdId,
+            query.RequestingUserId,
+            cancellationToken);
+        if (!access.HouseholdExists)
+        {
+            return GetCurrentBudgetSnapshotResult.HouseholdNotFound();
+        }
+
+        if (!access.IsMember)
+        {
+            return GetCurrentBudgetSnapshotResult.AccessDenied();
+        }
+
+        var nowUtc = timeProvider.GetUtcNow();
+        var periodStartUtc = BudgetPeriod.GetPeriodStart(nowUtc);
+        var periodEndUtc = BudgetPeriod.GetPeriodEnd(periodStartUtc);
+        var periodEndInclusive = periodEndUtc.AddTicks(-1);
+
+        var categories = await budgetRepository.GetCategoriesAsync(query.HouseholdId, cancellationToken);
+        var allocations = await budgetRepository.GetAllocationsAsync(query.HouseholdId, periodStartUtc, cancellationToken);
+        var transactions = await transactionRepository.GetByHouseholdAsync(
+            query.HouseholdId,
+            periodStartUtc,
+            periodEndInclusive,
+            cancellationToken);
+
+        var allocationByCategory = allocations.ToDictionary(allocation => allocation.CategoryId.Value, allocation => allocation.Amount);
+        var spendByCategory = transactions
+            .Where(transaction => transaction.CategoryId.HasValue)
+            .GroupBy(transaction => transaction.CategoryId!.Value)
+            .ToDictionary(group => group.Key, group => group.Sum(transaction => transaction.Amount));
+
+        var categorySnapshots = categories
+            .OrderBy(category => category.Name, StringComparer.OrdinalIgnoreCase)
+            .Select(category =>
+            {
+                allocationByCategory.TryGetValue(category.Id.Value, out var allocated);
+                spendByCategory.TryGetValue(category.Id.Value, out var spent);
+                var remaining = allocated - spent;
+                return new BudgetCategorySnapshot(category.Id.Value, category.Name, allocated, spent, remaining);
+            })
+            .ToArray();
+
+        var totalAllocated = allocationByCategory.Values.Sum();
+        var totalSpent = transactions.Sum(transaction => transaction.Amount);
+        var uncategorizedSpent = transactions
+            .Where(transaction => transaction.CategoryId is null)
+            .Sum(transaction => transaction.Amount);
+
+        var snapshot = new CurrentBudgetSnapshot(
+            query.HouseholdId,
+            periodStartUtc,
+            periodEndUtc,
+            totalAllocated,
+            totalSpent,
+            totalAllocated - totalSpent,
+            uncategorizedSpent,
+            categorySnapshots);
+
+        return GetCurrentBudgetSnapshotResult.Success(snapshot);
+    }
+}

--- a/backend/src/Modules/Households/Application/GetCurrentBudgetSnapshot/GetCurrentBudgetSnapshotQuery.cs
+++ b/backend/src/Modules/Households/Application/GetCurrentBudgetSnapshot/GetCurrentBudgetSnapshotQuery.cs
@@ -1,0 +1,3 @@
+namespace MoneyTracker.Modules.Households.Application.GetCurrentBudgetSnapshot;
+
+public sealed record GetCurrentBudgetSnapshotQuery(Guid HouseholdId, Guid RequestingUserId);

--- a/backend/src/Modules/Households/Application/GetCurrentBudgetSnapshot/GetCurrentBudgetSnapshotResult.cs
+++ b/backend/src/Modules/Households/Application/GetCurrentBudgetSnapshot/GetCurrentBudgetSnapshotResult.cs
@@ -1,0 +1,60 @@
+namespace MoneyTracker.Modules.Households.Application.GetCurrentBudgetSnapshot;
+
+public sealed class GetCurrentBudgetSnapshotResult
+{
+    private GetCurrentBudgetSnapshotResult(
+        CurrentBudgetSnapshot? snapshot,
+        string? errorCode,
+        string? errorMessage)
+    {
+        Snapshot = snapshot;
+        ErrorCode = errorCode;
+        ErrorMessage = errorMessage;
+    }
+
+    public CurrentBudgetSnapshot? Snapshot { get; }
+
+    public string? ErrorCode { get; }
+
+    public string? ErrorMessage { get; }
+
+    public bool IsSuccess => Snapshot is not null;
+
+    public static GetCurrentBudgetSnapshotResult Success(CurrentBudgetSnapshot snapshot)
+    {
+        return new GetCurrentBudgetSnapshotResult(snapshot, errorCode: null, errorMessage: null);
+    }
+
+    public static GetCurrentBudgetSnapshotResult AccessDenied()
+    {
+        return new GetCurrentBudgetSnapshotResult(
+            snapshot: null,
+            MoneyTracker.Modules.Budgets.Domain.BudgetErrors.BudgetAccessDenied,
+            "User is not a member of this household.");
+    }
+
+    public static GetCurrentBudgetSnapshotResult HouseholdNotFound()
+    {
+        return new GetCurrentBudgetSnapshotResult(
+            snapshot: null,
+            MoneyTracker.Modules.Budgets.Domain.BudgetErrors.BudgetHouseholdNotFound,
+            "Household not found.");
+    }
+}
+
+public sealed record CurrentBudgetSnapshot(
+    Guid HouseholdId,
+    DateTimeOffset PeriodStartUtc,
+    DateTimeOffset PeriodEndUtc,
+    decimal TotalAllocated,
+    decimal TotalSpent,
+    decimal TotalRemaining,
+    decimal UncategorizedSpent,
+    BudgetCategorySnapshot[] Categories);
+
+public sealed record BudgetCategorySnapshot(
+    Guid CategoryId,
+    string Name,
+    decimal Allocated,
+    decimal Spent,
+    decimal Remaining);

--- a/backend/src/Modules/Households/Infrastructure/HouseholdAccessService.cs
+++ b/backend/src/Modules/Households/Infrastructure/HouseholdAccessService.cs
@@ -1,0 +1,36 @@
+using MoneyTracker.Modules.Households.Domain;
+using MoneyTracker.Modules.SharedKernel.Households;
+
+namespace MoneyTracker.Modules.Households.Infrastructure;
+
+public sealed class HouseholdAccessService(IHouseholdRepository repository) : IHouseholdAccessService
+{
+    public async Task<HouseholdAccessResult> CheckMemberAsync(
+        Guid householdId,
+        Guid userId,
+        CancellationToken cancellationToken)
+    {
+        var household = await repository.GetByIdAsync(new HouseholdId(householdId), cancellationToken);
+        if (household is null)
+        {
+            return HouseholdAccessResult.NotFound();
+        }
+
+        return household.IsMember(userId)
+            ? HouseholdAccessResult.Allowed()
+            : HouseholdAccessResult.Denied();
+    }
+
+    public async Task<IReadOnlyCollection<Guid>> GetMemberIdsAsync(
+        Guid householdId,
+        CancellationToken cancellationToken)
+    {
+        var household = await repository.GetByIdAsync(new HouseholdId(householdId), cancellationToken);
+        if (household is null)
+        {
+            return Array.Empty<Guid>();
+        }
+
+        return household.Members.Select(member => member.UserId).ToArray();
+    }
+}

--- a/backend/src/Modules/Households/Presentation/BudgetSnapshotEndpoint.cs
+++ b/backend/src/Modules/Households/Presentation/BudgetSnapshotEndpoint.cs
@@ -178,5 +178,3 @@ public sealed record BudgetCategorySnapshotResponse(
     decimal Allocated,
     decimal Spent,
     decimal Remaining);
-
-internal sealed record AuthenticatedUser(Guid UserId, string Email);

--- a/backend/src/Modules/Households/Presentation/BudgetSnapshotEndpoint.cs
+++ b/backend/src/Modules/Households/Presentation/BudgetSnapshotEndpoint.cs
@@ -1,0 +1,182 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using MoneyTracker.Modules.Auth.Application.GetAuthenticatedUser;
+using MoneyTracker.Modules.Auth.Domain;
+using MoneyTracker.Modules.Budgets.Domain;
+using MoneyTracker.Modules.Households.Application.GetCurrentBudgetSnapshot;
+
+namespace MoneyTracker.Modules.Households.Presentation;
+
+public static class BudgetSnapshotEndpoint
+{
+    public static IEndpointRouteBuilder MapBudgetSnapshotEndpoints(this IEndpointRouteBuilder app)
+    {
+        app.MapGet("/budgets/current", GetCurrentBudgetSnapshot)
+            .WithName("GetCurrentBudgetSnapshot")
+            .WithSummary("Get the current budget snapshot.")
+            .WithDescription("Returns budget allocations and transaction totals for the current month.");
+
+        return app;
+    }
+
+    private static async Task GetCurrentBudgetSnapshot(HttpContext httpContext)
+    {
+        var authResult = await ResolveAuthenticatedUser(httpContext);
+        if (!authResult.Success)
+        {
+            await authResult.Problem!.ExecuteAsync(httpContext);
+            return;
+        }
+
+        if (!TryGetGuidQuery(httpContext, "householdId", out var householdId))
+        {
+            await WriteProblemAsync(
+                httpContext,
+                StatusCodes.Status400BadRequest,
+                "Validation failed.",
+                "householdId query parameter is required.",
+                BudgetErrors.ValidationError,
+                BudgetErrors.ValidationError);
+            return;
+        }
+
+        var handler = httpContext.RequestServices.GetRequiredService<GetCurrentBudgetSnapshotHandler>();
+        var result = await handler.HandleAsync(
+            new GetCurrentBudgetSnapshotQuery(householdId, authResult.AuthenticatedUser!.UserId),
+            httpContext.RequestAborted);
+
+        if (!result.IsSuccess)
+        {
+            var statusCode = result.ErrorCode switch
+            {
+                BudgetErrors.BudgetHouseholdNotFound => StatusCodes.Status404NotFound,
+                BudgetErrors.BudgetAccessDenied => StatusCodes.Status403Forbidden,
+                _ => StatusCodes.Status400BadRequest
+            };
+
+            await WriteProblemAsync(
+                httpContext,
+                statusCode,
+                statusCode == StatusCodes.Status403Forbidden ? "Access denied." : "Validation failed.",
+                result.ErrorMessage ?? "Request rejected.",
+                result.ErrorCode,
+                BudgetErrors.ValidationError);
+            return;
+        }
+
+        var snapshot = result.Snapshot!;
+        var response = new CurrentBudgetSnapshotResponse(
+            snapshot.HouseholdId,
+            snapshot.PeriodStartUtc,
+            snapshot.PeriodEndUtc,
+            snapshot.TotalAllocated,
+            snapshot.TotalSpent,
+            snapshot.TotalRemaining,
+            snapshot.UncategorizedSpent,
+            snapshot.Categories
+                .Select(category => new BudgetCategorySnapshotResponse(
+                    category.CategoryId,
+                    category.Name,
+                    category.Allocated,
+                    category.Spent,
+                    category.Remaining))
+                .ToArray());
+
+        await TypedResults.Ok(response).ExecuteAsync(httpContext);
+    }
+
+    private static async Task<(bool Success, AuthenticatedUser? AuthenticatedUser, IResult? Problem)> ResolveAuthenticatedUser(HttpContext httpContext)
+    {
+        var token = ExtractBearerToken(httpContext.Request.Headers.Authorization.ToString());
+        var handler = httpContext.RequestServices.GetRequiredService<GetAuthenticatedUserHandler>();
+        var authResult = await handler.HandleAsync(new GetAuthenticatedUserQuery(token), httpContext.RequestAborted);
+
+        if (!authResult.IsSuccess)
+        {
+            var problem = BuildProblemResult(
+                StatusCodes.Status401Unauthorized,
+                "Authentication required.",
+                authResult.ErrorMessage ?? "Authentication required.",
+                authResult.ErrorCode ?? AuthErrors.AccessTokenInvalid,
+                httpContext.Request.Path);
+
+            return (false, null, problem);
+        }
+
+        return (true, new AuthenticatedUser(authResult.UserId, authResult.Email), null);
+    }
+
+    private static string? ExtractBearerToken(string? authorizationHeader)
+    {
+        if (string.IsNullOrWhiteSpace(authorizationHeader))
+        {
+            return null;
+        }
+
+        if (!authorizationHeader.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase))
+        {
+            return null;
+        }
+
+        var token = authorizationHeader.Substring("Bearer ".Length).Trim();
+        return string.IsNullOrWhiteSpace(token) ? null : token;
+    }
+
+    private static bool TryGetGuidQuery(HttpContext httpContext, string key, out Guid value)
+    {
+        value = Guid.Empty;
+        var raw = httpContext.Request.Query[key].FirstOrDefault();
+        return raw is not null && Guid.TryParse(raw, out value);
+    }
+
+    private static IResult BuildProblemResult(int statusCode, string title, string detail, string code, string instance)
+    {
+        var problem = new ProblemDetails
+        {
+            Status = statusCode,
+            Title = title,
+            Detail = detail,
+            Instance = instance
+        };
+        problem.Extensions["code"] = code;
+        return TypedResults.Problem(problem);
+    }
+
+    private static async Task WriteProblemAsync(
+        HttpContext httpContext,
+        int statusCode,
+        string title,
+        string detail,
+        string? code,
+        string fallbackCode)
+    {
+        await BuildProblemResult(
+            statusCode,
+            title,
+            detail,
+            code ?? fallbackCode,
+            httpContext.Request.Path).ExecuteAsync(httpContext);
+    }
+}
+
+public sealed record CurrentBudgetSnapshotResponse(
+    Guid HouseholdId,
+    DateTimeOffset PeriodStartUtc,
+    DateTimeOffset PeriodEndUtc,
+    decimal TotalAllocated,
+    decimal TotalSpent,
+    decimal TotalRemaining,
+    decimal UncategorizedSpent,
+    BudgetCategorySnapshotResponse[] Categories);
+
+public sealed record BudgetCategorySnapshotResponse(
+    Guid CategoryId,
+    string Name,
+    decimal Allocated,
+    decimal Spent,
+    decimal Remaining);
+
+internal sealed record AuthenticatedUser(Guid UserId, string Email);

--- a/backend/src/Modules/Households/Presentation/CreateHouseholdEndpoint.cs
+++ b/backend/src/Modules/Households/Presentation/CreateHouseholdEndpoint.cs
@@ -8,9 +8,11 @@ using MoneyTracker.Modules.Auth.Application.GetAuthenticatedUser;
 using MoneyTracker.Modules.Auth.Domain;
 using MoneyTracker.Modules.Households.Application.AcceptHouseholdInvitation;
 using MoneyTracker.Modules.Households.Application.CreateHousehold;
+using MoneyTracker.Modules.Households.Application.GetCurrentBudgetSnapshot;
 using MoneyTracker.Modules.Households.Application.GetHouseholdMembers;
 using MoneyTracker.Modules.Households.Application.InviteHouseholdMember;
 using MoneyTracker.Modules.Households.Domain;
+using MoneyTracker.Modules.SharedKernel.Households;
 
 namespace MoneyTracker.Modules.Households.Presentation;
 
@@ -19,11 +21,13 @@ public static class CreateHouseholdEndpoint
     public static IServiceCollection AddHouseholdsModule(this IServiceCollection services)
     {
         services.AddSingleton<IHouseholdRepository, Infrastructure.InMemoryHouseholdRepository>();
+        services.AddScoped<IHouseholdAccessService, Infrastructure.HouseholdAccessService>();
         services.AddSingleton(TimeProvider.System);
         services.AddScoped<CreateHouseholdHandler>();
         services.AddScoped<InviteHouseholdMemberHandler>();
         services.AddScoped<AcceptHouseholdInvitationHandler>();
         services.AddScoped<GetHouseholdMembersHandler>();
+        services.AddScoped<GetCurrentBudgetSnapshotHandler>();
 
         return services;
     }

--- a/backend/src/Modules/SharedKernel/Households/IHouseholdAccessService.cs
+++ b/backend/src/Modules/SharedKernel/Households/IHouseholdAccessService.cs
@@ -1,0 +1,22 @@
+namespace MoneyTracker.Modules.SharedKernel.Households;
+
+public readonly record struct HouseholdAccessResult(bool HouseholdExists, bool IsMember)
+{
+    public static HouseholdAccessResult NotFound() => new(false, false);
+
+    public static HouseholdAccessResult Denied() => new(true, false);
+
+    public static HouseholdAccessResult Allowed() => new(true, true);
+}
+
+public interface IHouseholdAccessService
+{
+    Task<HouseholdAccessResult> CheckMemberAsync(
+        Guid householdId,
+        Guid userId,
+        CancellationToken cancellationToken);
+
+    Task<IReadOnlyCollection<Guid>> GetMemberIdsAsync(
+        Guid householdId,
+        CancellationToken cancellationToken);
+}

--- a/backend/src/Modules/SharedKernel/MoneyTracker.Modules.SharedKernel.csproj
+++ b/backend/src/Modules/SharedKernel/MoneyTracker.Modules.SharedKernel.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/backend/src/Modules/Transactions/Application/CreateTransaction/CreateTransactionCommand.cs
+++ b/backend/src/Modules/Transactions/Application/CreateTransaction/CreateTransactionCommand.cs
@@ -1,0 +1,9 @@
+namespace MoneyTracker.Modules.Transactions.Application.CreateTransaction;
+
+public sealed record CreateTransactionCommand(
+    Guid HouseholdId,
+    decimal Amount,
+    DateTimeOffset OccurredAtUtc,
+    string? Description,
+    Guid? CategoryId,
+    Guid RequestingUserId);

--- a/backend/src/Modules/Transactions/Application/CreateTransaction/CreateTransactionHandler.cs
+++ b/backend/src/Modules/Transactions/Application/CreateTransaction/CreateTransactionHandler.cs
@@ -1,0 +1,63 @@
+using MoneyTracker.Modules.Budgets.Domain;
+using MoneyTracker.Modules.SharedKernel.Households;
+using MoneyTracker.Modules.Transactions.Domain;
+
+namespace MoneyTracker.Modules.Transactions.Application.CreateTransaction;
+
+public sealed class CreateTransactionHandler(
+    ITransactionRepository transactionRepository,
+    IBudgetRepository budgetRepository,
+    IHouseholdAccessService householdAccessService,
+    TimeProvider timeProvider)
+{
+    public async Task<CreateTransactionResult> HandleAsync(
+        CreateTransactionCommand command,
+        CancellationToken cancellationToken)
+    {
+        var access = await householdAccessService.CheckMemberAsync(
+            command.HouseholdId,
+            command.RequestingUserId,
+            cancellationToken);
+        if (!access.HouseholdExists)
+        {
+            return CreateTransactionResult.HouseholdNotFound();
+        }
+
+        if (!access.IsMember)
+        {
+            return CreateTransactionResult.AccessDenied();
+        }
+
+        if (command.CategoryId.HasValue)
+        {
+            var category = await budgetRepository.GetCategoryAsync(
+                command.HouseholdId,
+                new BudgetCategoryId(command.CategoryId.Value),
+                cancellationToken);
+            if (category is null)
+            {
+                return CreateTransactionResult.CategoryNotFound();
+            }
+        }
+
+        Transaction transaction;
+        try
+        {
+            transaction = Transaction.Create(
+                command.HouseholdId,
+                command.RequestingUserId,
+                command.Amount,
+                command.OccurredAtUtc,
+                command.Description,
+                command.CategoryId,
+                timeProvider.GetUtcNow());
+        }
+        catch (TransactionDomainException exception)
+        {
+            return CreateTransactionResult.Validation(exception.Code, exception.Message);
+        }
+
+        await transactionRepository.AddAsync(transaction, cancellationToken);
+        return CreateTransactionResult.Success(transaction);
+    }
+}

--- a/backend/src/Modules/Transactions/Application/CreateTransaction/CreateTransactionResult.cs
+++ b/backend/src/Modules/Transactions/Application/CreateTransaction/CreateTransactionResult.cs
@@ -1,0 +1,55 @@
+using MoneyTracker.Modules.Transactions.Domain;
+
+namespace MoneyTracker.Modules.Transactions.Application.CreateTransaction;
+
+public sealed class CreateTransactionResult
+{
+    private CreateTransactionResult(Transaction? transaction, string? errorCode, string? errorMessage)
+    {
+        Transaction = transaction;
+        ErrorCode = errorCode;
+        ErrorMessage = errorMessage;
+    }
+
+    public Transaction? Transaction { get; }
+
+    public string? ErrorCode { get; }
+
+    public string? ErrorMessage { get; }
+
+    public bool IsSuccess => Transaction is not null;
+
+    public static CreateTransactionResult Success(Transaction transaction)
+    {
+        return new CreateTransactionResult(transaction, errorCode: null, errorMessage: null);
+    }
+
+    public static CreateTransactionResult Validation(string code, string message)
+    {
+        return new CreateTransactionResult(transaction: null, code, message);
+    }
+
+    public static CreateTransactionResult CategoryNotFound()
+    {
+        return new CreateTransactionResult(
+            transaction: null,
+            TransactionErrors.TransactionCategoryNotFound,
+            "Category not found.");
+    }
+
+    public static CreateTransactionResult AccessDenied()
+    {
+        return new CreateTransactionResult(
+            transaction: null,
+            TransactionErrors.TransactionAccessDenied,
+            "User is not a member of this household.");
+    }
+
+    public static CreateTransactionResult HouseholdNotFound()
+    {
+        return new CreateTransactionResult(
+            transaction: null,
+            TransactionErrors.TransactionHouseholdNotFound,
+            "Household not found.");
+    }
+}

--- a/backend/src/Modules/Transactions/Application/GetTransactions/GetTransactionsHandler.cs
+++ b/backend/src/Modules/Transactions/Application/GetTransactions/GetTransactionsHandler.cs
@@ -1,0 +1,55 @@
+using MoneyTracker.Modules.Budgets.Domain;
+using MoneyTracker.Modules.SharedKernel.Households;
+using MoneyTracker.Modules.Transactions.Domain;
+
+namespace MoneyTracker.Modules.Transactions.Application.GetTransactions;
+
+public sealed class GetTransactionsHandler(
+    ITransactionRepository transactionRepository,
+    IBudgetRepository budgetRepository,
+    IHouseholdAccessService householdAccessService)
+{
+    public async Task<GetTransactionsResult> HandleAsync(
+        GetTransactionsQuery query,
+        CancellationToken cancellationToken)
+    {
+        var access = await householdAccessService.CheckMemberAsync(
+            query.HouseholdId,
+            query.RequestingUserId,
+            cancellationToken);
+        if (!access.HouseholdExists)
+        {
+            return GetTransactionsResult.HouseholdNotFound();
+        }
+
+        if (!access.IsMember)
+        {
+            return GetTransactionsResult.AccessDenied();
+        }
+
+        var transactions = await transactionRepository.GetByHouseholdAsync(
+            query.HouseholdId,
+            query.FromUtc,
+            query.ToUtc,
+            cancellationToken);
+        var categories = await budgetRepository.GetCategoriesAsync(query.HouseholdId, cancellationToken);
+        var categoryLookup = categories.ToDictionary(category => category.Id.Value, category => category.Name);
+
+        var summaries = transactions
+            .OrderByDescending(transaction => transaction.OccurredAtUtc)
+            .Select(transaction => new TransactionSummary(
+                transaction.Id.Value,
+                transaction.HouseholdId,
+                transaction.Amount,
+                transaction.OccurredAtUtc,
+                transaction.Description,
+                transaction.CategoryId,
+                transaction.CategoryId.HasValue && categoryLookup.TryGetValue(transaction.CategoryId.Value, out var name)
+                    ? name
+                    : null,
+                transaction.CreatedAtUtc))
+            .ToArray();
+
+        return GetTransactionsResult.Success(summaries);
+    }
+}

--- a/backend/src/Modules/Transactions/Application/GetTransactions/GetTransactionsQuery.cs
+++ b/backend/src/Modules/Transactions/Application/GetTransactions/GetTransactionsQuery.cs
@@ -1,0 +1,7 @@
+namespace MoneyTracker.Modules.Transactions.Application.GetTransactions;
+
+public sealed record GetTransactionsQuery(
+    Guid HouseholdId,
+    Guid RequestingUserId,
+    DateTimeOffset? FromUtc,
+    DateTimeOffset? ToUtc);

--- a/backend/src/Modules/Transactions/Application/GetTransactions/GetTransactionsResult.cs
+++ b/backend/src/Modules/Transactions/Application/GetTransactions/GetTransactionsResult.cs
@@ -1,0 +1,55 @@
+using MoneyTracker.Modules.Transactions.Domain;
+
+namespace MoneyTracker.Modules.Transactions.Application.GetTransactions;
+
+public sealed class GetTransactionsResult
+{
+    private GetTransactionsResult(
+        IReadOnlyCollection<TransactionSummary>? transactions,
+        string? errorCode,
+        string? errorMessage)
+    {
+        Transactions = transactions;
+        ErrorCode = errorCode;
+        ErrorMessage = errorMessage;
+    }
+
+    public IReadOnlyCollection<TransactionSummary>? Transactions { get; }
+
+    public string? ErrorCode { get; }
+
+    public string? ErrorMessage { get; }
+
+    public bool IsSuccess => Transactions is not null;
+
+    public static GetTransactionsResult Success(IReadOnlyCollection<TransactionSummary> transactions)
+    {
+        return new GetTransactionsResult(transactions, errorCode: null, errorMessage: null);
+    }
+
+    public static GetTransactionsResult AccessDenied()
+    {
+        return new GetTransactionsResult(
+            transactions: null,
+            TransactionErrors.TransactionAccessDenied,
+            "User is not a member of this household.");
+    }
+
+    public static GetTransactionsResult HouseholdNotFound()
+    {
+        return new GetTransactionsResult(
+            transactions: null,
+            TransactionErrors.TransactionHouseholdNotFound,
+            "Household not found.");
+    }
+}
+
+public sealed record TransactionSummary(
+    Guid Id,
+    Guid HouseholdId,
+    decimal Amount,
+    DateTimeOffset OccurredAtUtc,
+    string? Description,
+    Guid? CategoryId,
+    string? CategoryName,
+    DateTimeOffset CreatedAtUtc);

--- a/backend/src/Modules/Transactions/Domain/ITransactionRepository.cs
+++ b/backend/src/Modules/Transactions/Domain/ITransactionRepository.cs
@@ -1,0 +1,11 @@
+namespace MoneyTracker.Modules.Transactions.Domain;
+
+public interface ITransactionRepository
+{
+    Task AddAsync(Transaction transaction, CancellationToken cancellationToken);
+    Task<IReadOnlyCollection<Transaction>> GetByHouseholdAsync(
+        Guid householdId,
+        DateTimeOffset? fromUtc,
+        DateTimeOffset? toUtc,
+        CancellationToken cancellationToken);
+}

--- a/backend/src/Modules/Transactions/Domain/Transaction.cs
+++ b/backend/src/Modules/Transactions/Domain/Transaction.cs
@@ -41,14 +41,15 @@ public sealed class Transaction
         DateTimeOffset nowUtc)
     {
         ValidateAmount(amount);
-        ValidateOccurredAt(occurredAtUtc, nowUtc);
+        var utcOccurredAt = occurredAtUtc.ToUniversalTime();
+        ValidateOccurredAt(utcOccurredAt, nowUtc);
 
         return new Transaction(
             TransactionId.New(),
             householdId,
             createdByUserId,
             amount,
-            occurredAtUtc.ToUniversalTime(),
+            utcOccurredAt,
             NormalizeDescription(description),
             categoryId,
             nowUtc);
@@ -66,10 +67,9 @@ public sealed class Transaction
 
     private static void ValidateOccurredAt(DateTimeOffset occurredAtUtc, DateTimeOffset nowUtc)
     {
-        var utc = occurredAtUtc.ToUniversalTime();
         var min = nowUtc.Add(-TransactionPolicy.MaxPastSkew);
         var max = nowUtc.Add(TransactionPolicy.MaxFutureSkew);
-        if (utc < min || utc > max)
+        if (occurredAtUtc < min || occurredAtUtc > max)
         {
             throw new TransactionDomainException(
                 TransactionErrors.TransactionDateOutOfRange,

--- a/backend/src/Modules/Transactions/Domain/Transaction.cs
+++ b/backend/src/Modules/Transactions/Domain/Transaction.cs
@@ -1,0 +1,89 @@
+namespace MoneyTracker.Modules.Transactions.Domain;
+
+public sealed class Transaction
+{
+    public TransactionId Id { get; }
+    public Guid HouseholdId { get; }
+    public Guid CreatedByUserId { get; }
+    public decimal Amount { get; }
+    public DateTimeOffset OccurredAtUtc { get; }
+    public string? Description { get; }
+    public Guid? CategoryId { get; }
+    public DateTimeOffset CreatedAtUtc { get; }
+
+    private Transaction(
+        TransactionId id,
+        Guid householdId,
+        Guid createdByUserId,
+        decimal amount,
+        DateTimeOffset occurredAtUtc,
+        string? description,
+        Guid? categoryId,
+        DateTimeOffset createdAtUtc)
+    {
+        Id = id;
+        HouseholdId = householdId;
+        CreatedByUserId = createdByUserId;
+        Amount = amount;
+        OccurredAtUtc = occurredAtUtc;
+        Description = description;
+        CategoryId = categoryId;
+        CreatedAtUtc = createdAtUtc;
+    }
+
+    public static Transaction Create(
+        Guid householdId,
+        Guid createdByUserId,
+        decimal amount,
+        DateTimeOffset occurredAtUtc,
+        string? description,
+        Guid? categoryId,
+        DateTimeOffset nowUtc)
+    {
+        ValidateAmount(amount);
+        ValidateOccurredAt(occurredAtUtc, nowUtc);
+
+        return new Transaction(
+            TransactionId.New(),
+            householdId,
+            createdByUserId,
+            amount,
+            occurredAtUtc.ToUniversalTime(),
+            NormalizeDescription(description),
+            categoryId,
+            nowUtc);
+    }
+
+    private static void ValidateAmount(decimal amount)
+    {
+        if (amount <= 0)
+        {
+            throw new TransactionDomainException(
+                TransactionErrors.TransactionAmountInvalid,
+                "Transaction amount must be greater than zero.");
+        }
+    }
+
+    private static void ValidateOccurredAt(DateTimeOffset occurredAtUtc, DateTimeOffset nowUtc)
+    {
+        var utc = occurredAtUtc.ToUniversalTime();
+        var min = nowUtc.Add(-TransactionPolicy.MaxPastSkew);
+        var max = nowUtc.Add(TransactionPolicy.MaxFutureSkew);
+        if (utc < min || utc > max)
+        {
+            throw new TransactionDomainException(
+                TransactionErrors.TransactionDateOutOfRange,
+                "Transaction date is outside the allowed range.");
+        }
+    }
+
+    private static string? NormalizeDescription(string? description)
+    {
+        if (string.IsNullOrWhiteSpace(description))
+        {
+            return null;
+        }
+
+        return description.Trim();
+    }
+}

--- a/backend/src/Modules/Transactions/Domain/TransactionDomainException.cs
+++ b/backend/src/Modules/Transactions/Domain/TransactionDomainException.cs
@@ -1,0 +1,6 @@
+namespace MoneyTracker.Modules.Transactions.Domain;
+
+public sealed class TransactionDomainException(string code, string message) : InvalidOperationException(message)
+{
+    public string Code { get; } = code;
+}

--- a/backend/src/Modules/Transactions/Domain/TransactionErrors.cs
+++ b/backend/src/Modules/Transactions/Domain/TransactionErrors.cs
@@ -1,0 +1,11 @@
+namespace MoneyTracker.Modules.Transactions.Domain;
+
+public static class TransactionErrors
+{
+    public const string ValidationError = "validation_error";
+    public const string TransactionAmountInvalid = "transaction_amount_invalid";
+    public const string TransactionDateOutOfRange = "transaction_date_out_of_range";
+    public const string TransactionCategoryNotFound = "transaction_category_not_found";
+    public const string TransactionHouseholdNotFound = "transaction_household_not_found";
+    public const string TransactionAccessDenied = "transaction_access_denied";
+}

--- a/backend/src/Modules/Transactions/Domain/TransactionId.cs
+++ b/backend/src/Modules/Transactions/Domain/TransactionId.cs
@@ -1,0 +1,6 @@
+namespace MoneyTracker.Modules.Transactions.Domain;
+
+public readonly record struct TransactionId(Guid Value)
+{
+    public static TransactionId New() => new(Guid.NewGuid());
+}

--- a/backend/src/Modules/Transactions/Domain/TransactionPolicy.cs
+++ b/backend/src/Modules/Transactions/Domain/TransactionPolicy.cs
@@ -1,0 +1,7 @@
+namespace MoneyTracker.Modules.Transactions.Domain;
+
+public static class TransactionPolicy
+{
+    public static readonly TimeSpan MaxFutureSkew = TimeSpan.FromDays(1);
+    public static readonly TimeSpan MaxPastSkew = TimeSpan.FromDays(730);
+}

--- a/backend/src/Modules/Transactions/Infrastructure/InMemoryTransactionRepository.cs
+++ b/backend/src/Modules/Transactions/Infrastructure/InMemoryTransactionRepository.cs
@@ -1,0 +1,65 @@
+using MoneyTracker.Modules.Transactions.Domain;
+
+namespace MoneyTracker.Modules.Transactions.Infrastructure;
+
+public sealed class InMemoryTransactionRepository : ITransactionRepository
+{
+    private readonly object _sync = new();
+    private readonly Dictionary<Guid, List<Transaction>> _transactionsByHousehold = new();
+
+    public Task AddAsync(Transaction transaction, CancellationToken cancellationToken)
+    {
+        if (cancellationToken.IsCancellationRequested)
+        {
+            return Task.FromCanceled(cancellationToken);
+        }
+
+        lock (_sync)
+        {
+            if (!_transactionsByHousehold.TryGetValue(transaction.HouseholdId, out var list))
+            {
+                list = [];
+                _transactionsByHousehold[transaction.HouseholdId] = list;
+            }
+
+            list.Add(transaction);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public Task<IReadOnlyCollection<Transaction>> GetByHouseholdAsync(
+        Guid householdId,
+        DateTimeOffset? fromUtc,
+        DateTimeOffset? toUtc,
+        CancellationToken cancellationToken)
+    {
+        if (cancellationToken.IsCancellationRequested)
+        {
+            return Task.FromCanceled<IReadOnlyCollection<Transaction>>(cancellationToken);
+        }
+
+        lock (_sync)
+        {
+            if (!_transactionsByHousehold.TryGetValue(householdId, out var list))
+            {
+                return Task.FromResult<IReadOnlyCollection<Transaction>>(Array.Empty<Transaction>());
+            }
+
+            IEnumerable<Transaction> query = list;
+            if (fromUtc.HasValue)
+            {
+                var start = fromUtc.Value.ToUniversalTime();
+                query = query.Where(transaction => transaction.OccurredAtUtc >= start);
+            }
+
+            if (toUtc.HasValue)
+            {
+                var end = toUtc.Value.ToUniversalTime();
+                query = query.Where(transaction => transaction.OccurredAtUtc <= end);
+            }
+
+            return Task.FromResult<IReadOnlyCollection<Transaction>>(query.ToArray());
+        }
+    }
+}

--- a/backend/src/Modules/Transactions/MoneyTracker.Modules.Transactions.csproj
+++ b/backend/src/Modules/Transactions/MoneyTracker.Modules.Transactions.csproj
@@ -9,9 +9,8 @@
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <ProjectReference Include="..\\Auth\\MoneyTracker.Modules.Auth.csproj" />
-    <ProjectReference Include="..\\Budgets\\MoneyTracker.Modules.Budgets.csproj" />
     <ProjectReference Include="..\\SharedKernel\\MoneyTracker.Modules.SharedKernel.csproj" />
-    <ProjectReference Include="..\\Transactions\\MoneyTracker.Modules.Transactions.csproj" />
+    <ProjectReference Include="..\\Budgets\\MoneyTracker.Modules.Budgets.csproj" />
   </ItemGroup>
 
 </Project>

--- a/backend/src/Modules/Transactions/Presentation/TransactionEndpoints.cs
+++ b/backend/src/Modules/Transactions/Presentation/TransactionEndpoints.cs
@@ -140,8 +140,22 @@ public static class TransactionEndpoints
             return;
         }
 
-        var fromUtc = TryGetDateTimeOffsetQuery(httpContext, "fromUtc");
-        var toUtc = TryGetDateTimeOffsetQuery(httpContext, "toUtc");
+        var (fromUtc, fromValid) = TryGetDateTimeOffsetQuery(httpContext, "fromUtc");
+        var (toUtc, toValid) = TryGetDateTimeOffsetQuery(httpContext, "toUtc");
+        if (!fromValid || !toValid)
+        {
+            var message = !fromValid
+                ? "fromUtc query parameter is invalid."
+                : "toUtc query parameter is invalid.";
+            await WriteProblemAsync(
+                httpContext,
+                StatusCodes.Status400BadRequest,
+                "Validation failed.",
+                message,
+                TransactionErrors.ValidationError,
+                TransactionErrors.ValidationError);
+            return;
+        }
 
         var handler = httpContext.RequestServices.GetRequiredService<GetTransactionsHandler>();
         var result = await handler.HandleAsync(
@@ -289,15 +303,20 @@ public static class TransactionEndpoints
         return raw is not null && Guid.TryParse(raw, out value);
     }
 
-    private static DateTimeOffset? TryGetDateTimeOffsetQuery(HttpContext httpContext, string key)
+    private static (DateTimeOffset? Value, bool IsValid) TryGetDateTimeOffsetQuery(HttpContext httpContext, string key)
     {
         var raw = httpContext.Request.Query[key].FirstOrDefault();
         if (raw is null)
         {
-            return null;
+            return (null, true);
         }
 
-        return DateTimeOffset.TryParse(raw, out var value) ? value : null;
+        if (DateTimeOffset.TryParse(raw, out var value))
+        {
+            return (value, true);
+        }
+
+        return (null, false);
     }
 
     private static IResult BuildProblemResult(int statusCode, string title, string detail, string code, string instance)

--- a/backend/src/Modules/Transactions/Presentation/TransactionEndpoints.cs
+++ b/backend/src/Modules/Transactions/Presentation/TransactionEndpoints.cs
@@ -1,0 +1,360 @@
+using System.Text.Json;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using MoneyTracker.Modules.Auth.Application.GetAuthenticatedUser;
+using MoneyTracker.Modules.Auth.Domain;
+using MoneyTracker.Modules.Transactions.Application.CreateTransaction;
+using MoneyTracker.Modules.Transactions.Application.GetTransactions;
+using MoneyTracker.Modules.Transactions.Domain;
+
+namespace MoneyTracker.Modules.Transactions.Presentation;
+
+public static class TransactionEndpoints
+{
+    public static IServiceCollection AddTransactionsModule(this IServiceCollection services)
+    {
+        services.AddSingleton<ITransactionRepository, Infrastructure.InMemoryTransactionRepository>();
+        services.AddSingleton(TimeProvider.System);
+        services.AddScoped<CreateTransactionHandler>();
+        services.AddScoped<GetTransactionsHandler>();
+
+        return services;
+    }
+
+    public static IEndpointRouteBuilder MapTransactionEndpoints(this IEndpointRouteBuilder app)
+    {
+        var createTransactionEndpoint = (RouteHandlerBuilder)app.MapPost("/transactions", CreateTransaction);
+        createTransactionEndpoint
+            .WithName("CreateTransaction")
+            .WithSummary("Create a manual transaction.")
+            .WithDescription("Creates a household-scoped manual transaction entry.")
+            .Accepts<CreateTransactionRequest>("application/json")
+            .Produces<TransactionResponse>(StatusCodes.Status201Created)
+            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status403Forbidden)
+            .ProducesProblem(StatusCodes.Status404NotFound);
+
+        app.MapGet("/transactions", GetTransactions)
+            .WithName("GetTransactions")
+            .WithSummary("List transactions.")
+            .WithDescription("Returns household-scoped manual transactions.");
+
+        return app;
+    }
+
+    private static async Task CreateTransaction(HttpContext httpContext)
+    {
+        var authResult = await ResolveAuthenticatedUser(httpContext);
+        if (!authResult.Success)
+        {
+            await authResult.Problem!.ExecuteAsync(httpContext);
+            return;
+        }
+
+        var (isValidRequest, request, parseProblem) =
+            await ReadJsonRequestAsync<CreateTransactionRequest>(httpContext);
+        if (!isValidRequest || request is null)
+        {
+            if (parseProblem is not null)
+            {
+                await parseProblem.ExecuteAsync(httpContext);
+            }
+            else
+            {
+                await WriteProblemAsync(
+                    httpContext,
+                    StatusCodes.Status400BadRequest,
+                    "Validation failed.",
+                    "The request payload is required.",
+                    TransactionErrors.ValidationError,
+                    TransactionErrors.ValidationError);
+            }
+            return;
+        }
+
+        var handler = httpContext.RequestServices.GetRequiredService<CreateTransactionHandler>();
+        var result = await handler.HandleAsync(
+            new CreateTransactionCommand(
+                request.HouseholdId,
+                request.Amount,
+                request.OccurredAtUtc,
+                request.Description,
+                request.CategoryId,
+                authResult.AuthenticatedUser!.UserId),
+            httpContext.RequestAborted);
+
+        if (!result.IsSuccess)
+        {
+            var statusCode = result.ErrorCode switch
+            {
+                TransactionErrors.TransactionHouseholdNotFound => StatusCodes.Status404NotFound,
+                TransactionErrors.TransactionAccessDenied => StatusCodes.Status403Forbidden,
+                TransactionErrors.TransactionCategoryNotFound => StatusCodes.Status404NotFound,
+                _ => StatusCodes.Status400BadRequest
+            };
+
+            await WriteProblemAsync(
+                httpContext,
+                statusCode,
+                statusCode == StatusCodes.Status403Forbidden ? "Access denied." : "Validation failed.",
+                result.ErrorMessage ?? "Request rejected.",
+                result.ErrorCode,
+                TransactionErrors.ValidationError);
+            return;
+        }
+
+        var transaction = result.Transaction!;
+        var response = new TransactionResponse(
+            transaction.Id.Value,
+            transaction.HouseholdId,
+            transaction.Amount,
+            transaction.OccurredAtUtc,
+            transaction.Description,
+            transaction.CategoryId,
+            transaction.CreatedAtUtc);
+        await TypedResults.Created($"/transactions/{transaction.Id.Value}", response)
+            .ExecuteAsync(httpContext);
+    }
+
+    private static async Task GetTransactions(HttpContext httpContext)
+    {
+        var authResult = await ResolveAuthenticatedUser(httpContext);
+        if (!authResult.Success)
+        {
+            await authResult.Problem!.ExecuteAsync(httpContext);
+            return;
+        }
+
+        if (!TryGetGuidQuery(httpContext, "householdId", out var householdId))
+        {
+            await WriteProblemAsync(
+                httpContext,
+                StatusCodes.Status400BadRequest,
+                "Validation failed.",
+                "householdId query parameter is required.",
+                TransactionErrors.ValidationError,
+                TransactionErrors.ValidationError);
+            return;
+        }
+
+        var fromUtc = TryGetDateTimeOffsetQuery(httpContext, "fromUtc");
+        var toUtc = TryGetDateTimeOffsetQuery(httpContext, "toUtc");
+
+        var handler = httpContext.RequestServices.GetRequiredService<GetTransactionsHandler>();
+        var result = await handler.HandleAsync(
+            new GetTransactionsQuery(householdId, authResult.AuthenticatedUser!.UserId, fromUtc, toUtc),
+            httpContext.RequestAborted);
+
+        if (!result.IsSuccess)
+        {
+            var statusCode = result.ErrorCode switch
+            {
+                TransactionErrors.TransactionHouseholdNotFound => StatusCodes.Status404NotFound,
+                TransactionErrors.TransactionAccessDenied => StatusCodes.Status403Forbidden,
+                _ => StatusCodes.Status400BadRequest
+            };
+
+            await WriteProblemAsync(
+                httpContext,
+                statusCode,
+                statusCode == StatusCodes.Status403Forbidden ? "Access denied." : "Validation failed.",
+                result.ErrorMessage ?? "Request rejected.",
+                result.ErrorCode,
+                TransactionErrors.ValidationError);
+            return;
+        }
+
+        var response = new TransactionsResponse(
+            result.Transactions!
+                .Select(transaction => new TransactionSummaryResponse(
+                    transaction.Id,
+                    transaction.Amount,
+                    transaction.OccurredAtUtc,
+                    transaction.Description,
+                    transaction.CategoryId,
+                    transaction.CategoryName,
+                    transaction.CreatedAtUtc))
+                .ToArray());
+        await TypedResults.Ok(response).ExecuteAsync(httpContext);
+    }
+
+    private static async Task<(bool Success, AuthenticatedUser? AuthenticatedUser, IResult? Problem)> ResolveAuthenticatedUser(HttpContext httpContext)
+    {
+        var token = ExtractBearerToken(httpContext.Request.Headers.Authorization.ToString());
+        var handler = httpContext.RequestServices.GetRequiredService<GetAuthenticatedUserHandler>();
+        var authResult = await handler.HandleAsync(new GetAuthenticatedUserQuery(token), httpContext.RequestAborted);
+
+        if (!authResult.IsSuccess)
+        {
+            var problem = BuildProblemResult(
+                StatusCodes.Status401Unauthorized,
+                "Authentication required.",
+                authResult.ErrorMessage ?? "Authentication required.",
+                authResult.ErrorCode ?? AuthErrors.AccessTokenInvalid,
+                httpContext.Request.Path);
+
+            return (false, null, problem);
+        }
+
+        return (true, new AuthenticatedUser(authResult.UserId, authResult.Email), null);
+    }
+
+    private static string? ExtractBearerToken(string? authorizationHeader)
+    {
+        if (string.IsNullOrWhiteSpace(authorizationHeader))
+        {
+            return null;
+        }
+
+        if (!authorizationHeader.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase))
+        {
+            return null;
+        }
+
+        var token = authorizationHeader.Substring("Bearer ".Length).Trim();
+        return string.IsNullOrWhiteSpace(token) ? null : token;
+    }
+
+    private static async Task<(bool IsValid, TRequest? Request, IResult? Error)> ReadJsonRequestAsync<TRequest>(HttpContext httpContext)
+        where TRequest : class
+    {
+        var contentType = httpContext.Request.ContentType;
+        if (string.IsNullOrWhiteSpace(contentType) || !IsJsonContentType(contentType))
+        {
+            return (false, default, BuildProblemResult(
+                StatusCodes.Status400BadRequest,
+                "Validation failed.",
+                "The request payload is required to be JSON.",
+                TransactionErrors.ValidationError,
+                httpContext.Request.Path));
+        }
+
+        try
+        {
+            var request = await httpContext.Request.ReadFromJsonAsync<TRequest>(cancellationToken: httpContext.RequestAborted);
+            if (request is null)
+            {
+                return (false, default, BuildProblemResult(
+                    StatusCodes.Status400BadRequest,
+                    "Validation failed.",
+                    "The request payload is invalid.",
+                    TransactionErrors.ValidationError,
+                    httpContext.Request.Path));
+            }
+
+            return (true, request, null);
+        }
+        catch (JsonException)
+        {
+            return (false, default, BuildProblemResult(
+                StatusCodes.Status400BadRequest,
+                "Validation failed.",
+                "The request payload is invalid.",
+                TransactionErrors.ValidationError,
+                httpContext.Request.Path));
+        }
+        catch (NotSupportedException)
+        {
+            return (false, default, BuildProblemResult(
+                StatusCodes.Status400BadRequest,
+                "Validation failed.",
+                "The request payload is invalid.",
+                TransactionErrors.ValidationError,
+                httpContext.Request.Path));
+        }
+        catch (BadHttpRequestException)
+        {
+            return (false, default, BuildProblemResult(
+                StatusCodes.Status400BadRequest,
+                "Validation failed.",
+                "The request payload is invalid.",
+                TransactionErrors.ValidationError,
+                httpContext.Request.Path));
+        }
+    }
+
+    private static bool IsJsonContentType(string contentType)
+    {
+        var mediaType = contentType.Split(';')[0].Trim();
+        return mediaType.Equals("application/json", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool TryGetGuidQuery(HttpContext httpContext, string key, out Guid value)
+    {
+        value = Guid.Empty;
+        var raw = httpContext.Request.Query[key].FirstOrDefault();
+        return raw is not null && Guid.TryParse(raw, out value);
+    }
+
+    private static DateTimeOffset? TryGetDateTimeOffsetQuery(HttpContext httpContext, string key)
+    {
+        var raw = httpContext.Request.Query[key].FirstOrDefault();
+        if (raw is null)
+        {
+            return null;
+        }
+
+        return DateTimeOffset.TryParse(raw, out var value) ? value : null;
+    }
+
+    private static IResult BuildProblemResult(int statusCode, string title, string detail, string code, string instance)
+    {
+        var problem = new ProblemDetails
+        {
+            Status = statusCode,
+            Title = title,
+            Detail = detail,
+            Instance = instance
+        };
+        problem.Extensions["code"] = code;
+        return TypedResults.Problem(problem);
+    }
+
+    private static async Task WriteProblemAsync(
+        HttpContext httpContext,
+        int statusCode,
+        string title,
+        string detail,
+        string? code,
+        string fallbackCode)
+    {
+        await BuildProblemResult(
+            statusCode,
+            title,
+            detail,
+            code ?? fallbackCode,
+            httpContext.Request.Path).ExecuteAsync(httpContext);
+    }
+}
+
+public sealed record CreateTransactionRequest(
+    Guid HouseholdId,
+    decimal Amount,
+    DateTimeOffset OccurredAtUtc,
+    string? Description,
+    Guid? CategoryId);
+
+public sealed record TransactionResponse(
+    Guid Id,
+    Guid HouseholdId,
+    decimal Amount,
+    DateTimeOffset OccurredAtUtc,
+    string? Description,
+    Guid? CategoryId,
+    DateTimeOffset CreatedAtUtc);
+
+public sealed record TransactionSummaryResponse(
+    Guid Id,
+    decimal Amount,
+    DateTimeOffset OccurredAtUtc,
+    string? Description,
+    Guid? CategoryId,
+    string? CategoryName,
+    DateTimeOffset CreatedAtUtc);
+
+public sealed record TransactionsResponse(TransactionSummaryResponse[] Transactions);
+
+internal sealed record AuthenticatedUser(Guid UserId, string Email);

--- a/backend/src/MoneyTracker.Api/MoneyTracker.Api.csproj
+++ b/backend/src/MoneyTracker.Api/MoneyTracker.Api.csproj
@@ -9,6 +9,8 @@
   <ItemGroup>
     <ProjectReference Include="..\Modules\Households\MoneyTracker.Modules.Households.csproj" />
     <ProjectReference Include="..\Modules\Auth\MoneyTracker.Modules.Auth.csproj" />
+    <ProjectReference Include="..\Modules\Budgets\MoneyTracker.Modules.Budgets.csproj" />
+    <ProjectReference Include="..\Modules\Transactions\MoneyTracker.Modules.Transactions.csproj" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.0" />
   </ItemGroup>
 

--- a/backend/src/MoneyTracker.Api/Program.cs
+++ b/backend/src/MoneyTracker.Api/Program.cs
@@ -2,7 +2,9 @@ using MoneyTracker.Api.Configuration;
 using MoneyTracker.Api.Contracts;
 using MoneyTracker.Api.Diagnostics;
 using MoneyTracker.Modules.Auth.Presentation;
+using MoneyTracker.Modules.Budgets.Presentation;
 using MoneyTracker.Modules.Households.Presentation;
+using MoneyTracker.Modules.Transactions.Presentation;
 using MoneyTracker.Api.Observability;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -13,6 +15,8 @@ builder.Services.AddValidatedConfiguration(builder.Configuration);
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddAuthModule();
 builder.Services.AddHouseholdsModule();
+builder.Services.AddBudgetsModule();
+builder.Services.AddTransactionsModule();
 builder.Services.AddOpenApi();
 
 var app = builder.Build();
@@ -29,6 +33,9 @@ app.MapGet("/", static () => Results.Ok(new { message = "MoneyTracker API" }));
 app.MapGet("/health", static () => Results.Ok(new HealthResponse("ok")));
 app.MapAuthEndpoints();
 app.MapHouseholdEndpoints();
+app.MapBudgetEndpoints();
+app.MapBudgetSnapshotEndpoints();
+app.MapTransactionEndpoints();
 
 if (app.Environment.IsEnvironment("Testing"))
 {

--- a/backend/tests/MoneyTracker.Api.Tests/Component/BudgetCategoryEndpointTests.cs
+++ b/backend/tests/MoneyTracker.Api.Tests/Component/BudgetCategoryEndpointTests.cs
@@ -1,0 +1,38 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json.Nodes;
+
+namespace MoneyTracker.Api.Tests.Component;
+
+public sealed class BudgetCategoryEndpointTests : IClassFixture<MoneyTrackerApiFactory>
+{
+    private readonly MoneyTrackerApiFactory _factory;
+
+    public BudgetCategoryEndpointTests(MoneyTrackerApiFactory factory)
+    {
+        _factory = factory;
+    }
+
+    [Fact]
+    [Trait("Category", "Component")]
+    public async Task PostBudgetCategories_RequiresAuthentication()
+    {
+        using var client = _factory.CreateClient();
+        var request = new { householdId = Guid.NewGuid(), name = "Groceries" };
+
+        using var response = await client.PostAsJsonAsync("/budgets/categories", request);
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+        Assert.Equal("application/problem+json", response.Content.Headers.ContentType?.MediaType);
+
+        var payload = JsonNode.Parse(await response.Content.ReadAsStringAsync())?.AsObject();
+        Assert.NotNull(payload);
+        var code = payload["code"]?.GetValue<string>();
+        Assert.NotNull(code);
+        Assert.Contains(code, new[]
+        {
+            "auth_access_token_missing",
+            "auth_access_token_invalid"
+        });
+    }
+}

--- a/backend/tests/MoneyTracker.Api.Tests/Component/TransactionEndpointTests.cs
+++ b/backend/tests/MoneyTracker.Api.Tests/Component/TransactionEndpointTests.cs
@@ -1,0 +1,36 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text;
+using System.Text.Json.Nodes;
+
+namespace MoneyTracker.Api.Tests.Component;
+
+public sealed class TransactionEndpointTests : IClassFixture<MoneyTrackerApiFactory>
+{
+    private readonly MoneyTrackerApiFactory _factory;
+
+    public TransactionEndpointTests(MoneyTrackerApiFactory factory)
+    {
+        _factory = factory;
+    }
+
+    [Fact]
+    [Trait("Category", "Component")]
+    public async Task PostTransactions_ReturnsBadRequest_WhenBodyIsEmpty()
+    {
+        using var client = _factory.CreateClient();
+        var accessToken = await AuthTestHelpers.GetAccessTokenAsync(client, $"{Guid.NewGuid():N}@example.com");
+        AuthTestHelpers.SetBearer(client, accessToken);
+
+        using var emptyBodyContent = new StringContent(string.Empty, Encoding.UTF8, "application/json");
+
+        using var response = await client.PostAsync("/transactions", emptyBodyContent);
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        Assert.Equal("application/problem+json", response.Content.Headers.ContentType?.MediaType);
+
+        var payload = JsonNode.Parse(await response.Content.ReadAsStringAsync())?.AsObject();
+        Assert.NotNull(payload);
+        Assert.Equal("validation_error", payload["code"]?.GetValue<string>());
+    }
+}

--- a/backend/tests/MoneyTracker.Api.Tests/Integration/BudgetSnapshotTests.cs
+++ b/backend/tests/MoneyTracker.Api.Tests/Integration/BudgetSnapshotTests.cs
@@ -1,0 +1,69 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json.Nodes;
+using MoneyTracker.Api.Tests.Component;
+
+namespace MoneyTracker.Api.Tests.Integration;
+
+public sealed class BudgetSnapshotTests : IClassFixture<MoneyTrackerApiFactory>
+{
+    private readonly MoneyTrackerApiFactory _factory;
+
+    public BudgetSnapshotTests(MoneyTrackerApiFactory factory)
+    {
+        _factory = factory;
+    }
+
+    [Fact]
+    [Trait("Category", "Integration")]
+    public async Task BudgetSnapshot_ReturnsTotalsForCurrentPeriod()
+    {
+        using var client = _factory.CreateClient();
+        var accessToken = await AuthTestHelpers.GetAccessTokenAsync(client, $"{Guid.NewGuid():N}@example.com");
+        AuthTestHelpers.SetBearer(client, accessToken);
+
+        var householdName = $"Household-{Guid.NewGuid():N}";
+        using var householdResponse = await client.PostAsJsonAsync("/households", new { name = householdName });
+        Assert.Equal(HttpStatusCode.Created, householdResponse.StatusCode);
+
+        var householdPayload = JsonNode.Parse(await householdResponse.Content.ReadAsStringAsync())?.AsObject();
+        Assert.NotNull(householdPayload);
+        var householdId = Guid.Parse(householdPayload["id"]!.GetValue<string>());
+
+        using var categoryResponse = await client.PostAsJsonAsync(
+            "/budgets/categories",
+            new { householdId, name = "Groceries" });
+        Assert.Equal(HttpStatusCode.Created, categoryResponse.StatusCode);
+        var categoryPayload = JsonNode.Parse(await categoryResponse.Content.ReadAsStringAsync())?.AsObject();
+        Assert.NotNull(categoryPayload);
+        var categoryId = Guid.Parse(categoryPayload["id"]!.GetValue<string>());
+
+        using var allocationResponse = await client.PostAsJsonAsync(
+            "/budgets",
+            new { householdId, categoryId, amount = 500m });
+        Assert.Equal(HttpStatusCode.OK, allocationResponse.StatusCode);
+
+        var occurredAtUtc = DateTimeOffset.UtcNow;
+        using var transactionResponse = await client.PostAsJsonAsync(
+            "/transactions",
+            new
+            {
+                householdId,
+                amount = 120m,
+                occurredAtUtc,
+                description = "Market",
+                categoryId
+            });
+        Assert.Equal(HttpStatusCode.Created, transactionResponse.StatusCode);
+
+        using var snapshotResponse = await client.GetAsync($"/budgets/current?householdId={householdId}");
+        Assert.Equal(HttpStatusCode.OK, snapshotResponse.StatusCode);
+
+        var snapshotPayload = JsonNode.Parse(await snapshotResponse.Content.ReadAsStringAsync())?.AsObject();
+        Assert.NotNull(snapshotPayload);
+
+        Assert.Equal(500m, snapshotPayload["totalAllocated"]!.GetValue<decimal>());
+        Assert.Equal(120m, snapshotPayload["totalSpent"]!.GetValue<decimal>());
+        Assert.Equal(380m, snapshotPayload["totalRemaining"]!.GetValue<decimal>());
+    }
+}

--- a/backend/tests/MoneyTracker.Api.Tests/Integration/BudgetSnapshotTests.cs
+++ b/backend/tests/MoneyTracker.Api.Tests/Integration/BudgetSnapshotTests.cs
@@ -1,6 +1,8 @@
 using System.Net;
 using System.Net.Http.Json;
 using System.Text.Json.Nodes;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using MoneyTracker.Api.Tests.Component;
 
 namespace MoneyTracker.Api.Tests.Integration;
@@ -18,7 +20,15 @@ public sealed class BudgetSnapshotTests : IClassFixture<MoneyTrackerApiFactory>
     [Trait("Category", "Integration")]
     public async Task BudgetSnapshot_ReturnsTotalsForCurrentPeriod()
     {
-        using var client = _factory.CreateClient();
+        var fixedNow = DateTimeOffset.Parse("2026-03-01T12:00:00Z");
+        using var client = _factory.WithWebHostBuilder(builder =>
+        {
+            builder.ConfigureServices(services =>
+            {
+                services.RemoveAll<TimeProvider>();
+                services.AddSingleton<TimeProvider>(new FixedTimeProvider(fixedNow));
+            });
+        }).CreateClient();
         var accessToken = await AuthTestHelpers.GetAccessTokenAsync(client, $"{Guid.NewGuid():N}@example.com");
         AuthTestHelpers.SetBearer(client, accessToken);
 
@@ -43,7 +53,7 @@ public sealed class BudgetSnapshotTests : IClassFixture<MoneyTrackerApiFactory>
             new { householdId, categoryId, amount = 500m });
         Assert.Equal(HttpStatusCode.OK, allocationResponse.StatusCode);
 
-        var occurredAtUtc = DateTimeOffset.UtcNow;
+        var occurredAtUtc = fixedNow;
         using var transactionResponse = await client.PostAsJsonAsync(
             "/transactions",
             new
@@ -66,4 +76,9 @@ public sealed class BudgetSnapshotTests : IClassFixture<MoneyTrackerApiFactory>
         Assert.Equal(120m, snapshotPayload["totalSpent"]!.GetValue<decimal>());
         Assert.Equal(380m, snapshotPayload["totalRemaining"]!.GetValue<decimal>());
     }
+}
+
+internal sealed class FixedTimeProvider(DateTimeOffset utcNow) : TimeProvider
+{
+    public override DateTimeOffset GetUtcNow() => utcNow;
 }

--- a/backend/tests/MoneyTracker.Modules.Budgets.Tests/Application/CreateBudgetCategoryHandlerTests.cs
+++ b/backend/tests/MoneyTracker.Modules.Budgets.Tests/Application/CreateBudgetCategoryHandlerTests.cs
@@ -1,0 +1,49 @@
+using MoneyTracker.Modules.Budgets.Application.CreateBudgetCategory;
+using MoneyTracker.Modules.Budgets.Domain;
+using MoneyTracker.Modules.Budgets.Infrastructure;
+using MoneyTracker.Modules.SharedKernel.Households;
+
+namespace MoneyTracker.Modules.Budgets.Tests.Application;
+
+public sealed class CreateBudgetCategoryHandlerTests
+{
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task HandleAsync_ReturnsConflict_WhenNameAlreadyExistsCaseInsensitive()
+    {
+        var householdId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        var repository = new InMemoryBudgetRepository();
+        var handler = new CreateBudgetCategoryHandler(
+            repository,
+            new AllowedHouseholdAccessService(),
+            TimeProvider.System);
+
+        var first = await handler.HandleAsync(
+            new CreateBudgetCategoryCommand(householdId, "Dining", userId),
+            CancellationToken.None);
+        var result = await handler.HandleAsync(
+            new CreateBudgetCategoryCommand(householdId, "DINING", userId),
+            CancellationToken.None);
+
+        Assert.True(first.IsSuccess);
+        Assert.False(result.IsSuccess);
+        Assert.Equal(BudgetErrors.BudgetCategoryNameConflict, result.ErrorCode);
+    }
+}
+
+internal sealed class AllowedHouseholdAccessService : IHouseholdAccessService
+{
+    public Task<HouseholdAccessResult> CheckMemberAsync(
+        Guid householdId,
+        Guid userId,
+        CancellationToken cancellationToken)
+    {
+        return Task.FromResult(HouseholdAccessResult.Allowed());
+    }
+
+    public Task<IReadOnlyCollection<Guid>> GetMemberIdsAsync(Guid householdId, CancellationToken cancellationToken)
+    {
+        return Task.FromResult<IReadOnlyCollection<Guid>>(Array.Empty<Guid>());
+    }
+}

--- a/backend/tests/MoneyTracker.Modules.Budgets.Tests/MoneyTracker.Modules.Budgets.Tests.csproj
+++ b/backend/tests/MoneyTracker.Modules.Budgets.Tests/MoneyTracker.Modules.Budgets.Tests.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Modules\Budgets\MoneyTracker.Modules.Budgets.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>

--- a/backend/tests/MoneyTracker.Modules.Transactions.Tests/Application/CreateTransactionHandlerTests.cs
+++ b/backend/tests/MoneyTracker.Modules.Transactions.Tests/Application/CreateTransactionHandlerTests.cs
@@ -1,0 +1,58 @@
+using MoneyTracker.Modules.Budgets.Infrastructure;
+using MoneyTracker.Modules.SharedKernel.Households;
+using MoneyTracker.Modules.Transactions.Application.CreateTransaction;
+using MoneyTracker.Modules.Transactions.Domain;
+using MoneyTracker.Modules.Transactions.Infrastructure;
+
+namespace MoneyTracker.Modules.Transactions.Tests.Application;
+
+public sealed class CreateTransactionHandlerTests
+{
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task HandleAsync_ReturnsValidationError_WhenAmountIsZero()
+    {
+        var householdId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        var nowUtc = DateTimeOffset.Parse("2026-03-01T00:00:00Z");
+        var handler = new CreateTransactionHandler(
+            new InMemoryTransactionRepository(),
+            new InMemoryBudgetRepository(),
+            new AllowedHouseholdAccessService(),
+            new FakeTimeProvider(nowUtc));
+
+        var result = await handler.HandleAsync(
+            new CreateTransactionCommand(
+                householdId,
+                0,
+                nowUtc,
+                "Rent",
+                null,
+                userId),
+            CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(TransactionErrors.TransactionAmountInvalid, result.ErrorCode);
+    }
+}
+
+internal sealed class AllowedHouseholdAccessService : IHouseholdAccessService
+{
+    public Task<HouseholdAccessResult> CheckMemberAsync(
+        Guid householdId,
+        Guid userId,
+        CancellationToken cancellationToken)
+    {
+        return Task.FromResult(HouseholdAccessResult.Allowed());
+    }
+
+    public Task<IReadOnlyCollection<Guid>> GetMemberIdsAsync(Guid householdId, CancellationToken cancellationToken)
+    {
+        return Task.FromResult<IReadOnlyCollection<Guid>>(Array.Empty<Guid>());
+    }
+}
+
+internal sealed class FakeTimeProvider(DateTimeOffset utcNow) : TimeProvider
+{
+    public override DateTimeOffset GetUtcNow() => utcNow;
+}

--- a/backend/tests/MoneyTracker.Modules.Transactions.Tests/MoneyTracker.Modules.Transactions.Tests.csproj
+++ b/backend/tests/MoneyTracker.Modules.Transactions.Tests/MoneyTracker.Modules.Transactions.Tests.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Modules\Transactions\MoneyTracker.Modules.Transactions.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Summary
- add household-scoped budget categories/allocations and manual transactions
- expose current budget snapshot endpoint for dashboard consumption
- add API + module tests for budgets, transactions, and household access

## Changes
- budgets module domain/application/endpoints with in-memory repository
- transactions module domain/application/endpoints with in-memory repository
- household access service + current budget snapshot query/endpoint wiring
- OpenAPI + API module registration updates

## Acceptance Criteria
- [x] AC-1: Household owner/member can create unique category names (case-insensitive) per household.
- [x] AC-2: Monthly budget allocations can be created and updated.
- [x] AC-3: Manual transaction create/list APIs return household-scoped records with category linkage.
- [x] AC-4: Budget calculations for current period reflect transaction totals and category allocations.
- [x] AC-5: Unauthorized users cannot create or read household budgets/transactions.

## Verification
- `dotnet test backend/tests/MoneyTracker.Api.Tests/MoneyTracker.Api.Tests.csproj`
- `dotnet test backend/tests/MoneyTracker.Modules.Budgets.Tests/MoneyTracker.Modules.Budgets.Tests.csproj`
- `dotnet test backend/tests/MoneyTracker.Modules.Transactions.Tests/MoneyTracker.Modules.Transactions.Tests.csproj`
- `dotnet test backend/tests/MoneyTracker.Modules.Households.Tests/MoneyTracker.Modules.Households.Tests.csproj`
- `backend/scripts/export-openapi.sh`

## Risk
- medium: new budgeting and transaction flows, plus snapshot calculation logic

## Review log
- Post-open (2026-03-07): manual review of BudgetEndpoints, TransactionEndpoints, BudgetCategory + InMemoryBudgetRepository, GetCurrentBudgetSnapshotHandler. No actionable findings.
- Post-review fixes (2026-03-07): addressed CodeRabbit/Copilot comments (invalid date handling, UTC normalization, category snapshot immutability, fixed TimeProvider in BudgetSnapshotTests) and resolved threads; summary: [review responses](https://github.com/garethbaumgart/money-tracker/pull/61#issuecomment-4015016500).
- Pre-merge (2026-03-07): recheck on head `b9fe6d5`; no new findings.
- AI reviewers: CodeRabbit rate-limited after latest push; Copilot review comments addressed. Sourcery rate limit notice (non-actionable).

## References
- Closes #53
