### PR TITLE
Add Basiq bank connection link/session flow and callback handling

### DIFF
--- a/backend/src/Modules/BankConnections/Application/CreateLinkSession/CreateLinkSessionCommand.cs
+++ b/backend/src/Modules/BankConnections/Application/CreateLinkSession/CreateLinkSessionCommand.cs
@@ -1,0 +1,5 @@
+namespace MoneyTracker.Modules.BankConnections.Application.CreateLinkSession;
+
+public sealed record CreateLinkSessionCommand(
+    Guid HouseholdId,
+    Guid RequestingUserId);

--- a/backend/src/Modules/BankConnections/Application/CreateLinkSession/CreateLinkSessionHandler.cs
+++ b/backend/src/Modules/BankConnections/Application/CreateLinkSession/CreateLinkSessionHandler.cs
@@ -1,0 +1,69 @@
+using MoneyTracker.Modules.BankConnections.Domain;
+using MoneyTracker.Modules.SharedKernel.Households;
+
+namespace MoneyTracker.Modules.BankConnections.Application.CreateLinkSession;
+
+public sealed class CreateLinkSessionHandler(
+    IBankConnectionRepository repository,
+    IBankProviderAdapter providerAdapter,
+    IHouseholdAccessService householdAccessService,
+    TimeProvider timeProvider)
+{
+    public async Task<CreateLinkSessionResult> HandleAsync(
+        CreateLinkSessionCommand command,
+        CancellationToken cancellationToken)
+    {
+        var access = await householdAccessService.CheckMemberAsync(
+            command.HouseholdId,
+            command.RequestingUserId,
+            cancellationToken);
+        if (!access.HouseholdExists)
+        {
+            return CreateLinkSessionResult.HouseholdNotFound();
+        }
+
+        if (!access.IsMember)
+        {
+            return CreateLinkSessionResult.AccessDenied();
+        }
+
+        var createUserResult = await providerAdapter.CreateUserAsync(
+            command.HouseholdId,
+            command.RequestingUserId,
+            cancellationToken);
+        if (!createUserResult.IsSuccess)
+        {
+            return CreateLinkSessionResult.ProviderError(
+                createUserResult.ErrorCode,
+                createUserResult.ErrorMessage);
+        }
+
+        var consentResult = await providerAdapter.CreateConsentSessionAsync(
+            createUserResult.ExternalUserId!,
+            cancellationToken);
+        if (!consentResult.IsSuccess)
+        {
+            return CreateLinkSessionResult.ProviderError(
+                consentResult.ErrorCode,
+                consentResult.ErrorMessage);
+        }
+
+        BankConnection connection;
+        try
+        {
+            connection = BankConnection.CreatePending(
+                command.HouseholdId,
+                command.RequestingUserId,
+                createUserResult.ExternalUserId!,
+                consentResult.SessionId!,
+                timeProvider.GetUtcNow());
+        }
+        catch (BankConnectionDomainException exception)
+        {
+            return CreateLinkSessionResult.Validation(exception.Code, exception.Message);
+        }
+
+        await repository.AddAsync(connection, cancellationToken);
+        return CreateLinkSessionResult.Success(consentResult.ConsentUrl!, connection.Id.Value);
+    }
+}

--- a/backend/src/Modules/BankConnections/Application/CreateLinkSession/CreateLinkSessionResult.cs
+++ b/backend/src/Modules/BankConnections/Application/CreateLinkSession/CreateLinkSessionResult.cs
@@ -1,0 +1,63 @@
+namespace MoneyTracker.Modules.BankConnections.Application.CreateLinkSession;
+
+public sealed class CreateLinkSessionResult
+{
+    private CreateLinkSessionResult(
+        string? consentUrl,
+        Guid? connectionId,
+        string? errorCode,
+        string? errorMessage)
+    {
+        ConsentUrl = consentUrl;
+        ConnectionId = connectionId;
+        ErrorCode = errorCode;
+        ErrorMessage = errorMessage;
+    }
+
+    public string? ConsentUrl { get; }
+
+    public Guid? ConnectionId { get; }
+
+    public string? ErrorCode { get; }
+
+    public string? ErrorMessage { get; }
+
+    public bool IsSuccess => ConsentUrl is not null;
+
+    public static CreateLinkSessionResult Success(string consentUrl, Guid connectionId)
+    {
+        return new CreateLinkSessionResult(consentUrl, connectionId, errorCode: null, errorMessage: null);
+    }
+
+    public static CreateLinkSessionResult Validation(string code, string message)
+    {
+        return new CreateLinkSessionResult(consentUrl: null, connectionId: null, code, message);
+    }
+
+    public static CreateLinkSessionResult AccessDenied()
+    {
+        return new CreateLinkSessionResult(
+            consentUrl: null,
+            connectionId: null,
+            Domain.BankConnectionErrors.ConnectionAccessDenied,
+            "User is not a member of this household.");
+    }
+
+    public static CreateLinkSessionResult HouseholdNotFound()
+    {
+        return new CreateLinkSessionResult(
+            consentUrl: null,
+            connectionId: null,
+            Domain.BankConnectionErrors.ConnectionHouseholdNotFound,
+            "Household not found.");
+    }
+
+    public static CreateLinkSessionResult ProviderError(string? errorCode, string? errorMessage)
+    {
+        return new CreateLinkSessionResult(
+            consentUrl: null,
+            connectionId: null,
+            errorCode ?? Domain.BankConnectionErrors.ConnectionProviderError,
+            errorMessage ?? "Bank provider returned an error.");
+    }
+}

--- a/backend/src/Modules/BankConnections/Application/GetBankConnections/GetBankConnectionsHandler.cs
+++ b/backend/src/Modules/BankConnections/Application/GetBankConnections/GetBankConnectionsHandler.cs
@@ -1,0 +1,47 @@
+using MoneyTracker.Modules.BankConnections.Domain;
+using MoneyTracker.Modules.SharedKernel.Households;
+
+namespace MoneyTracker.Modules.BankConnections.Application.GetBankConnections;
+
+public sealed class GetBankConnectionsHandler(
+    IBankConnectionRepository repository,
+    IHouseholdAccessService householdAccessService)
+{
+    public async Task<GetBankConnectionsResult> HandleAsync(
+        GetBankConnectionsQuery query,
+        CancellationToken cancellationToken)
+    {
+        var access = await householdAccessService.CheckMemberAsync(
+            query.HouseholdId,
+            query.RequestingUserId,
+            cancellationToken);
+        if (!access.HouseholdExists)
+        {
+            return GetBankConnectionsResult.HouseholdNotFound();
+        }
+
+        if (!access.IsMember)
+        {
+            return GetBankConnectionsResult.AccessDenied();
+        }
+
+        var connections = await repository.GetByHouseholdAsync(
+            query.HouseholdId,
+            cancellationToken);
+
+        var summaries = connections
+            .OrderByDescending(c => c.CreatedAtUtc)
+            .Select(c => new BankConnectionSummary(
+                c.Id.Value,
+                c.HouseholdId,
+                c.InstitutionName,
+                c.Status.ToString(),
+                c.ErrorCode,
+                c.ErrorMessage,
+                c.CreatedAtUtc,
+                c.UpdatedAtUtc))
+            .ToArray();
+
+        return GetBankConnectionsResult.Success(summaries);
+    }
+}

--- a/backend/src/Modules/BankConnections/Application/GetBankConnections/GetBankConnectionsQuery.cs
+++ b/backend/src/Modules/BankConnections/Application/GetBankConnections/GetBankConnectionsQuery.cs
@@ -1,0 +1,5 @@
+namespace MoneyTracker.Modules.BankConnections.Application.GetBankConnections;
+
+public sealed record GetBankConnectionsQuery(
+    Guid HouseholdId,
+    Guid RequestingUserId);

--- a/backend/src/Modules/BankConnections/Application/GetBankConnections/GetBankConnectionsResult.cs
+++ b/backend/src/Modules/BankConnections/Application/GetBankConnections/GetBankConnectionsResult.cs
@@ -1,0 +1,55 @@
+using MoneyTracker.Modules.BankConnections.Domain;
+
+namespace MoneyTracker.Modules.BankConnections.Application.GetBankConnections;
+
+public sealed class GetBankConnectionsResult
+{
+    private GetBankConnectionsResult(
+        IReadOnlyCollection<BankConnectionSummary>? connections,
+        string? errorCode,
+        string? errorMessage)
+    {
+        Connections = connections;
+        ErrorCode = errorCode;
+        ErrorMessage = errorMessage;
+    }
+
+    public IReadOnlyCollection<BankConnectionSummary>? Connections { get; }
+
+    public string? ErrorCode { get; }
+
+    public string? ErrorMessage { get; }
+
+    public bool IsSuccess => Connections is not null;
+
+    public static GetBankConnectionsResult Success(IReadOnlyCollection<BankConnectionSummary> connections)
+    {
+        return new GetBankConnectionsResult(connections, errorCode: null, errorMessage: null);
+    }
+
+    public static GetBankConnectionsResult AccessDenied()
+    {
+        return new GetBankConnectionsResult(
+            connections: null,
+            BankConnectionErrors.ConnectionAccessDenied,
+            "User is not a member of this household.");
+    }
+
+    public static GetBankConnectionsResult HouseholdNotFound()
+    {
+        return new GetBankConnectionsResult(
+            connections: null,
+            BankConnectionErrors.ConnectionHouseholdNotFound,
+            "Household not found.");
+    }
+}
+
+public sealed record BankConnectionSummary(
+    Guid Id,
+    Guid HouseholdId,
+    string? InstitutionName,
+    string Status,
+    string? ErrorCode,
+    string? ErrorMessage,
+    DateTimeOffset CreatedAtUtc,
+    DateTimeOffset UpdatedAtUtc);

--- a/backend/src/Modules/BankConnections/Application/ProcessCallback/ProcessCallbackCommand.cs
+++ b/backend/src/Modules/BankConnections/Application/ProcessCallback/ProcessCallbackCommand.cs
@@ -1,0 +1,4 @@
+namespace MoneyTracker.Modules.BankConnections.Application.ProcessCallback;
+
+public sealed record ProcessCallbackCommand(
+    string ConsentSessionId);

--- a/backend/src/Modules/BankConnections/Application/ProcessCallback/ProcessCallbackHandler.cs
+++ b/backend/src/Modules/BankConnections/Application/ProcessCallback/ProcessCallbackHandler.cs
@@ -1,0 +1,72 @@
+using MoneyTracker.Modules.BankConnections.Domain;
+
+namespace MoneyTracker.Modules.BankConnections.Application.ProcessCallback;
+
+public sealed class ProcessCallbackHandler(
+    IBankConnectionRepository repository,
+    IBankProviderAdapter providerAdapter,
+    TimeProvider timeProvider)
+{
+    public async Task<ProcessCallbackResult> HandleAsync(
+        ProcessCallbackCommand command,
+        CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(command.ConsentSessionId))
+        {
+            return ProcessCallbackResult.Validation(
+                BankConnectionErrors.ConnectionCallbackInvalid,
+                "Consent session ID is required.");
+        }
+
+        var connection = await repository.GetByConsentSessionIdAsync(
+            command.ConsentSessionId,
+            cancellationToken);
+        if (connection is null)
+        {
+            return ProcessCallbackResult.ConnectionNotFound();
+        }
+
+        var connectionResult = await providerAdapter.GetConnectionAsync(
+            connection.ExternalUserId,
+            command.ConsentSessionId,
+            cancellationToken);
+
+        var nowUtc = timeProvider.GetUtcNow();
+
+        if (!connectionResult.IsSuccess)
+        {
+            try
+            {
+                connection.MarkFailed(
+                    connectionResult.ErrorCode ?? BankConnectionErrors.ConnectionProviderError,
+                    connectionResult.ErrorMessage ?? "Provider returned an error.",
+                    nowUtc);
+                await repository.UpdateAsync(connection, cancellationToken);
+            }
+            catch (BankConnectionDomainException)
+            {
+                // Connection may already be in a terminal state; persist as-is.
+            }
+
+            return ProcessCallbackResult.Failed(
+                connection,
+                connectionResult.ErrorCode ?? BankConnectionErrors.ConnectionProviderError,
+                connectionResult.ErrorMessage ?? "Provider returned an error.");
+        }
+
+        try
+        {
+            connection.Activate(
+                connectionResult.ConnectionId!,
+                connectionResult.InstitutionName,
+                nowUtc);
+        }
+        catch (BankConnectionDomainException exception)
+        {
+            return ProcessCallbackResult.Validation(exception.Code, exception.Message);
+        }
+
+        await repository.UpdateAsync(connection, cancellationToken);
+        return ProcessCallbackResult.Success(connection);
+    }
+}

--- a/backend/src/Modules/BankConnections/Application/ProcessCallback/ProcessCallbackResult.cs
+++ b/backend/src/Modules/BankConnections/Application/ProcessCallback/ProcessCallbackResult.cs
@@ -46,12 +46,4 @@ public sealed class ProcessCallbackResult
             BankConnectionErrors.ConnectionNotFound,
             "No pending connection found for this session.");
     }
-
-    public static ProcessCallbackResult ProviderError(string? errorCode, string? errorMessage)
-    {
-        return new ProcessCallbackResult(
-            connection: null,
-            errorCode ?? BankConnectionErrors.ConnectionProviderError,
-            errorMessage ?? "Bank provider returned an error.");
-    }
 }

--- a/backend/src/Modules/BankConnections/Application/ProcessCallback/ProcessCallbackResult.cs
+++ b/backend/src/Modules/BankConnections/Application/ProcessCallback/ProcessCallbackResult.cs
@@ -1,0 +1,57 @@
+using MoneyTracker.Modules.BankConnections.Domain;
+
+namespace MoneyTracker.Modules.BankConnections.Application.ProcessCallback;
+
+public sealed class ProcessCallbackResult
+{
+    private ProcessCallbackResult(
+        BankConnection? connection,
+        string? errorCode,
+        string? errorMessage)
+    {
+        Connection = connection;
+        ErrorCode = errorCode;
+        ErrorMessage = errorMessage;
+    }
+
+    public BankConnection? Connection { get; }
+
+    public string? ErrorCode { get; }
+
+    public string? ErrorMessage { get; }
+
+    public bool IsSuccess => Connection is not null && Connection.Status == BankConnectionStatus.Active;
+
+    public bool IsFailedConnection => Connection is not null && Connection.Status == BankConnectionStatus.Failed;
+
+    public static ProcessCallbackResult Success(BankConnection connection)
+    {
+        return new ProcessCallbackResult(connection, errorCode: null, errorMessage: null);
+    }
+
+    public static ProcessCallbackResult Failed(BankConnection connection, string errorCode, string errorMessage)
+    {
+        return new ProcessCallbackResult(connection, errorCode, errorMessage);
+    }
+
+    public static ProcessCallbackResult Validation(string code, string message)
+    {
+        return new ProcessCallbackResult(connection: null, code, message);
+    }
+
+    public static ProcessCallbackResult ConnectionNotFound()
+    {
+        return new ProcessCallbackResult(
+            connection: null,
+            BankConnectionErrors.ConnectionNotFound,
+            "No pending connection found for this session.");
+    }
+
+    public static ProcessCallbackResult ProviderError(string? errorCode, string? errorMessage)
+    {
+        return new ProcessCallbackResult(
+            connection: null,
+            errorCode ?? BankConnectionErrors.ConnectionProviderError,
+            errorMessage ?? "Bank provider returned an error.");
+    }
+}

--- a/backend/src/Modules/BankConnections/Domain/BankConnection.cs
+++ b/backend/src/Modules/BankConnections/Domain/BankConnection.cs
@@ -1,0 +1,128 @@
+namespace MoneyTracker.Modules.BankConnections.Domain;
+
+public sealed class BankConnection
+{
+    public BankConnectionId Id { get; }
+    public Guid HouseholdId { get; }
+    public Guid CreatedByUserId { get; }
+    public string ExternalUserId { get; }
+    public string ExternalConnectionId { get; private set; }
+    public string? ConsentSessionId { get; }
+    public string? InstitutionName { get; private set; }
+    public BankConnectionStatus Status { get; private set; }
+    public string? ErrorCode { get; private set; }
+    public string? ErrorMessage { get; private set; }
+    public DateTimeOffset CreatedAtUtc { get; }
+    public DateTimeOffset UpdatedAtUtc { get; private set; }
+
+    private BankConnection(
+        BankConnectionId id,
+        Guid householdId,
+        Guid createdByUserId,
+        string externalUserId,
+        string externalConnectionId,
+        string? consentSessionId,
+        string? institutionName,
+        BankConnectionStatus status,
+        DateTimeOffset createdAtUtc)
+    {
+        Id = id;
+        HouseholdId = householdId;
+        CreatedByUserId = createdByUserId;
+        ExternalUserId = externalUserId;
+        ExternalConnectionId = externalConnectionId;
+        ConsentSessionId = consentSessionId;
+        InstitutionName = institutionName;
+        Status = status;
+        CreatedAtUtc = createdAtUtc;
+        UpdatedAtUtc = createdAtUtc;
+    }
+
+    public static BankConnection CreatePending(
+        Guid householdId,
+        Guid createdByUserId,
+        string externalUserId,
+        string consentSessionId,
+        DateTimeOffset nowUtc)
+    {
+        if (string.IsNullOrWhiteSpace(externalUserId))
+        {
+            throw new BankConnectionDomainException(
+                BankConnectionErrors.ValidationError,
+                "External user ID is required.");
+        }
+
+        if (string.IsNullOrWhiteSpace(consentSessionId))
+        {
+            throw new BankConnectionDomainException(
+                BankConnectionErrors.ValidationError,
+                "Consent session ID is required.");
+        }
+
+        return new BankConnection(
+            BankConnectionId.New(),
+            householdId,
+            createdByUserId,
+            externalUserId,
+            externalConnectionId: string.Empty,
+            consentSessionId,
+            institutionName: null,
+            BankConnectionStatus.Pending,
+            nowUtc);
+    }
+
+    public void Activate(string externalConnectionId, string? institutionName, DateTimeOffset nowUtc)
+    {
+        EnsureTransitionAllowed(BankConnectionStatus.Active);
+
+        if (string.IsNullOrWhiteSpace(externalConnectionId))
+        {
+            throw new BankConnectionDomainException(
+                BankConnectionErrors.ValidationError,
+                "External connection ID is required for activation.");
+        }
+
+        ExternalConnectionId = externalConnectionId;
+        InstitutionName = institutionName?.Trim();
+        Status = BankConnectionStatus.Active;
+        ErrorCode = null;
+        ErrorMessage = null;
+        UpdatedAtUtc = nowUtc;
+    }
+
+    public void MarkFailed(string errorCode, string errorMessage, DateTimeOffset nowUtc)
+    {
+        EnsureTransitionAllowed(BankConnectionStatus.Failed);
+
+        Status = BankConnectionStatus.Failed;
+        ErrorCode = errorCode;
+        ErrorMessage = errorMessage;
+        UpdatedAtUtc = nowUtc;
+    }
+
+    public void Revoke(DateTimeOffset nowUtc)
+    {
+        EnsureTransitionAllowed(BankConnectionStatus.Revoked);
+
+        Status = BankConnectionStatus.Revoked;
+        UpdatedAtUtc = nowUtc;
+    }
+
+    private void EnsureTransitionAllowed(BankConnectionStatus target)
+    {
+        var allowed = (Status, target) switch
+        {
+            (BankConnectionStatus.Pending, BankConnectionStatus.Active) => true,
+            (BankConnectionStatus.Pending, BankConnectionStatus.Failed) => true,
+            (BankConnectionStatus.Active, BankConnectionStatus.Revoked) => true,
+            _ => false
+        };
+
+        if (!allowed)
+        {
+            throw new BankConnectionDomainException(
+                BankConnectionErrors.ConnectionInvalidStateTransition,
+                $"Cannot transition from {Status} to {target}.");
+        }
+    }
+}

--- a/backend/src/Modules/BankConnections/Domain/BankConnectionDomainException.cs
+++ b/backend/src/Modules/BankConnections/Domain/BankConnectionDomainException.cs
@@ -1,0 +1,6 @@
+namespace MoneyTracker.Modules.BankConnections.Domain;
+
+public sealed class BankConnectionDomainException(string code, string message) : InvalidOperationException(message)
+{
+    public string Code { get; } = code;
+}

--- a/backend/src/Modules/BankConnections/Domain/BankConnectionErrors.cs
+++ b/backend/src/Modules/BankConnections/Domain/BankConnectionErrors.cs
@@ -1,0 +1,13 @@
+namespace MoneyTracker.Modules.BankConnections.Domain;
+
+public static class BankConnectionErrors
+{
+    public const string ValidationError = "validation_error";
+    public const string ConnectionHouseholdNotFound = "bank_connection_household_not_found";
+    public const string ConnectionAccessDenied = "bank_connection_access_denied";
+    public const string ConnectionNotFound = "bank_connection_not_found";
+    public const string ConnectionInvalidStateTransition = "bank_connection_invalid_state_transition";
+    public const string ConnectionProviderError = "bank_connection_provider_error";
+    public const string ConnectionCallbackInvalid = "bank_connection_callback_invalid";
+    public const string ConnectionSessionExpired = "bank_connection_session_expired";
+}

--- a/backend/src/Modules/BankConnections/Domain/BankConnectionId.cs
+++ b/backend/src/Modules/BankConnections/Domain/BankConnectionId.cs
@@ -1,0 +1,6 @@
+namespace MoneyTracker.Modules.BankConnections.Domain;
+
+public readonly record struct BankConnectionId(Guid Value)
+{
+    public static BankConnectionId New() => new(Guid.NewGuid());
+}

--- a/backend/src/Modules/BankConnections/Domain/BankConnectionStatus.cs
+++ b/backend/src/Modules/BankConnections/Domain/BankConnectionStatus.cs
@@ -1,0 +1,9 @@
+namespace MoneyTracker.Modules.BankConnections.Domain;
+
+public enum BankConnectionStatus
+{
+    Pending,
+    Active,
+    Failed,
+    Revoked
+}

--- a/backend/src/Modules/BankConnections/Domain/IBankConnectionRepository.cs
+++ b/backend/src/Modules/BankConnections/Domain/IBankConnectionRepository.cs
@@ -1,0 +1,11 @@
+namespace MoneyTracker.Modules.BankConnections.Domain;
+
+public interface IBankConnectionRepository
+{
+    Task AddAsync(BankConnection connection, CancellationToken cancellationToken);
+    Task UpdateAsync(BankConnection connection, CancellationToken cancellationToken);
+    Task<BankConnection?> GetByConsentSessionIdAsync(string consentSessionId, CancellationToken cancellationToken);
+    Task<IReadOnlyCollection<BankConnection>> GetByHouseholdAsync(
+        Guid householdId,
+        CancellationToken cancellationToken);
+}

--- a/backend/src/Modules/BankConnections/Domain/IBankProviderAdapter.cs
+++ b/backend/src/Modules/BankConnections/Domain/IBankProviderAdapter.cs
@@ -1,0 +1,51 @@
+namespace MoneyTracker.Modules.BankConnections.Domain;
+
+public interface IBankProviderAdapter
+{
+    Task<CreateUserResult> CreateUserAsync(
+        Guid householdId,
+        Guid userId,
+        CancellationToken cancellationToken);
+
+    Task<CreateConsentSessionResult> CreateConsentSessionAsync(
+        string externalUserId,
+        CancellationToken cancellationToken);
+
+    Task<GetConnectionResult> GetConnectionAsync(
+        string externalUserId,
+        string consentSessionId,
+        CancellationToken cancellationToken);
+
+    Task<GetAccountsResult> GetAccountsAsync(
+        string externalConnectionId,
+        CancellationToken cancellationToken);
+}
+
+public sealed record CreateUserResult(bool IsSuccess, string? ExternalUserId, string? ErrorCode, string? ErrorMessage);
+
+public sealed record CreateConsentSessionResult(
+    bool IsSuccess,
+    string? SessionId,
+    string? ConsentUrl,
+    string? ErrorCode,
+    string? ErrorMessage);
+
+public sealed record GetConnectionResult(
+    bool IsSuccess,
+    string? ConnectionId,
+    string? InstitutionName,
+    string? Status,
+    string? ErrorCode,
+    string? ErrorMessage);
+
+public sealed record GetAccountsResult(
+    bool IsSuccess,
+    IReadOnlyCollection<BankAccountInfo>? Accounts,
+    string? ErrorCode,
+    string? ErrorMessage);
+
+public sealed record BankAccountInfo(
+    string AccountId,
+    string Name,
+    string? AccountNumber,
+    string? Type);

--- a/backend/src/Modules/BankConnections/Infrastructure/BasiqBankProviderAdapter.cs
+++ b/backend/src/Modules/BankConnections/Infrastructure/BasiqBankProviderAdapter.cs
@@ -1,0 +1,390 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.Extensions.Logging;
+using MoneyTracker.Modules.BankConnections.Domain;
+
+namespace MoneyTracker.Modules.BankConnections.Infrastructure;
+
+public sealed class BasiqBankProviderAdapter : IBankProviderAdapter
+{
+    private readonly HttpClient _httpClient;
+    private readonly ILogger<BasiqBankProviderAdapter> _logger;
+    private readonly TimeProvider _timeProvider;
+
+    private const int MaxRetries = 3;
+    private static readonly TimeSpan InitialRetryDelay = TimeSpan.FromSeconds(1);
+    private static readonly TimeSpan RequestTimeout = TimeSpan.FromSeconds(30);
+
+    public BasiqBankProviderAdapter(
+        HttpClient httpClient,
+        ILogger<BasiqBankProviderAdapter> logger,
+        TimeProvider timeProvider)
+    {
+        _httpClient = httpClient;
+        _logger = logger;
+        _timeProvider = timeProvider;
+    }
+
+    public async Task<CreateUserResult> CreateUserAsync(
+        Guid householdId,
+        Guid userId,
+        CancellationToken cancellationToken)
+    {
+        var correlationId = Guid.NewGuid().ToString("N");
+        _logger.LogInformation(
+            "Creating Basiq user for household={HouseholdId} user={UserId} correlationId={CorrelationId}",
+            householdId,
+            userId,
+            correlationId);
+
+        try
+        {
+            var response = await ExecuteWithRetryAsync(
+                () =>
+                {
+                    var request = new HttpRequestMessage(HttpMethod.Post, "/users")
+                    {
+                        Content = JsonContent.Create(new { householdId, userId })
+                    };
+                    request.Headers.Add("X-Correlation-Id", correlationId);
+                    return request;
+                },
+                cancellationToken);
+
+            if (!response.IsSuccessStatusCode)
+            {
+                var errorBody = await response.Content.ReadAsStringAsync(cancellationToken);
+                _logger.LogWarning(
+                    "Basiq CreateUser failed status={StatusCode} correlationId={CorrelationId} body={Body}",
+                    response.StatusCode,
+                    correlationId,
+                    errorBody);
+                return new CreateUserResult(false, null, BankConnectionErrors.ConnectionProviderError, $"Basiq API returned {(int)response.StatusCode}.");
+            }
+
+            var result = await response.Content.ReadFromJsonAsync<BasiqUserResponse>(cancellationToken: cancellationToken);
+            if (result is null || string.IsNullOrWhiteSpace(result.Id))
+            {
+                return new CreateUserResult(false, null, BankConnectionErrors.ConnectionProviderError, "Basiq API returned an invalid user response.");
+            }
+
+            _logger.LogInformation(
+                "Basiq user created externalUserId={ExternalUserId} correlationId={CorrelationId}",
+                result.Id,
+                correlationId);
+            return new CreateUserResult(true, result.Id, null, null);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _logger.LogError(
+                ex,
+                "Basiq CreateUser exception correlationId={CorrelationId}",
+                correlationId);
+            return new CreateUserResult(false, null, BankConnectionErrors.ConnectionProviderError, ex.Message);
+        }
+    }
+
+    public async Task<CreateConsentSessionResult> CreateConsentSessionAsync(
+        string externalUserId,
+        CancellationToken cancellationToken)
+    {
+        var correlationId = Guid.NewGuid().ToString("N");
+        _logger.LogInformation(
+            "Creating Basiq consent session for externalUserId={ExternalUserId} correlationId={CorrelationId}",
+            externalUserId,
+            correlationId);
+
+        try
+        {
+            var response = await ExecuteWithRetryAsync(
+                () =>
+                {
+                    var request = new HttpRequestMessage(HttpMethod.Post, $"/users/{externalUserId}/auth_link")
+                    {
+                        Content = JsonContent.Create(new { userId = externalUserId })
+                    };
+                    request.Headers.Add("X-Correlation-Id", correlationId);
+                    return request;
+                },
+                cancellationToken);
+
+            if (!response.IsSuccessStatusCode)
+            {
+                var errorBody = await response.Content.ReadAsStringAsync(cancellationToken);
+                _logger.LogWarning(
+                    "Basiq CreateConsentSession failed status={StatusCode} correlationId={CorrelationId} body={Body}",
+                    response.StatusCode,
+                    correlationId,
+                    errorBody);
+                return new CreateConsentSessionResult(false, null, null, BankConnectionErrors.ConnectionProviderError, $"Basiq API returned {(int)response.StatusCode}.");
+            }
+
+            var result = await response.Content.ReadFromJsonAsync<BasiqConsentSessionResponse>(cancellationToken: cancellationToken);
+            if (result is null || string.IsNullOrWhiteSpace(result.Id) || string.IsNullOrWhiteSpace(result.Url))
+            {
+                return new CreateConsentSessionResult(false, null, null, BankConnectionErrors.ConnectionProviderError, "Basiq API returned an invalid consent session response.");
+            }
+
+            _logger.LogInformation(
+                "Basiq consent session created sessionId={SessionId} correlationId={CorrelationId}",
+                result.Id,
+                correlationId);
+            return new CreateConsentSessionResult(true, result.Id, result.Url, null, null);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _logger.LogError(
+                ex,
+                "Basiq CreateConsentSession exception correlationId={CorrelationId}",
+                correlationId);
+            return new CreateConsentSessionResult(false, null, null, BankConnectionErrors.ConnectionProviderError, ex.Message);
+        }
+    }
+
+    public async Task<GetConnectionResult> GetConnectionAsync(
+        string externalUserId,
+        string consentSessionId,
+        CancellationToken cancellationToken)
+    {
+        var correlationId = Guid.NewGuid().ToString("N");
+        _logger.LogInformation(
+            "Fetching Basiq connection for externalUserId={ExternalUserId} session={SessionId} correlationId={CorrelationId}",
+            externalUserId,
+            consentSessionId,
+            correlationId);
+
+        try
+        {
+            var response = await ExecuteWithRetryAsync(
+                () =>
+                {
+                    var request = new HttpRequestMessage(HttpMethod.Get, $"/users/{externalUserId}/connections");
+                    request.Headers.Add("X-Correlation-Id", correlationId);
+                    return request;
+                },
+                cancellationToken);
+
+            if (!response.IsSuccessStatusCode)
+            {
+                var errorBody = await response.Content.ReadAsStringAsync(cancellationToken);
+                _logger.LogWarning(
+                    "Basiq GetConnection failed status={StatusCode} correlationId={CorrelationId} body={Body}",
+                    response.StatusCode,
+                    correlationId,
+                    errorBody);
+
+                var errorCode = (int)response.StatusCode == 410 || (int)response.StatusCode == 404
+                    ? BankConnectionErrors.ConnectionSessionExpired
+                    : BankConnectionErrors.ConnectionProviderError;
+                return new GetConnectionResult(false, null, null, null, errorCode, $"Basiq API returned {(int)response.StatusCode}.");
+            }
+
+            var result = await response.Content.ReadFromJsonAsync<BasiqConnectionsResponse>(cancellationToken: cancellationToken);
+            var connection = result?.Data?.FirstOrDefault();
+            if (connection is null || string.IsNullOrWhiteSpace(connection.Id))
+            {
+                return new GetConnectionResult(false, null, null, null, BankConnectionErrors.ConnectionCallbackInvalid, "No connection found for this session.");
+            }
+
+            _logger.LogInformation(
+                "Basiq connection retrieved connectionId={ConnectionId} status={Status} correlationId={CorrelationId}",
+                connection.Id,
+                connection.Status,
+                correlationId);
+            return new GetConnectionResult(true, connection.Id, connection.Institution?.ShortName, connection.Status, null, null);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _logger.LogError(
+                ex,
+                "Basiq GetConnection exception correlationId={CorrelationId}",
+                correlationId);
+            return new GetConnectionResult(false, null, null, null, BankConnectionErrors.ConnectionProviderError, ex.Message);
+        }
+    }
+
+    public async Task<GetAccountsResult> GetAccountsAsync(
+        string externalConnectionId,
+        CancellationToken cancellationToken)
+    {
+        var correlationId = Guid.NewGuid().ToString("N");
+        _logger.LogInformation(
+            "Fetching Basiq accounts for connectionId={ConnectionId} correlationId={CorrelationId}",
+            externalConnectionId,
+            correlationId);
+
+        try
+        {
+            var response = await ExecuteWithRetryAsync(
+                () =>
+                {
+                    var request = new HttpRequestMessage(HttpMethod.Get, $"/connections/{externalConnectionId}/accounts");
+                    request.Headers.Add("X-Correlation-Id", correlationId);
+                    return request;
+                },
+                cancellationToken);
+
+            if (!response.IsSuccessStatusCode)
+            {
+                var errorBody = await response.Content.ReadAsStringAsync(cancellationToken);
+                _logger.LogWarning(
+                    "Basiq GetAccounts failed status={StatusCode} correlationId={CorrelationId} body={Body}",
+                    response.StatusCode,
+                    correlationId,
+                    errorBody);
+                return new GetAccountsResult(false, null, BankConnectionErrors.ConnectionProviderError, $"Basiq API returned {(int)response.StatusCode}.");
+            }
+
+            var result = await response.Content.ReadFromJsonAsync<BasiqAccountsResponse>(cancellationToken: cancellationToken);
+            var accounts = result?.Data?
+                .Select(a => new BankAccountInfo(a.Id ?? string.Empty, a.Name ?? string.Empty, a.AccountNo, a.Class?.Type))
+                .ToArray() ?? [];
+
+            _logger.LogInformation(
+                "Basiq accounts retrieved count={Count} correlationId={CorrelationId}",
+                accounts.Length,
+                correlationId);
+            return new GetAccountsResult(true, accounts, null, null);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _logger.LogError(
+                ex,
+                "Basiq GetAccounts exception correlationId={CorrelationId}",
+                correlationId);
+            return new GetAccountsResult(false, null, BankConnectionErrors.ConnectionProviderError, ex.Message);
+        }
+    }
+
+    internal async Task<HttpResponseMessage> ExecuteWithRetryAsync(
+        Func<HttpRequestMessage> requestFactory,
+        CancellationToken cancellationToken)
+    {
+        var delay = InitialRetryDelay;
+
+        for (var attempt = 0; attempt <= MaxRetries; attempt++)
+        {
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            cts.CancelAfter(RequestTimeout);
+
+            var request = requestFactory();
+
+            try
+            {
+                var response = await _httpClient.SendAsync(request, cts.Token);
+
+                if (attempt < MaxRetries && IsTransientFailure(response.StatusCode))
+                {
+                    _logger.LogWarning(
+                        "Basiq transient failure status={StatusCode} attempt={Attempt}/{MaxRetries}, retrying in {Delay}ms",
+                        (int)response.StatusCode,
+                        attempt + 1,
+                        MaxRetries,
+                        delay.TotalMilliseconds);
+                    response.Dispose();
+                    await Task.Delay(delay, cancellationToken);
+                    delay = TimeSpan.FromTicks(delay.Ticks * 2);
+                    continue;
+                }
+
+                return response;
+            }
+            catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+            {
+                // Timeout
+                if (attempt < MaxRetries)
+                {
+                    _logger.LogWarning(
+                        "Basiq request timeout attempt={Attempt}/{MaxRetries}, retrying in {Delay}ms",
+                        attempt + 1,
+                        MaxRetries,
+                        delay.TotalMilliseconds);
+                    await Task.Delay(delay, cancellationToken);
+                    delay = TimeSpan.FromTicks(delay.Ticks * 2);
+                    continue;
+                }
+
+                throw new TimeoutException($"Basiq API request timed out after {MaxRetries + 1} attempts.");
+            }
+        }
+
+        throw new InvalidOperationException("Retry loop exited without returning or throwing.");
+    }
+
+    private static bool IsTransientFailure(HttpStatusCode statusCode)
+    {
+        return statusCode is HttpStatusCode.InternalServerError
+            or HttpStatusCode.BadGateway
+            or HttpStatusCode.ServiceUnavailable
+            or HttpStatusCode.GatewayTimeout
+            or HttpStatusCode.RequestTimeout;
+    }
+}
+
+internal sealed record BasiqUserResponse
+{
+    [JsonPropertyName("id")]
+    public string? Id { get; init; }
+}
+
+internal sealed record BasiqConsentSessionResponse
+{
+    [JsonPropertyName("id")]
+    public string? Id { get; init; }
+
+    [JsonPropertyName("url")]
+    public string? Url { get; init; }
+}
+
+internal sealed record BasiqConnectionsResponse
+{
+    [JsonPropertyName("data")]
+    public BasiqConnectionData[]? Data { get; init; }
+}
+
+internal sealed record BasiqConnectionData
+{
+    [JsonPropertyName("id")]
+    public string? Id { get; init; }
+
+    [JsonPropertyName("status")]
+    public string? Status { get; init; }
+
+    [JsonPropertyName("institution")]
+    public BasiqInstitution? Institution { get; init; }
+}
+
+internal sealed record BasiqInstitution
+{
+    [JsonPropertyName("shortName")]
+    public string? ShortName { get; init; }
+}
+
+internal sealed record BasiqAccountsResponse
+{
+    [JsonPropertyName("data")]
+    public BasiqAccountData[]? Data { get; init; }
+}
+
+internal sealed record BasiqAccountData
+{
+    [JsonPropertyName("id")]
+    public string? Id { get; init; }
+
+    [JsonPropertyName("name")]
+    public string? Name { get; init; }
+
+    [JsonPropertyName("accountNo")]
+    public string? AccountNo { get; init; }
+
+    [JsonPropertyName("class")]
+    public BasiqAccountClass? Class { get; init; }
+}
+
+internal sealed record BasiqAccountClass
+{
+    [JsonPropertyName("type")]
+    public string? Type { get; init; }
+}

--- a/backend/src/Modules/BankConnections/Infrastructure/BasiqBankProviderAdapter.cs
+++ b/backend/src/Modules/BankConnections/Infrastructure/BasiqBankProviderAdapter.cs
@@ -11,7 +11,6 @@ public sealed class BasiqBankProviderAdapter : IBankProviderAdapter
 {
     private readonly HttpClient _httpClient;
     private readonly ILogger<BasiqBankProviderAdapter> _logger;
-    private readonly TimeProvider _timeProvider;
 
     private const int MaxRetries = 3;
     private static readonly TimeSpan InitialRetryDelay = TimeSpan.FromSeconds(1);
@@ -19,12 +18,10 @@ public sealed class BasiqBankProviderAdapter : IBankProviderAdapter
 
     public BasiqBankProviderAdapter(
         HttpClient httpClient,
-        ILogger<BasiqBankProviderAdapter> logger,
-        TimeProvider timeProvider)
+        ILogger<BasiqBankProviderAdapter> logger)
     {
         _httpClient = httpClient;
         _logger = logger;
-        _timeProvider = timeProvider;
     }
 
     public async Task<CreateUserResult> CreateUserAsync(

--- a/backend/src/Modules/BankConnections/Infrastructure/InMemoryBankConnectionRepository.cs
+++ b/backend/src/Modules/BankConnections/Infrastructure/InMemoryBankConnectionRepository.cs
@@ -1,0 +1,82 @@
+using MoneyTracker.Modules.BankConnections.Domain;
+
+namespace MoneyTracker.Modules.BankConnections.Infrastructure;
+
+public sealed class InMemoryBankConnectionRepository : IBankConnectionRepository
+{
+    private readonly object _sync = new();
+    private readonly Dictionary<Guid, List<BankConnection>> _connectionsByHousehold = new();
+    private readonly Dictionary<string, BankConnection> _connectionsByConsentSession = new();
+
+    public Task AddAsync(BankConnection connection, CancellationToken cancellationToken)
+    {
+        if (cancellationToken.IsCancellationRequested)
+        {
+            return Task.FromCanceled(cancellationToken);
+        }
+
+        lock (_sync)
+        {
+            if (!_connectionsByHousehold.TryGetValue(connection.HouseholdId, out var list))
+            {
+                list = [];
+                _connectionsByHousehold[connection.HouseholdId] = list;
+            }
+
+            list.Add(connection);
+
+            if (!string.IsNullOrWhiteSpace(connection.ConsentSessionId))
+            {
+                _connectionsByConsentSession[connection.ConsentSessionId] = connection;
+            }
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public Task UpdateAsync(BankConnection connection, CancellationToken cancellationToken)
+    {
+        if (cancellationToken.IsCancellationRequested)
+        {
+            return Task.FromCanceled(cancellationToken);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public Task<BankConnection?> GetByConsentSessionIdAsync(
+        string consentSessionId,
+        CancellationToken cancellationToken)
+    {
+        if (cancellationToken.IsCancellationRequested)
+        {
+            return Task.FromCanceled<BankConnection?>(cancellationToken);
+        }
+
+        lock (_sync)
+        {
+            _connectionsByConsentSession.TryGetValue(consentSessionId, out var connection);
+            return Task.FromResult(connection);
+        }
+    }
+
+    public Task<IReadOnlyCollection<BankConnection>> GetByHouseholdAsync(
+        Guid householdId,
+        CancellationToken cancellationToken)
+    {
+        if (cancellationToken.IsCancellationRequested)
+        {
+            return Task.FromCanceled<IReadOnlyCollection<BankConnection>>(cancellationToken);
+        }
+
+        lock (_sync)
+        {
+            if (!_connectionsByHousehold.TryGetValue(householdId, out var list))
+            {
+                return Task.FromResult<IReadOnlyCollection<BankConnection>>(Array.Empty<BankConnection>());
+            }
+
+            return Task.FromResult<IReadOnlyCollection<BankConnection>>(list.ToArray());
+        }
+    }
+}

--- a/backend/src/Modules/BankConnections/Infrastructure/InMemoryBankProviderAdapter.cs
+++ b/backend/src/Modules/BankConnections/Infrastructure/InMemoryBankProviderAdapter.cs
@@ -1,0 +1,62 @@
+using MoneyTracker.Modules.BankConnections.Domain;
+
+namespace MoneyTracker.Modules.BankConnections.Infrastructure;
+
+public sealed class InMemoryBankProviderAdapter : IBankProviderAdapter
+{
+    public Task<CreateUserResult> CreateUserAsync(
+        Guid householdId,
+        Guid userId,
+        CancellationToken cancellationToken)
+    {
+        if (cancellationToken.IsCancellationRequested)
+        {
+            return Task.FromCanceled<CreateUserResult>(cancellationToken);
+        }
+
+        var externalUserId = $"inmemory-user-{userId:N}";
+        return Task.FromResult(new CreateUserResult(true, externalUserId, null, null));
+    }
+
+    public Task<CreateConsentSessionResult> CreateConsentSessionAsync(
+        string externalUserId,
+        CancellationToken cancellationToken)
+    {
+        if (cancellationToken.IsCancellationRequested)
+        {
+            return Task.FromCanceled<CreateConsentSessionResult>(cancellationToken);
+        }
+
+        var sessionId = $"inmemory-session-{Guid.NewGuid():N}";
+        var consentUrl = $"https://consent.example.com/{sessionId}";
+        return Task.FromResult(new CreateConsentSessionResult(true, sessionId, consentUrl, null, null));
+    }
+
+    public Task<GetConnectionResult> GetConnectionAsync(
+        string externalUserId,
+        string consentSessionId,
+        CancellationToken cancellationToken)
+    {
+        if (cancellationToken.IsCancellationRequested)
+        {
+            return Task.FromCanceled<GetConnectionResult>(cancellationToken);
+        }
+
+        var connectionId = $"inmemory-conn-{Guid.NewGuid():N}";
+        return Task.FromResult(new GetConnectionResult(
+            true, connectionId, "In-Memory Bank", "active", null, null));
+    }
+
+    public Task<GetAccountsResult> GetAccountsAsync(
+        string externalConnectionId,
+        CancellationToken cancellationToken)
+    {
+        if (cancellationToken.IsCancellationRequested)
+        {
+            return Task.FromCanceled<GetAccountsResult>(cancellationToken);
+        }
+
+        return Task.FromResult(new GetAccountsResult(
+            true, Array.Empty<BankAccountInfo>(), null, null));
+    }
+}

--- a/backend/src/Modules/BankConnections/MoneyTracker.Modules.BankConnections.csproj
+++ b/backend/src/Modules/BankConnections/MoneyTracker.Modules.BankConnections.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    <ProjectReference Include="..\Auth\MoneyTracker.Modules.Auth.csproj" />
+    <ProjectReference Include="..\SharedKernel\MoneyTracker.Modules.SharedKernel.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/backend/src/Modules/BankConnections/Presentation/BankConnectionEndpoints.cs
+++ b/backend/src/Modules/BankConnections/Presentation/BankConnectionEndpoints.cs
@@ -4,7 +4,6 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
 using MoneyTracker.Modules.Auth.Application.GetAuthenticatedUser;
 using MoneyTracker.Modules.Auth.Domain;
 using MoneyTracker.Modules.BankConnections.Application.CreateLinkSession;

--- a/backend/src/Modules/BankConnections/Presentation/BankConnectionEndpoints.cs
+++ b/backend/src/Modules/BankConnections/Presentation/BankConnectionEndpoints.cs
@@ -1,15 +1,13 @@
-using System.Text.Json;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
-using MoneyTracker.Modules.Auth.Application.GetAuthenticatedUser;
-using MoneyTracker.Modules.Auth.Domain;
 using MoneyTracker.Modules.BankConnections.Application.CreateLinkSession;
 using MoneyTracker.Modules.BankConnections.Application.GetBankConnections;
 using MoneyTracker.Modules.BankConnections.Application.ProcessCallback;
 using MoneyTracker.Modules.BankConnections.Domain;
+using MoneyTracker.Modules.SharedKernel.Households;
+using MoneyTracker.Modules.SharedKernel.Presentation;
 
 namespace MoneyTracker.Modules.BankConnections.Presentation;
 
@@ -54,6 +52,8 @@ public static class BankConnectionEndpoints
             .Accepts<ProcessCallbackRequest>("application/json")
             .Produces<BankConnectionResponse>(StatusCodes.Status200OK)
             .ProducesProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status401Unauthorized)
+            .ProducesProblem(StatusCodes.Status403Forbidden)
             .ProducesProblem(StatusCodes.Status404NotFound);
 
         var getConnectionsEndpoint = (RouteHandlerBuilder)app.MapGet("/bank/connections", GetBankConnections);
@@ -72,7 +72,7 @@ public static class BankConnectionEndpoints
 
     private static async Task CreateLinkSession(HttpContext httpContext)
     {
-        var authResult = await ResolveAuthenticatedUser(httpContext);
+        var authResult = await EndpointHelpers.ResolveAuthenticatedUser(httpContext);
         if (!authResult.Success)
         {
             await authResult.Problem!.ExecuteAsync(httpContext);
@@ -80,7 +80,7 @@ public static class BankConnectionEndpoints
         }
 
         var (isValidRequest, request, parseProblem) =
-            await ReadJsonRequestAsync<CreateLinkSessionRequest>(httpContext);
+            await EndpointHelpers.ReadJsonRequestAsync<CreateLinkSessionRequest>(httpContext, BankConnectionErrors.ValidationError);
         if (!isValidRequest || request is null)
         {
             if (parseProblem is not null)
@@ -89,7 +89,7 @@ public static class BankConnectionEndpoints
             }
             else
             {
-                await WriteProblemAsync(
+                await EndpointHelpers.WriteProblemAsync(
                     httpContext,
                     StatusCodes.Status400BadRequest,
                     "Validation failed.",
@@ -116,7 +116,7 @@ public static class BankConnectionEndpoints
                 _ => StatusCodes.Status400BadRequest
             };
 
-            await WriteProblemAsync(
+            await EndpointHelpers.WriteProblemAsync(
                 httpContext,
                 statusCode,
                 statusCode == StatusCodes.Status403Forbidden ? "Access denied." : "Validation failed.",
@@ -132,8 +132,15 @@ public static class BankConnectionEndpoints
 
     private static async Task ProcessCallback(HttpContext httpContext)
     {
+        var authResult = await EndpointHelpers.ResolveAuthenticatedUser(httpContext);
+        if (!authResult.Success)
+        {
+            await authResult.Problem!.ExecuteAsync(httpContext);
+            return;
+        }
+
         var (isValidRequest, request, parseProblem) =
-            await ReadJsonRequestAsync<ProcessCallbackRequest>(httpContext);
+            await EndpointHelpers.ReadJsonRequestAsync<ProcessCallbackRequest>(httpContext, BankConnectionErrors.ValidationError);
         if (!isValidRequest || request is null)
         {
             if (parseProblem is not null)
@@ -142,7 +149,7 @@ public static class BankConnectionEndpoints
             }
             else
             {
-                await WriteProblemAsync(
+                await EndpointHelpers.WriteProblemAsync(
                     httpContext,
                     StatusCodes.Status400BadRequest,
                     "Validation failed.",
@@ -168,7 +175,7 @@ public static class BankConnectionEndpoints
                 _ => StatusCodes.Status400BadRequest
             };
 
-            await WriteProblemAsync(
+            await EndpointHelpers.WriteProblemAsync(
                 httpContext,
                 statusCode,
                 "Validation failed.",
@@ -179,6 +186,34 @@ public static class BankConnectionEndpoints
         }
 
         var connection = result.Connection!;
+
+        // Verify the authenticated user has access to the connection's household
+        var householdAccess = httpContext.RequestServices.GetRequiredService<IHouseholdAccessService>();
+        var accessResult = await householdAccess.CheckMemberAsync(
+            connection.HouseholdId,
+            authResult.AuthenticatedUser!.UserId,
+            httpContext.RequestAborted);
+
+        if (!accessResult.IsMember)
+        {
+            var statusCode = accessResult.HouseholdExists
+                ? StatusCodes.Status403Forbidden
+                : StatusCodes.Status404NotFound;
+
+            await EndpointHelpers.WriteProblemAsync(
+                httpContext,
+                statusCode,
+                statusCode == StatusCodes.Status403Forbidden ? "Access denied." : "Not found.",
+                statusCode == StatusCodes.Status403Forbidden
+                    ? "You do not have access to this household."
+                    : "The household was not found.",
+                statusCode == StatusCodes.Status403Forbidden
+                    ? BankConnectionErrors.ConnectionAccessDenied
+                    : BankConnectionErrors.ConnectionHouseholdNotFound,
+                BankConnectionErrors.ValidationError);
+            return;
+        }
+
         var response = new BankConnectionResponse(
             connection.Id.Value,
             connection.HouseholdId,
@@ -191,7 +226,7 @@ public static class BankConnectionEndpoints
 
         if (result.IsFailedConnection)
         {
-            await WriteProblemAsync(
+            await EndpointHelpers.WriteProblemAsync(
                 httpContext,
                 StatusCodes.Status400BadRequest,
                 "Connection failed.",
@@ -206,7 +241,7 @@ public static class BankConnectionEndpoints
 
     private static async Task GetBankConnections(HttpContext httpContext)
     {
-        var authResult = await ResolveAuthenticatedUser(httpContext);
+        var authResult = await EndpointHelpers.ResolveAuthenticatedUser(httpContext);
         if (!authResult.Success)
         {
             await authResult.Problem!.ExecuteAsync(httpContext);
@@ -215,7 +250,7 @@ public static class BankConnectionEndpoints
 
         if (!TryGetGuidQuery(httpContext, "householdId", out var householdId))
         {
-            await WriteProblemAsync(
+            await EndpointHelpers.WriteProblemAsync(
                 httpContext,
                 StatusCodes.Status400BadRequest,
                 "Validation failed.",
@@ -239,7 +274,7 @@ public static class BankConnectionEndpoints
                 _ => StatusCodes.Status400BadRequest
             };
 
-            await WriteProblemAsync(
+            await EndpointHelpers.WriteProblemAsync(
                 httpContext,
                 statusCode,
                 statusCode == StatusCodes.Status403Forbidden ? "Access denied." : "Validation failed.",
@@ -264,141 +299,11 @@ public static class BankConnectionEndpoints
         await TypedResults.Ok(response).ExecuteAsync(httpContext);
     }
 
-    private static async Task<(bool Success, AuthenticatedUser? AuthenticatedUser, IResult? Problem)> ResolveAuthenticatedUser(HttpContext httpContext)
-    {
-        var token = ExtractBearerToken(httpContext.Request.Headers.Authorization.ToString());
-        var handler = httpContext.RequestServices.GetRequiredService<GetAuthenticatedUserHandler>();
-        var authResult = await handler.HandleAsync(new GetAuthenticatedUserQuery(token), httpContext.RequestAborted);
-
-        if (!authResult.IsSuccess)
-        {
-            var problem = BuildProblemResult(
-                StatusCodes.Status401Unauthorized,
-                "Authentication required.",
-                authResult.ErrorMessage ?? "Authentication required.",
-                authResult.ErrorCode ?? AuthErrors.AccessTokenInvalid,
-                httpContext.Request.Path);
-
-            return (false, null, problem);
-        }
-
-        return (true, new AuthenticatedUser(authResult.UserId, authResult.Email), null);
-    }
-
-    private static string? ExtractBearerToken(string? authorizationHeader)
-    {
-        if (string.IsNullOrWhiteSpace(authorizationHeader))
-        {
-            return null;
-        }
-
-        if (!authorizationHeader.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase))
-        {
-            return null;
-        }
-
-        var token = authorizationHeader.Substring("Bearer ".Length).Trim();
-        return string.IsNullOrWhiteSpace(token) ? null : token;
-    }
-
-    private static async Task<(bool IsValid, TRequest? Request, IResult? Error)> ReadJsonRequestAsync<TRequest>(HttpContext httpContext)
-        where TRequest : class
-    {
-        var contentType = httpContext.Request.ContentType;
-        if (string.IsNullOrWhiteSpace(contentType) || !IsJsonContentType(contentType))
-        {
-            return (false, default, BuildProblemResult(
-                StatusCodes.Status400BadRequest,
-                "Validation failed.",
-                "The request payload is required to be JSON.",
-                BankConnectionErrors.ValidationError,
-                httpContext.Request.Path));
-        }
-
-        try
-        {
-            var request = await httpContext.Request.ReadFromJsonAsync<TRequest>(cancellationToken: httpContext.RequestAborted);
-            if (request is null)
-            {
-                return (false, default, BuildProblemResult(
-                    StatusCodes.Status400BadRequest,
-                    "Validation failed.",
-                    "The request payload is invalid.",
-                    BankConnectionErrors.ValidationError,
-                    httpContext.Request.Path));
-            }
-
-            return (true, request, null);
-        }
-        catch (JsonException)
-        {
-            return (false, default, BuildProblemResult(
-                StatusCodes.Status400BadRequest,
-                "Validation failed.",
-                "The request payload is invalid.",
-                BankConnectionErrors.ValidationError,
-                httpContext.Request.Path));
-        }
-        catch (NotSupportedException)
-        {
-            return (false, default, BuildProblemResult(
-                StatusCodes.Status400BadRequest,
-                "Validation failed.",
-                "The request payload is invalid.",
-                BankConnectionErrors.ValidationError,
-                httpContext.Request.Path));
-        }
-        catch (BadHttpRequestException)
-        {
-            return (false, default, BuildProblemResult(
-                StatusCodes.Status400BadRequest,
-                "Validation failed.",
-                "The request payload is invalid.",
-                BankConnectionErrors.ValidationError,
-                httpContext.Request.Path));
-        }
-    }
-
-    private static bool IsJsonContentType(string contentType)
-    {
-        var mediaType = contentType.Split(';')[0].Trim();
-        return mediaType.Equals("application/json", StringComparison.OrdinalIgnoreCase);
-    }
-
     private static bool TryGetGuidQuery(HttpContext httpContext, string key, out Guid value)
     {
         value = Guid.Empty;
         var raw = httpContext.Request.Query[key].FirstOrDefault();
         return raw is not null && Guid.TryParse(raw, out value);
-    }
-
-    private static IResult BuildProblemResult(int statusCode, string title, string detail, string code, string instance)
-    {
-        var problem = new ProblemDetails
-        {
-            Status = statusCode,
-            Title = title,
-            Detail = detail,
-            Instance = instance
-        };
-        problem.Extensions["code"] = code;
-        return TypedResults.Problem(problem);
-    }
-
-    private static async Task WriteProblemAsync(
-        HttpContext httpContext,
-        int statusCode,
-        string title,
-        string detail,
-        string? code,
-        string fallbackCode)
-    {
-        await BuildProblemResult(
-            statusCode,
-            title,
-            detail,
-            code ?? fallbackCode,
-            httpContext.Request.Path).ExecuteAsync(httpContext);
     }
 }
 
@@ -429,5 +334,3 @@ public sealed record BankConnectionSummaryResponse(
     DateTimeOffset UpdatedAtUtc);
 
 public sealed record BankConnectionsResponse(BankConnectionSummaryResponse[] Connections);
-
-internal sealed record AuthenticatedUser(Guid UserId, string Email);

--- a/backend/src/Modules/BankConnections/Presentation/BankConnectionEndpoints.cs
+++ b/backend/src/Modules/BankConnections/Presentation/BankConnectionEndpoints.cs
@@ -1,0 +1,434 @@
+using System.Text.Json;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using MoneyTracker.Modules.Auth.Application.GetAuthenticatedUser;
+using MoneyTracker.Modules.Auth.Domain;
+using MoneyTracker.Modules.BankConnections.Application.CreateLinkSession;
+using MoneyTracker.Modules.BankConnections.Application.GetBankConnections;
+using MoneyTracker.Modules.BankConnections.Application.ProcessCallback;
+using MoneyTracker.Modules.BankConnections.Domain;
+
+namespace MoneyTracker.Modules.BankConnections.Presentation;
+
+public static class BankConnectionEndpoints
+{
+    public static IServiceCollection AddBankConnectionsModule(this IServiceCollection services)
+    {
+        services.AddSingleton<IBankConnectionRepository, Infrastructure.InMemoryBankConnectionRepository>();
+        services.AddSingleton<IBankProviderAdapter, Infrastructure.InMemoryBankProviderAdapter>();
+        services.AddSingleton(TimeProvider.System);
+        services.AddHttpClient<Infrastructure.BasiqBankProviderAdapter>(client =>
+        {
+            client.BaseAddress = new Uri("https://au-api.basiq.io");
+            client.Timeout = TimeSpan.FromSeconds(30);
+        });
+        services.AddScoped<CreateLinkSessionHandler>();
+        services.AddScoped<ProcessCallbackHandler>();
+        services.AddScoped<GetBankConnectionsHandler>();
+
+        return services;
+    }
+
+    public static IEndpointRouteBuilder MapBankConnectionEndpoints(this IEndpointRouteBuilder app)
+    {
+        var createLinkSessionEndpoint = (RouteHandlerBuilder)app.MapPost("/bank/link-session", CreateLinkSession);
+        createLinkSessionEndpoint
+            .WithName("CreateBankLinkSession")
+            .WithSummary("Create a bank link session.")
+            .WithDescription("Creates a Basiq consent session and returns a consent URL for the user.")
+            .Accepts<CreateLinkSessionRequest>("application/json")
+            .Produces<LinkSessionResponse>(StatusCodes.Status200OK)
+            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status401Unauthorized)
+            .ProducesProblem(StatusCodes.Status403Forbidden)
+            .ProducesProblem(StatusCodes.Status404NotFound);
+
+        var callbackEndpoint = (RouteHandlerBuilder)app.MapPost("/bank/callback", ProcessCallback);
+        callbackEndpoint
+            .WithName("ProcessBankCallback")
+            .WithSummary("Process bank connection callback.")
+            .WithDescription("Handles the OAuth redirect callback from the bank provider.")
+            .Accepts<ProcessCallbackRequest>("application/json")
+            .Produces<BankConnectionResponse>(StatusCodes.Status200OK)
+            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status404NotFound);
+
+        var getConnectionsEndpoint = (RouteHandlerBuilder)app.MapGet("/bank/connections", GetBankConnections);
+        getConnectionsEndpoint
+            .WithName("GetBankConnections")
+            .WithSummary("List bank connections.")
+            .WithDescription("Returns all bank connections for a household with current status.")
+            .Produces<BankConnectionsResponse>(StatusCodes.Status200OK)
+            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status401Unauthorized)
+            .ProducesProblem(StatusCodes.Status403Forbidden)
+            .ProducesProblem(StatusCodes.Status404NotFound);
+
+        return app;
+    }
+
+    private static async Task CreateLinkSession(HttpContext httpContext)
+    {
+        var authResult = await ResolveAuthenticatedUser(httpContext);
+        if (!authResult.Success)
+        {
+            await authResult.Problem!.ExecuteAsync(httpContext);
+            return;
+        }
+
+        var (isValidRequest, request, parseProblem) =
+            await ReadJsonRequestAsync<CreateLinkSessionRequest>(httpContext);
+        if (!isValidRequest || request is null)
+        {
+            if (parseProblem is not null)
+            {
+                await parseProblem.ExecuteAsync(httpContext);
+            }
+            else
+            {
+                await WriteProblemAsync(
+                    httpContext,
+                    StatusCodes.Status400BadRequest,
+                    "Validation failed.",
+                    "The request payload is required.",
+                    BankConnectionErrors.ValidationError,
+                    BankConnectionErrors.ValidationError);
+            }
+            return;
+        }
+
+        var handler = httpContext.RequestServices.GetRequiredService<CreateLinkSessionHandler>();
+        var result = await handler.HandleAsync(
+            new CreateLinkSessionCommand(
+                request.HouseholdId,
+                authResult.AuthenticatedUser!.UserId),
+            httpContext.RequestAborted);
+
+        if (!result.IsSuccess)
+        {
+            var statusCode = result.ErrorCode switch
+            {
+                BankConnectionErrors.ConnectionHouseholdNotFound => StatusCodes.Status404NotFound,
+                BankConnectionErrors.ConnectionAccessDenied => StatusCodes.Status403Forbidden,
+                _ => StatusCodes.Status400BadRequest
+            };
+
+            await WriteProblemAsync(
+                httpContext,
+                statusCode,
+                statusCode == StatusCodes.Status403Forbidden ? "Access denied." : "Validation failed.",
+                result.ErrorMessage ?? "Request rejected.",
+                result.ErrorCode,
+                BankConnectionErrors.ValidationError);
+            return;
+        }
+
+        var response = new LinkSessionResponse(result.ConsentUrl!, result.ConnectionId!.Value);
+        await TypedResults.Ok(response).ExecuteAsync(httpContext);
+    }
+
+    private static async Task ProcessCallback(HttpContext httpContext)
+    {
+        var (isValidRequest, request, parseProblem) =
+            await ReadJsonRequestAsync<ProcessCallbackRequest>(httpContext);
+        if (!isValidRequest || request is null)
+        {
+            if (parseProblem is not null)
+            {
+                await parseProblem.ExecuteAsync(httpContext);
+            }
+            else
+            {
+                await WriteProblemAsync(
+                    httpContext,
+                    StatusCodes.Status400BadRequest,
+                    "Validation failed.",
+                    "The request payload is required.",
+                    BankConnectionErrors.ValidationError,
+                    BankConnectionErrors.ValidationError);
+            }
+            return;
+        }
+
+        var handler = httpContext.RequestServices.GetRequiredService<ProcessCallbackHandler>();
+        var result = await handler.HandleAsync(
+            new ProcessCallbackCommand(request.ConsentSessionId),
+            httpContext.RequestAborted);
+
+        if (!result.IsSuccess && !result.IsFailedConnection)
+        {
+            var statusCode = result.ErrorCode switch
+            {
+                BankConnectionErrors.ConnectionNotFound => StatusCodes.Status404NotFound,
+                BankConnectionErrors.ConnectionSessionExpired => StatusCodes.Status400BadRequest,
+                BankConnectionErrors.ConnectionCallbackInvalid => StatusCodes.Status400BadRequest,
+                _ => StatusCodes.Status400BadRequest
+            };
+
+            await WriteProblemAsync(
+                httpContext,
+                statusCode,
+                "Validation failed.",
+                result.ErrorMessage ?? "Request rejected.",
+                result.ErrorCode,
+                BankConnectionErrors.ValidationError);
+            return;
+        }
+
+        var connection = result.Connection!;
+        var response = new BankConnectionResponse(
+            connection.Id.Value,
+            connection.HouseholdId,
+            connection.InstitutionName,
+            connection.Status.ToString(),
+            connection.ErrorCode,
+            connection.ErrorMessage,
+            connection.CreatedAtUtc,
+            connection.UpdatedAtUtc);
+
+        if (result.IsFailedConnection)
+        {
+            await WriteProblemAsync(
+                httpContext,
+                StatusCodes.Status400BadRequest,
+                "Connection failed.",
+                result.ErrorMessage ?? "The bank connection could not be established.",
+                result.ErrorCode,
+                BankConnectionErrors.ConnectionProviderError);
+            return;
+        }
+
+        await TypedResults.Ok(response).ExecuteAsync(httpContext);
+    }
+
+    private static async Task GetBankConnections(HttpContext httpContext)
+    {
+        var authResult = await ResolveAuthenticatedUser(httpContext);
+        if (!authResult.Success)
+        {
+            await authResult.Problem!.ExecuteAsync(httpContext);
+            return;
+        }
+
+        if (!TryGetGuidQuery(httpContext, "householdId", out var householdId))
+        {
+            await WriteProblemAsync(
+                httpContext,
+                StatusCodes.Status400BadRequest,
+                "Validation failed.",
+                "householdId query parameter is required.",
+                BankConnectionErrors.ValidationError,
+                BankConnectionErrors.ValidationError);
+            return;
+        }
+
+        var handler = httpContext.RequestServices.GetRequiredService<GetBankConnectionsHandler>();
+        var result = await handler.HandleAsync(
+            new GetBankConnectionsQuery(householdId, authResult.AuthenticatedUser!.UserId),
+            httpContext.RequestAborted);
+
+        if (!result.IsSuccess)
+        {
+            var statusCode = result.ErrorCode switch
+            {
+                BankConnectionErrors.ConnectionHouseholdNotFound => StatusCodes.Status404NotFound,
+                BankConnectionErrors.ConnectionAccessDenied => StatusCodes.Status403Forbidden,
+                _ => StatusCodes.Status400BadRequest
+            };
+
+            await WriteProblemAsync(
+                httpContext,
+                statusCode,
+                statusCode == StatusCodes.Status403Forbidden ? "Access denied." : "Validation failed.",
+                result.ErrorMessage ?? "Request rejected.",
+                result.ErrorCode,
+                BankConnectionErrors.ValidationError);
+            return;
+        }
+
+        var response = new BankConnectionsResponse(
+            result.Connections!
+                .Select(c => new BankConnectionSummaryResponse(
+                    c.Id,
+                    c.HouseholdId,
+                    c.InstitutionName,
+                    c.Status,
+                    c.ErrorCode,
+                    c.ErrorMessage,
+                    c.CreatedAtUtc,
+                    c.UpdatedAtUtc))
+                .ToArray());
+        await TypedResults.Ok(response).ExecuteAsync(httpContext);
+    }
+
+    private static async Task<(bool Success, AuthenticatedUser? AuthenticatedUser, IResult? Problem)> ResolveAuthenticatedUser(HttpContext httpContext)
+    {
+        var token = ExtractBearerToken(httpContext.Request.Headers.Authorization.ToString());
+        var handler = httpContext.RequestServices.GetRequiredService<GetAuthenticatedUserHandler>();
+        var authResult = await handler.HandleAsync(new GetAuthenticatedUserQuery(token), httpContext.RequestAborted);
+
+        if (!authResult.IsSuccess)
+        {
+            var problem = BuildProblemResult(
+                StatusCodes.Status401Unauthorized,
+                "Authentication required.",
+                authResult.ErrorMessage ?? "Authentication required.",
+                authResult.ErrorCode ?? AuthErrors.AccessTokenInvalid,
+                httpContext.Request.Path);
+
+            return (false, null, problem);
+        }
+
+        return (true, new AuthenticatedUser(authResult.UserId, authResult.Email), null);
+    }
+
+    private static string? ExtractBearerToken(string? authorizationHeader)
+    {
+        if (string.IsNullOrWhiteSpace(authorizationHeader))
+        {
+            return null;
+        }
+
+        if (!authorizationHeader.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase))
+        {
+            return null;
+        }
+
+        var token = authorizationHeader.Substring("Bearer ".Length).Trim();
+        return string.IsNullOrWhiteSpace(token) ? null : token;
+    }
+
+    private static async Task<(bool IsValid, TRequest? Request, IResult? Error)> ReadJsonRequestAsync<TRequest>(HttpContext httpContext)
+        where TRequest : class
+    {
+        var contentType = httpContext.Request.ContentType;
+        if (string.IsNullOrWhiteSpace(contentType) || !IsJsonContentType(contentType))
+        {
+            return (false, default, BuildProblemResult(
+                StatusCodes.Status400BadRequest,
+                "Validation failed.",
+                "The request payload is required to be JSON.",
+                BankConnectionErrors.ValidationError,
+                httpContext.Request.Path));
+        }
+
+        try
+        {
+            var request = await httpContext.Request.ReadFromJsonAsync<TRequest>(cancellationToken: httpContext.RequestAborted);
+            if (request is null)
+            {
+                return (false, default, BuildProblemResult(
+                    StatusCodes.Status400BadRequest,
+                    "Validation failed.",
+                    "The request payload is invalid.",
+                    BankConnectionErrors.ValidationError,
+                    httpContext.Request.Path));
+            }
+
+            return (true, request, null);
+        }
+        catch (JsonException)
+        {
+            return (false, default, BuildProblemResult(
+                StatusCodes.Status400BadRequest,
+                "Validation failed.",
+                "The request payload is invalid.",
+                BankConnectionErrors.ValidationError,
+                httpContext.Request.Path));
+        }
+        catch (NotSupportedException)
+        {
+            return (false, default, BuildProblemResult(
+                StatusCodes.Status400BadRequest,
+                "Validation failed.",
+                "The request payload is invalid.",
+                BankConnectionErrors.ValidationError,
+                httpContext.Request.Path));
+        }
+        catch (BadHttpRequestException)
+        {
+            return (false, default, BuildProblemResult(
+                StatusCodes.Status400BadRequest,
+                "Validation failed.",
+                "The request payload is invalid.",
+                BankConnectionErrors.ValidationError,
+                httpContext.Request.Path));
+        }
+    }
+
+    private static bool IsJsonContentType(string contentType)
+    {
+        var mediaType = contentType.Split(';')[0].Trim();
+        return mediaType.Equals("application/json", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool TryGetGuidQuery(HttpContext httpContext, string key, out Guid value)
+    {
+        value = Guid.Empty;
+        var raw = httpContext.Request.Query[key].FirstOrDefault();
+        return raw is not null && Guid.TryParse(raw, out value);
+    }
+
+    private static IResult BuildProblemResult(int statusCode, string title, string detail, string code, string instance)
+    {
+        var problem = new ProblemDetails
+        {
+            Status = statusCode,
+            Title = title,
+            Detail = detail,
+            Instance = instance
+        };
+        problem.Extensions["code"] = code;
+        return TypedResults.Problem(problem);
+    }
+
+    private static async Task WriteProblemAsync(
+        HttpContext httpContext,
+        int statusCode,
+        string title,
+        string detail,
+        string? code,
+        string fallbackCode)
+    {
+        await BuildProblemResult(
+            statusCode,
+            title,
+            detail,
+            code ?? fallbackCode,
+            httpContext.Request.Path).ExecuteAsync(httpContext);
+    }
+}
+
+public sealed record CreateLinkSessionRequest(Guid HouseholdId);
+
+public sealed record ProcessCallbackRequest(string ConsentSessionId);
+
+public sealed record LinkSessionResponse(string ConsentUrl, Guid ConnectionId);
+
+public sealed record BankConnectionResponse(
+    Guid Id,
+    Guid HouseholdId,
+    string? InstitutionName,
+    string Status,
+    string? ErrorCode,
+    string? ErrorMessage,
+    DateTimeOffset CreatedAtUtc,
+    DateTimeOffset UpdatedAtUtc);
+
+public sealed record BankConnectionSummaryResponse(
+    Guid Id,
+    Guid HouseholdId,
+    string? InstitutionName,
+    string Status,
+    string? ErrorCode,
+    string? ErrorMessage,
+    DateTimeOffset CreatedAtUtc,
+    DateTimeOffset UpdatedAtUtc);
+
+public sealed record BankConnectionsResponse(BankConnectionSummaryResponse[] Connections);
+
+internal sealed record AuthenticatedUser(Guid UserId, string Email);

--- a/backend/src/Modules/Households/Presentation/CreateHouseholdEndpoint.cs
+++ b/backend/src/Modules/Households/Presentation/CreateHouseholdEndpoint.cs
@@ -1,4 +1,3 @@
-using System.Text.Json;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
@@ -11,6 +10,7 @@ using MoneyTracker.Modules.Households.Application.GetHouseholdMembers;
 using MoneyTracker.Modules.Households.Application.InviteHouseholdMember;
 using MoneyTracker.Modules.Households.Domain;
 using MoneyTracker.Modules.SharedKernel.Households;
+using MoneyTracker.Modules.SharedKernel.Presentation;
 
 namespace MoneyTracker.Modules.Households.Presentation;
 
@@ -79,7 +79,8 @@ public static class CreateHouseholdEndpoint
             return;
         }
 
-        var (isValidRequest, request, parseProblem) = await ReadJsonRequestAsync<CreateHouseholdRequest>(httpContext);
+        var (isValidRequest, request, parseProblem) =
+            await EndpointHelpers.ReadJsonRequestAsync<CreateHouseholdRequest>(httpContext, HouseholdErrors.ValidationError);
         if (!isValidRequest || request is null)
         {
             if (parseProblem is not null)
@@ -144,7 +145,8 @@ public static class CreateHouseholdEndpoint
             return;
         }
 
-        var (isValidRequest, request, parseProblem) = await ReadJsonRequestAsync<InviteHouseholdMemberRequest>(httpContext);
+        var (isValidRequest, request, parseProblem) =
+            await EndpointHelpers.ReadJsonRequestAsync<InviteHouseholdMemberRequest>(httpContext, HouseholdErrors.ValidationError);
         if (!isValidRequest || request is null)
         {
             if (parseProblem is not null)
@@ -288,70 +290,6 @@ public static class CreateHouseholdEndpoint
         var response = new GetHouseholdMembersResponse(
             result.Members!.Select(member => new HouseholdMemberResponse(member.UserId, member.Role)).ToArray());
         await TypedResults.Ok(response).ExecuteAsync(httpContext);
-    }
-
-    private static async Task<(bool IsValid, TRequest? Request, IResult? Error)> ReadJsonRequestAsync<TRequest>(HttpContext httpContext)
-        where TRequest : class
-    {
-        var contentType = httpContext.Request.ContentType;
-        if (string.IsNullOrWhiteSpace(contentType) || !IsJsonContentType(contentType))
-        {
-            return (false, default, HouseholdEndpointHelpers.BuildProblemResult(
-                StatusCodes.Status400BadRequest,
-                "Validation failed.",
-                "The request payload is required to be JSON.",
-                HouseholdErrors.ValidationError,
-                httpContext.Request.Path));
-        }
-
-        try
-        {
-            var request = await httpContext.Request.ReadFromJsonAsync<TRequest>(cancellationToken: httpContext.RequestAborted);
-            if (request is null)
-            {
-                return (false, default, HouseholdEndpointHelpers.BuildProblemResult(
-                    StatusCodes.Status400BadRequest,
-                    "Validation failed.",
-                    "The request payload is invalid.",
-                    HouseholdErrors.ValidationError,
-                    httpContext.Request.Path));
-            }
-
-            return (true, request, null);
-        }
-        catch (JsonException)
-        {
-            return (false, default, HouseholdEndpointHelpers.BuildProblemResult(
-                StatusCodes.Status400BadRequest,
-                "Validation failed.",
-                "The request payload is invalid.",
-                HouseholdErrors.ValidationError,
-                httpContext.Request.Path));
-        }
-        catch (NotSupportedException)
-        {
-            return (false, default, HouseholdEndpointHelpers.BuildProblemResult(
-                StatusCodes.Status400BadRequest,
-                "Validation failed.",
-                "The request payload is invalid.",
-                HouseholdErrors.ValidationError,
-                httpContext.Request.Path));
-        }
-        catch (BadHttpRequestException)
-        {
-            return (false, default, HouseholdEndpointHelpers.BuildProblemResult(
-                StatusCodes.Status400BadRequest,
-                "Validation failed.",
-                "The request payload is invalid.",
-                HouseholdErrors.ValidationError,
-                httpContext.Request.Path));
-        }
-    }
-
-    private static bool IsJsonContentType(string contentType)
-    {
-        var mediaType = contentType.Split(';')[0].Trim();
-        return mediaType.Equals("application/json", StringComparison.OrdinalIgnoreCase);
     }
 }
 

--- a/backend/src/Modules/Households/Presentation/HouseholdEndpointHelpers.cs
+++ b/backend/src/Modules/Households/Presentation/HouseholdEndpointHelpers.cs
@@ -1,49 +1,22 @@
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.DependencyInjection;
-using MoneyTracker.Modules.Auth.Application.GetAuthenticatedUser;
-using MoneyTracker.Modules.Auth.Domain;
+using MoneyTracker.Modules.SharedKernel.Presentation;
 
 namespace MoneyTracker.Modules.Households.Presentation;
 
 internal static class HouseholdEndpointHelpers
 {
-    internal static async Task<(bool Success, AuthenticatedUser? AuthenticatedUser, IResult? Problem)> ResolveAuthenticatedUser(
+    internal static Task<(bool Success, AuthenticatedUser? AuthenticatedUser, IResult? Problem)> ResolveAuthenticatedUser(
         HttpContext httpContext)
     {
-        var token = ExtractBearerToken(httpContext.Request.Headers.Authorization.ToString());
-        var handler = httpContext.RequestServices.GetRequiredService<GetAuthenticatedUserHandler>();
-        var authResult = await handler.HandleAsync(new GetAuthenticatedUserQuery(token), httpContext.RequestAborted);
-
-        if (!authResult.IsSuccess)
-        {
-            var problem = BuildProblemResult(
-                StatusCodes.Status401Unauthorized,
-                "Authentication required.",
-                authResult.ErrorMessage ?? "Authentication required.",
-                authResult.ErrorCode ?? AuthErrors.AccessTokenInvalid,
-                httpContext.Request.Path);
-
-            return (false, null, problem);
-        }
-
-        return (true, new AuthenticatedUser(authResult.UserId, authResult.Email), null);
+        return EndpointHelpers.ResolveAuthenticatedUser(httpContext);
     }
 
     internal static IResult BuildProblemResult(int statusCode, string title, string detail, string code, string instance)
     {
-        var problem = new ProblemDetails
-        {
-            Status = statusCode,
-            Title = title,
-            Detail = detail,
-            Instance = instance
-        };
-        problem.Extensions["code"] = code;
-        return TypedResults.Problem(problem);
+        return EndpointHelpers.BuildProblemResult(statusCode, title, detail, code, instance);
     }
 
-    internal static async Task WriteProblemAsync(
+    internal static Task WriteProblemAsync(
         HttpContext httpContext,
         int statusCode,
         string title,
@@ -51,29 +24,6 @@ internal static class HouseholdEndpointHelpers
         string? code,
         string fallbackCode)
     {
-        await BuildProblemResult(
-            statusCode,
-            title,
-            detail,
-            code ?? fallbackCode,
-            httpContext.Request.Path).ExecuteAsync(httpContext);
-    }
-
-    private static string? ExtractBearerToken(string? authorizationHeader)
-    {
-        if (string.IsNullOrWhiteSpace(authorizationHeader))
-        {
-            return null;
-        }
-
-        if (!authorizationHeader.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase))
-        {
-            return null;
-        }
-
-        var token = authorizationHeader.Substring("Bearer ".Length).Trim();
-        return string.IsNullOrWhiteSpace(token) ? null : token;
+        return EndpointHelpers.WriteProblemAsync(httpContext, statusCode, title, detail, code, fallbackCode);
     }
 }
-
-internal sealed record AuthenticatedUser(Guid UserId, string Email);

--- a/backend/src/Modules/SharedKernel/MoneyTracker.Modules.SharedKernel.csproj
+++ b/backend/src/Modules/SharedKernel/MoneyTracker.Modules.SharedKernel.csproj
@@ -6,4 +6,9 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    <ProjectReference Include="..\Auth\MoneyTracker.Modules.Auth.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/backend/src/Modules/SharedKernel/Presentation/EndpointHelpers.cs
+++ b/backend/src/Modules/SharedKernel/Presentation/EndpointHelpers.cs
@@ -1,0 +1,146 @@
+using System.Text.Json;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
+using MoneyTracker.Modules.Auth.Application.GetAuthenticatedUser;
+using MoneyTracker.Modules.Auth.Domain;
+
+namespace MoneyTracker.Modules.SharedKernel.Presentation;
+
+public sealed record AuthenticatedUser(Guid UserId, string Email);
+
+public static class EndpointHelpers
+{
+    public static async Task<(bool Success, AuthenticatedUser? AuthenticatedUser, IResult? Problem)> ResolveAuthenticatedUser(
+        HttpContext httpContext)
+    {
+        var token = ExtractBearerToken(httpContext.Request.Headers.Authorization.ToString());
+        var handler = httpContext.RequestServices.GetRequiredService<GetAuthenticatedUserHandler>();
+        var authResult = await handler.HandleAsync(new GetAuthenticatedUserQuery(token), httpContext.RequestAborted);
+
+        if (!authResult.IsSuccess)
+        {
+            var problem = BuildProblemResult(
+                StatusCodes.Status401Unauthorized,
+                "Authentication required.",
+                authResult.ErrorMessage ?? "Authentication required.",
+                authResult.ErrorCode ?? AuthErrors.AccessTokenInvalid,
+                httpContext.Request.Path);
+
+            return (false, null, problem);
+        }
+
+        return (true, new AuthenticatedUser(authResult.UserId, authResult.Email), null);
+    }
+
+    public static string? ExtractBearerToken(string? authorizationHeader)
+    {
+        if (string.IsNullOrWhiteSpace(authorizationHeader))
+        {
+            return null;
+        }
+
+        if (!authorizationHeader.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase))
+        {
+            return null;
+        }
+
+        var token = authorizationHeader.Substring("Bearer ".Length).Trim();
+        return string.IsNullOrWhiteSpace(token) ? null : token;
+    }
+
+    public static async Task<(bool IsValid, TRequest? Request, IResult? Error)> ReadJsonRequestAsync<TRequest>(
+        HttpContext httpContext,
+        string validationErrorCode)
+        where TRequest : class
+    {
+        var contentType = httpContext.Request.ContentType;
+        if (string.IsNullOrWhiteSpace(contentType) || !IsJsonContentType(contentType))
+        {
+            return (false, default, BuildProblemResult(
+                StatusCodes.Status400BadRequest,
+                "Validation failed.",
+                "The request payload is required to be JSON.",
+                validationErrorCode,
+                httpContext.Request.Path));
+        }
+
+        try
+        {
+            var request = await httpContext.Request.ReadFromJsonAsync<TRequest>(cancellationToken: httpContext.RequestAborted);
+            if (request is null)
+            {
+                return (false, default, BuildProblemResult(
+                    StatusCodes.Status400BadRequest,
+                    "Validation failed.",
+                    "The request payload is invalid.",
+                    validationErrorCode,
+                    httpContext.Request.Path));
+            }
+
+            return (true, request, null);
+        }
+        catch (JsonException)
+        {
+            return (false, default, BuildProblemResult(
+                StatusCodes.Status400BadRequest,
+                "Validation failed.",
+                "The request payload is invalid.",
+                validationErrorCode,
+                httpContext.Request.Path));
+        }
+        catch (NotSupportedException)
+        {
+            return (false, default, BuildProblemResult(
+                StatusCodes.Status400BadRequest,
+                "Validation failed.",
+                "The request payload is invalid.",
+                validationErrorCode,
+                httpContext.Request.Path));
+        }
+        catch (BadHttpRequestException)
+        {
+            return (false, default, BuildProblemResult(
+                StatusCodes.Status400BadRequest,
+                "Validation failed.",
+                "The request payload is invalid.",
+                validationErrorCode,
+                httpContext.Request.Path));
+        }
+    }
+
+    public static IResult BuildProblemResult(int statusCode, string title, string detail, string code, string instance)
+    {
+        var problem = new ProblemDetails
+        {
+            Status = statusCode,
+            Title = title,
+            Detail = detail,
+            Instance = instance
+        };
+        problem.Extensions["code"] = code;
+        return TypedResults.Problem(problem);
+    }
+
+    public static async Task WriteProblemAsync(
+        HttpContext httpContext,
+        int statusCode,
+        string title,
+        string detail,
+        string? code,
+        string fallbackCode)
+    {
+        await BuildProblemResult(
+            statusCode,
+            title,
+            detail,
+            code ?? fallbackCode,
+            httpContext.Request.Path).ExecuteAsync(httpContext);
+    }
+
+    public static bool IsJsonContentType(string contentType)
+    {
+        var mediaType = contentType.Split(';')[0].Trim();
+        return mediaType.Equals("application/json", StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/backend/src/MoneyTracker.Api/MoneyTracker.Api.csproj
+++ b/backend/src/MoneyTracker.Api/MoneyTracker.Api.csproj
@@ -13,6 +13,7 @@
     <ProjectReference Include="..\Modules\Notifications\MoneyTracker.Modules.Notifications.csproj" />
     <ProjectReference Include="..\Modules\Budgets\MoneyTracker.Modules.Budgets.csproj" />
     <ProjectReference Include="..\Modules\Transactions\MoneyTracker.Modules.Transactions.csproj" />
+    <ProjectReference Include="..\Modules\BankConnections\MoneyTracker.Modules.BankConnections.csproj" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.0" />
   </ItemGroup>
 

--- a/backend/src/MoneyTracker.Api/Program.cs
+++ b/backend/src/MoneyTracker.Api/Program.cs
@@ -7,6 +7,7 @@ using MoneyTracker.Modules.Budgets.Presentation;
 using MoneyTracker.Modules.Households.Presentation;
 using MoneyTracker.Modules.Notifications.Presentation;
 using MoneyTracker.Modules.Transactions.Presentation;
+using MoneyTracker.Modules.BankConnections.Presentation;
 using MoneyTracker.Api.Observability;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -21,6 +22,7 @@ builder.Services.AddBudgetsModule();
 builder.Services.AddTransactionsModule();
 builder.Services.AddBillRemindersModule();
 builder.Services.AddNotificationsModule();
+builder.Services.AddBankConnectionsModule();
 builder.Services.AddOpenApi();
 
 var app = builder.Build();
@@ -42,6 +44,7 @@ app.MapBudgetSnapshotEndpoints();
 app.MapTransactionEndpoints();
 app.MapBillReminderEndpoints();
 app.MapNotificationEndpoints();
+app.MapBankConnectionEndpoints();
 
 if (app.Environment.IsEnvironment("Testing"))
 {

--- a/backend/tests/MoneyTracker.Api.Tests/Component/BankConnectionEndpointTests.cs
+++ b/backend/tests/MoneyTracker.Api.Tests/Component/BankConnectionEndpointTests.cs
@@ -1,0 +1,180 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text;
+using System.Text.Json.Nodes;
+
+namespace MoneyTracker.Api.Tests.Component;
+
+public sealed class BankConnectionEndpointTests : IClassFixture<MoneyTrackerApiFactory>
+{
+    private readonly MoneyTrackerApiFactory _factory;
+
+    public BankConnectionEndpointTests(MoneyTrackerApiFactory factory)
+    {
+        _factory = factory;
+    }
+
+    [Fact]
+    [Trait("Category", "Component")]
+    public async Task PostLinkSession_WithValidAuth_Returns200WithConsentUrl()
+    {
+        // P3-1-COMP-01: POST /bank/link-session with valid auth returns 200 with consent URL
+        using var client = _factory.CreateClient();
+        var accessToken = await AuthTestHelpers.GetAccessTokenAsync(client, $"{Guid.NewGuid():N}@example.com");
+        AuthTestHelpers.SetBearer(client, accessToken);
+
+        // Create a household first
+        using var householdResponse = await client.PostAsJsonAsync(
+            "/households",
+            new { name = $"Household-{Guid.NewGuid():N}" });
+        Assert.Equal(HttpStatusCode.Created, householdResponse.StatusCode);
+        var householdPayload = JsonNode.Parse(await householdResponse.Content.ReadAsStringAsync())?.AsObject();
+        Assert.NotNull(householdPayload);
+        var householdId = Guid.Parse(householdPayload["id"]!.GetValue<string>());
+
+        // Create link session
+        using var linkResponse = await client.PostAsJsonAsync(
+            "/bank/link-session",
+            new { householdId });
+        Assert.Equal(HttpStatusCode.OK, linkResponse.StatusCode);
+
+        var linkPayload = JsonNode.Parse(await linkResponse.Content.ReadAsStringAsync())?.AsObject();
+        Assert.NotNull(linkPayload);
+        Assert.False(string.IsNullOrWhiteSpace(linkPayload["consentUrl"]?.GetValue<string>()));
+        Assert.NotNull(linkPayload["connectionId"]?.GetValue<string>());
+    }
+
+    [Fact]
+    [Trait("Category", "Component")]
+    public async Task PostCallback_WithValidConnection_Returns200WithActiveConnection()
+    {
+        // P3-1-COMP-02: POST /bank/callback with valid connection returns 200 with Active connection
+        using var client = _factory.CreateClient();
+        var accessToken = await AuthTestHelpers.GetAccessTokenAsync(client, $"{Guid.NewGuid():N}@example.com");
+        AuthTestHelpers.SetBearer(client, accessToken);
+
+        // Create a household
+        using var householdResponse = await client.PostAsJsonAsync(
+            "/households",
+            new { name = $"Household-{Guid.NewGuid():N}" });
+        Assert.Equal(HttpStatusCode.Created, householdResponse.StatusCode);
+        var householdPayload = JsonNode.Parse(await householdResponse.Content.ReadAsStringAsync())?.AsObject();
+        Assert.NotNull(householdPayload);
+        var householdId = Guid.Parse(householdPayload["id"]!.GetValue<string>());
+
+        // Create link session
+        using var linkResponse = await client.PostAsJsonAsync(
+            "/bank/link-session",
+            new { householdId });
+        Assert.Equal(HttpStatusCode.OK, linkResponse.StatusCode);
+
+        // The in-memory stub adapter uses predictable session IDs, so we need to
+        // find the consent session ID from the connection that was created.
+        // Since we're using a real service with in-memory adapter, let's process the callback.
+        // The stub adapter returns connections for any consent session ID.
+        var linkPayload = JsonNode.Parse(await linkResponse.Content.ReadAsStringAsync())?.AsObject();
+        Assert.NotNull(linkPayload);
+
+        // We need to retrieve the consent session ID. With the stub adapter,
+        // we can retrieve it by getting connections and finding the pending one.
+        using var connectionsResponse = await client.GetAsync($"/bank/connections?householdId={householdId}");
+        Assert.Equal(HttpStatusCode.OK, connectionsResponse.StatusCode);
+        var connectionsPayload = JsonNode.Parse(await connectionsResponse.Content.ReadAsStringAsync())?.AsObject();
+        Assert.NotNull(connectionsPayload);
+
+        // The connection should be Pending
+        var connections = connectionsPayload["connections"]!.AsArray();
+        Assert.Single(connections);
+        Assert.Equal("Pending", connections[0]!["status"]?.GetValue<string>());
+    }
+
+    [Fact]
+    [Trait("Category", "Component")]
+    public async Task PostCallback_WithInvalidSession_Returns400WithTypedError()
+    {
+        // P3-1-COMP-03: POST /bank/callback with invalid session returns 400 with typed error
+        using var client = _factory.CreateClient();
+
+        using var callbackResponse = await client.PostAsJsonAsync(
+            "/bank/callback",
+            new { consentSessionId = "nonexistent-session-id" });
+
+        Assert.Equal(HttpStatusCode.NotFound, callbackResponse.StatusCode);
+        Assert.Equal("application/problem+json", callbackResponse.Content.Headers.ContentType?.MediaType);
+
+        var payload = JsonNode.Parse(await callbackResponse.Content.ReadAsStringAsync())?.AsObject();
+        Assert.NotNull(payload);
+        Assert.Equal("bank_connection_not_found", payload["code"]?.GetValue<string>());
+    }
+
+    [Fact]
+    [Trait("Category", "Component")]
+    public async Task GetConnections_WithValidHousehold_ReturnsConnectionList()
+    {
+        // P3-1-COMP-04: GET /bank/connections with valid household returns connection list
+        using var client = _factory.CreateClient();
+        var accessToken = await AuthTestHelpers.GetAccessTokenAsync(client, $"{Guid.NewGuid():N}@example.com");
+        AuthTestHelpers.SetBearer(client, accessToken);
+
+        // Create a household
+        using var householdResponse = await client.PostAsJsonAsync(
+            "/households",
+            new { name = $"Household-{Guid.NewGuid():N}" });
+        Assert.Equal(HttpStatusCode.Created, householdResponse.StatusCode);
+        var householdPayload = JsonNode.Parse(await householdResponse.Content.ReadAsStringAsync())?.AsObject();
+        Assert.NotNull(householdPayload);
+        var householdId = Guid.Parse(householdPayload["id"]!.GetValue<string>());
+
+        // Get connections (should be empty initially)
+        using var connectionsResponse = await client.GetAsync($"/bank/connections?householdId={householdId}");
+        Assert.Equal(HttpStatusCode.OK, connectionsResponse.StatusCode);
+
+        var payload = JsonNode.Parse(await connectionsResponse.Content.ReadAsStringAsync())?.AsObject();
+        Assert.NotNull(payload);
+        var connections = payload["connections"]!.AsArray();
+        Assert.NotNull(connections);
+        Assert.Empty(connections);
+    }
+
+    [Fact]
+    [Trait("Category", "Component")]
+    public async Task PostLinkSession_WithoutAuth_Returns401()
+    {
+        using var client = _factory.CreateClient();
+
+        using var response = await client.PostAsJsonAsync(
+            "/bank/link-session",
+            new { householdId = Guid.NewGuid() });
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    [Trait("Category", "Component")]
+    public async Task GetConnections_WithoutHouseholdId_Returns400()
+    {
+        using var client = _factory.CreateClient();
+        var accessToken = await AuthTestHelpers.GetAccessTokenAsync(client, $"{Guid.NewGuid():N}@example.com");
+        AuthTestHelpers.SetBearer(client, accessToken);
+
+        using var response = await client.GetAsync("/bank/connections");
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        var payload = JsonNode.Parse(await response.Content.ReadAsStringAsync())?.AsObject();
+        Assert.NotNull(payload);
+        Assert.Equal("validation_error", payload["code"]?.GetValue<string>());
+    }
+
+    [Fact]
+    [Trait("Category", "Component")]
+    public async Task PostCallback_WithEmptyBody_Returns400()
+    {
+        using var client = _factory.CreateClient();
+
+        using var emptyBodyContent = new StringContent(string.Empty, Encoding.UTF8, "application/json");
+        using var response = await client.PostAsync("/bank/callback", emptyBodyContent);
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        Assert.Equal("application/problem+json", response.Content.Headers.ContentType?.MediaType);
+    }
+}

--- a/backend/tests/MoneyTracker.Api.Tests/Component/BankConnectionEndpointTests.cs
+++ b/backend/tests/MoneyTracker.Api.Tests/Component/BankConnectionEndpointTests.cs
@@ -68,32 +68,34 @@ public sealed class BankConnectionEndpointTests : IClassFixture<MoneyTrackerApiF
             new { householdId });
         Assert.Equal(HttpStatusCode.OK, linkResponse.StatusCode);
 
-        // The in-memory stub adapter uses predictable session IDs, so we need to
-        // find the consent session ID from the connection that was created.
-        // Since we're using a real service with in-memory adapter, let's process the callback.
-        // The stub adapter returns connections for any consent session ID.
         var linkPayload = JsonNode.Parse(await linkResponse.Content.ReadAsStringAsync())?.AsObject();
         Assert.NotNull(linkPayload);
 
-        // We need to retrieve the consent session ID. With the stub adapter,
-        // we can retrieve it by getting connections and finding the pending one.
-        using var connectionsResponse = await client.GetAsync($"/bank/connections?householdId={householdId}");
-        Assert.Equal(HttpStatusCode.OK, connectionsResponse.StatusCode);
-        var connectionsPayload = JsonNode.Parse(await connectionsResponse.Content.ReadAsStringAsync())?.AsObject();
-        Assert.NotNull(connectionsPayload);
+        // Extract the consent session ID from the consent URL returned by the in-memory adapter.
+        // The stub adapter returns URLs in the form https://consent.example.com/{sessionId}.
+        var consentUrl = linkPayload["consentUrl"]!.GetValue<string>();
+        var consentSessionId = consentUrl.Split('/').Last();
 
-        // The connection should be Pending
-        var connections = connectionsPayload["connections"]!.AsArray();
-        Assert.Single(connections);
-        Assert.Equal("Pending", connections[0]!["status"]?.GetValue<string>());
+        // Call POST /bank/callback with the consent session ID
+        using var callbackResponse = await client.PostAsJsonAsync(
+            "/bank/callback",
+            new { consentSessionId });
+        Assert.Equal(HttpStatusCode.OK, callbackResponse.StatusCode);
+
+        var callbackPayload = JsonNode.Parse(await callbackResponse.Content.ReadAsStringAsync())?.AsObject();
+        Assert.NotNull(callbackPayload);
+        Assert.Equal("Active", callbackPayload["status"]?.GetValue<string>());
+        Assert.Equal(householdId.ToString(), callbackPayload["householdId"]?.GetValue<string>());
     }
 
     [Fact]
     [Trait("Category", "Component")]
-    public async Task PostCallback_WithInvalidSession_Returns400WithTypedError()
+    public async Task PostCallback_WithInvalidSession_Returns404WithTypedError()
     {
-        // P3-1-COMP-03: POST /bank/callback with invalid session returns 400 with typed error
+        // P3-1-COMP-03: POST /bank/callback with invalid session returns 404 with typed error
         using var client = _factory.CreateClient();
+        var accessToken = await AuthTestHelpers.GetAccessTokenAsync(client, $"{Guid.NewGuid():N}@example.com");
+        AuthTestHelpers.SetBearer(client, accessToken);
 
         using var callbackResponse = await client.PostAsJsonAsync(
             "/bank/callback",
@@ -167,9 +169,24 @@ public sealed class BankConnectionEndpointTests : IClassFixture<MoneyTrackerApiF
 
     [Fact]
     [Trait("Category", "Component")]
+    public async Task PostCallback_WithoutAuth_Returns401()
+    {
+        using var client = _factory.CreateClient();
+
+        using var callbackResponse = await client.PostAsJsonAsync(
+            "/bank/callback",
+            new { consentSessionId = "some-session-id" });
+
+        Assert.Equal(HttpStatusCode.Unauthorized, callbackResponse.StatusCode);
+    }
+
+    [Fact]
+    [Trait("Category", "Component")]
     public async Task PostCallback_WithEmptyBody_Returns400()
     {
         using var client = _factory.CreateClient();
+        var accessToken = await AuthTestHelpers.GetAccessTokenAsync(client, $"{Guid.NewGuid():N}@example.com");
+        AuthTestHelpers.SetBearer(client, accessToken);
 
         using var emptyBodyContent = new StringContent(string.Empty, Encoding.UTF8, "application/json");
         using var response = await client.PostAsync("/bank/callback", emptyBodyContent);

--- a/backend/tests/MoneyTracker.Api.Tests/Integration/BankConnectionFlowTests.cs
+++ b/backend/tests/MoneyTracker.Api.Tests/Integration/BankConnectionFlowTests.cs
@@ -1,0 +1,58 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json.Nodes;
+using MoneyTracker.Api.Tests.Component;
+
+namespace MoneyTracker.Api.Tests.Integration;
+
+public sealed class BankConnectionFlowTests : IClassFixture<MoneyTrackerApiFactory>
+{
+    private readonly MoneyTrackerApiFactory _factory;
+
+    public BankConnectionFlowTests(MoneyTrackerApiFactory factory)
+    {
+        _factory = factory;
+    }
+
+    [Fact]
+    [Trait("Category", "Integration")]
+    public async Task FullFlow_AuthThenLinkSessionThenListConnections_PendingConnectionAppears()
+    {
+        // P3-1-E2E-01: Auth -> link-session -> callback -> list connections
+        using var client = _factory.CreateClient();
+
+        // Step 1: Authenticate
+        var accessToken = await AuthTestHelpers.GetAccessTokenAsync(client, $"{Guid.NewGuid():N}@example.com");
+        AuthTestHelpers.SetBearer(client, accessToken);
+
+        // Step 2: Create a household
+        using var householdResponse = await client.PostAsJsonAsync(
+            "/households",
+            new { name = $"BankTest-{Guid.NewGuid():N}" });
+        Assert.Equal(HttpStatusCode.Created, householdResponse.StatusCode);
+        var householdPayload = JsonNode.Parse(await householdResponse.Content.ReadAsStringAsync())?.AsObject();
+        Assert.NotNull(householdPayload);
+        var householdId = Guid.Parse(householdPayload["id"]!.GetValue<string>());
+
+        // Step 3: Create link session
+        using var linkResponse = await client.PostAsJsonAsync(
+            "/bank/link-session",
+            new { householdId });
+        Assert.Equal(HttpStatusCode.OK, linkResponse.StatusCode);
+        var linkPayload = JsonNode.Parse(await linkResponse.Content.ReadAsStringAsync())?.AsObject();
+        Assert.NotNull(linkPayload);
+        Assert.False(string.IsNullOrWhiteSpace(linkPayload["consentUrl"]?.GetValue<string>()));
+
+        // Step 4: List connections — the pending connection should appear
+        using var listResponse = await client.GetAsync($"/bank/connections?householdId={householdId}");
+        Assert.Equal(HttpStatusCode.OK, listResponse.StatusCode);
+        var listPayload = JsonNode.Parse(await listResponse.Content.ReadAsStringAsync())?.AsObject();
+        Assert.NotNull(listPayload);
+        var connections = listPayload["connections"]!.AsArray();
+        Assert.Single(connections);
+
+        var connection = connections[0]!.AsObject();
+        Assert.Equal("Pending", connection["status"]?.GetValue<string>());
+        Assert.Equal(householdId.ToString(), connection["householdId"]?.GetValue<string>());
+    }
+}

--- a/backend/tests/MoneyTracker.Modules.BankConnections.Tests/Application/CreateLinkSessionHandlerTests.cs
+++ b/backend/tests/MoneyTracker.Modules.BankConnections.Tests/Application/CreateLinkSessionHandlerTests.cs
@@ -1,0 +1,183 @@
+using MoneyTracker.Modules.BankConnections.Application.CreateLinkSession;
+using MoneyTracker.Modules.BankConnections.Domain;
+using MoneyTracker.Modules.BankConnections.Infrastructure;
+using MoneyTracker.Modules.SharedKernel.Households;
+
+namespace MoneyTracker.Modules.BankConnections.Tests.Application;
+
+public sealed class CreateLinkSessionHandlerTests
+{
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task HandleAsync_ReturnsHouseholdNotFound_WhenHouseholdDoesNotExist()
+    {
+        // P3-1-UNIT-03: CreateLinkSession with missing household returns validation error
+        var handler = new CreateLinkSessionHandler(
+            new InMemoryBankConnectionRepository(),
+            new StubBankProviderAdapter(),
+            new NotFoundHouseholdAccessService(),
+            new FakeTimeProvider(DateTimeOffset.Parse("2026-03-01T00:00:00Z")));
+
+        var result = await handler.HandleAsync(
+            new CreateLinkSessionCommand(Guid.NewGuid(), Guid.NewGuid()),
+            CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(BankConnectionErrors.ConnectionHouseholdNotFound, result.ErrorCode);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task HandleAsync_ReturnsAccessDenied_WhenUserIsNotMember()
+    {
+        var handler = new CreateLinkSessionHandler(
+            new InMemoryBankConnectionRepository(),
+            new StubBankProviderAdapter(),
+            new DeniedHouseholdAccessService(),
+            new FakeTimeProvider(DateTimeOffset.Parse("2026-03-01T00:00:00Z")));
+
+        var result = await handler.HandleAsync(
+            new CreateLinkSessionCommand(Guid.NewGuid(), Guid.NewGuid()),
+            CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(BankConnectionErrors.ConnectionAccessDenied, result.ErrorCode);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task HandleAsync_ReturnsSuccess_WhenAllValid()
+    {
+        var handler = new CreateLinkSessionHandler(
+            new InMemoryBankConnectionRepository(),
+            new StubBankProviderAdapter(),
+            new AllowedHouseholdAccessService(),
+            new FakeTimeProvider(DateTimeOffset.Parse("2026-03-01T00:00:00Z")));
+
+        var result = await handler.HandleAsync(
+            new CreateLinkSessionCommand(Guid.NewGuid(), Guid.NewGuid()),
+            CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        Assert.NotNull(result.ConsentUrl);
+        Assert.Equal("https://consent.basiq.io/test-session", result.ConsentUrl);
+        Assert.NotNull(result.ConnectionId);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task HandleAsync_ReturnsProviderError_WhenAdapterFails()
+    {
+        var handler = new CreateLinkSessionHandler(
+            new InMemoryBankConnectionRepository(),
+            new FailingBankProviderAdapter(),
+            new AllowedHouseholdAccessService(),
+            new FakeTimeProvider(DateTimeOffset.Parse("2026-03-01T00:00:00Z")));
+
+        var result = await handler.HandleAsync(
+            new CreateLinkSessionCommand(Guid.NewGuid(), Guid.NewGuid()),
+            CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(BankConnectionErrors.ConnectionProviderError, result.ErrorCode);
+    }
+}
+
+internal sealed class AllowedHouseholdAccessService : IHouseholdAccessService
+{
+    public Task<HouseholdAccessResult> CheckMemberAsync(
+        Guid householdId,
+        Guid userId,
+        CancellationToken cancellationToken)
+    {
+        return Task.FromResult(HouseholdAccessResult.Allowed());
+    }
+
+    public Task<IReadOnlyCollection<Guid>> GetMemberIdsAsync(Guid householdId, CancellationToken cancellationToken)
+    {
+        return Task.FromResult<IReadOnlyCollection<Guid>>(Array.Empty<Guid>());
+    }
+}
+
+internal sealed class NotFoundHouseholdAccessService : IHouseholdAccessService
+{
+    public Task<HouseholdAccessResult> CheckMemberAsync(
+        Guid householdId,
+        Guid userId,
+        CancellationToken cancellationToken)
+    {
+        return Task.FromResult(HouseholdAccessResult.NotFound());
+    }
+
+    public Task<IReadOnlyCollection<Guid>> GetMemberIdsAsync(Guid householdId, CancellationToken cancellationToken)
+    {
+        return Task.FromResult<IReadOnlyCollection<Guid>>(Array.Empty<Guid>());
+    }
+}
+
+internal sealed class DeniedHouseholdAccessService : IHouseholdAccessService
+{
+    public Task<HouseholdAccessResult> CheckMemberAsync(
+        Guid householdId,
+        Guid userId,
+        CancellationToken cancellationToken)
+    {
+        return Task.FromResult(HouseholdAccessResult.Denied());
+    }
+
+    public Task<IReadOnlyCollection<Guid>> GetMemberIdsAsync(Guid householdId, CancellationToken cancellationToken)
+    {
+        return Task.FromResult<IReadOnlyCollection<Guid>>(Array.Empty<Guid>());
+    }
+}
+
+internal sealed class FakeTimeProvider(DateTimeOffset utcNow) : TimeProvider
+{
+    public override DateTimeOffset GetUtcNow() => utcNow;
+}
+
+internal sealed class StubBankProviderAdapter : IBankProviderAdapter
+{
+    public Task<CreateUserResult> CreateUserAsync(Guid householdId, Guid userId, CancellationToken cancellationToken)
+    {
+        return Task.FromResult(new CreateUserResult(true, "ext-user-123", null, null));
+    }
+
+    public Task<CreateConsentSessionResult> CreateConsentSessionAsync(string externalUserId, CancellationToken cancellationToken)
+    {
+        return Task.FromResult(new CreateConsentSessionResult(true, "session-abc", "https://consent.basiq.io/test-session", null, null));
+    }
+
+    public Task<GetConnectionResult> GetConnectionAsync(string externalUserId, string consentSessionId, CancellationToken cancellationToken)
+    {
+        return Task.FromResult(new GetConnectionResult(true, "conn-123", "Test Bank", "active", null, null));
+    }
+
+    public Task<GetAccountsResult> GetAccountsAsync(string externalConnectionId, CancellationToken cancellationToken)
+    {
+        return Task.FromResult(new GetAccountsResult(true, Array.Empty<BankAccountInfo>(), null, null));
+    }
+}
+
+internal sealed class FailingBankProviderAdapter : IBankProviderAdapter
+{
+    public Task<CreateUserResult> CreateUserAsync(Guid householdId, Guid userId, CancellationToken cancellationToken)
+    {
+        return Task.FromResult(new CreateUserResult(false, null, BankConnectionErrors.ConnectionProviderError, "Provider unavailable"));
+    }
+
+    public Task<CreateConsentSessionResult> CreateConsentSessionAsync(string externalUserId, CancellationToken cancellationToken)
+    {
+        return Task.FromResult(new CreateConsentSessionResult(false, null, null, BankConnectionErrors.ConnectionProviderError, "Provider unavailable"));
+    }
+
+    public Task<GetConnectionResult> GetConnectionAsync(string externalUserId, string consentSessionId, CancellationToken cancellationToken)
+    {
+        return Task.FromResult(new GetConnectionResult(false, null, null, null, BankConnectionErrors.ConnectionSessionExpired, "Session expired"));
+    }
+
+    public Task<GetAccountsResult> GetAccountsAsync(string externalConnectionId, CancellationToken cancellationToken)
+    {
+        return Task.FromResult(new GetAccountsResult(false, null, BankConnectionErrors.ConnectionProviderError, "Provider unavailable"));
+    }
+}

--- a/backend/tests/MoneyTracker.Modules.BankConnections.Tests/Domain/BankConnectionTests.cs
+++ b/backend/tests/MoneyTracker.Modules.BankConnections.Tests/Domain/BankConnectionTests.cs
@@ -1,0 +1,162 @@
+using MoneyTracker.Modules.BankConnections.Domain;
+
+namespace MoneyTracker.Modules.BankConnections.Tests.Domain;
+
+public sealed class BankConnectionTests
+{
+    private static readonly DateTimeOffset NowUtc = DateTimeOffset.Parse("2026-03-01T00:00:00Z");
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void Activate_FromPending_Succeeds()
+    {
+        // P3-1-UNIT-01: Valid state transition Pending -> Active succeeds
+        var connection = BankConnection.CreatePending(
+            Guid.NewGuid(),
+            Guid.NewGuid(),
+            "ext-user-1",
+            "session-1",
+            NowUtc);
+
+        connection.Activate("conn-123", "Test Bank", NowUtc.AddMinutes(5));
+
+        Assert.Equal(BankConnectionStatus.Active, connection.Status);
+        Assert.Equal("conn-123", connection.ExternalConnectionId);
+        Assert.Equal("Test Bank", connection.InstitutionName);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void Activate_FromFailed_ThrowsDomainException()
+    {
+        // P3-1-UNIT-02: Invalid state transition Failed -> Active throws domain exception
+        var connection = BankConnection.CreatePending(
+            Guid.NewGuid(),
+            Guid.NewGuid(),
+            "ext-user-1",
+            "session-1",
+            NowUtc);
+
+        connection.MarkFailed("some_error", "Some error", NowUtc.AddMinutes(1));
+
+        var exception = Assert.Throws<BankConnectionDomainException>(
+            () => connection.Activate("conn-123", "Test Bank", NowUtc.AddMinutes(5)));
+
+        Assert.Equal(BankConnectionErrors.ConnectionInvalidStateTransition, exception.Code);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void MarkFailed_FromPending_Succeeds()
+    {
+        var connection = BankConnection.CreatePending(
+            Guid.NewGuid(),
+            Guid.NewGuid(),
+            "ext-user-1",
+            "session-1",
+            NowUtc);
+
+        connection.MarkFailed("provider_error", "Something went wrong", NowUtc.AddMinutes(1));
+
+        Assert.Equal(BankConnectionStatus.Failed, connection.Status);
+        Assert.Equal("provider_error", connection.ErrorCode);
+        Assert.Equal("Something went wrong", connection.ErrorMessage);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void Revoke_FromActive_Succeeds()
+    {
+        var connection = BankConnection.CreatePending(
+            Guid.NewGuid(),
+            Guid.NewGuid(),
+            "ext-user-1",
+            "session-1",
+            NowUtc);
+        connection.Activate("conn-123", "Test Bank", NowUtc.AddMinutes(1));
+
+        connection.Revoke(NowUtc.AddMinutes(5));
+
+        Assert.Equal(BankConnectionStatus.Revoked, connection.Status);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void Revoke_FromPending_ThrowsDomainException()
+    {
+        var connection = BankConnection.CreatePending(
+            Guid.NewGuid(),
+            Guid.NewGuid(),
+            "ext-user-1",
+            "session-1",
+            NowUtc);
+
+        var exception = Assert.Throws<BankConnectionDomainException>(
+            () => connection.Revoke(NowUtc.AddMinutes(5)));
+
+        Assert.Equal(BankConnectionErrors.ConnectionInvalidStateTransition, exception.Code);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void Activate_FromActive_ThrowsDomainException()
+    {
+        var connection = BankConnection.CreatePending(
+            Guid.NewGuid(),
+            Guid.NewGuid(),
+            "ext-user-1",
+            "session-1",
+            NowUtc);
+        connection.Activate("conn-123", "Test Bank", NowUtc.AddMinutes(1));
+
+        var exception = Assert.Throws<BankConnectionDomainException>(
+            () => connection.Activate("conn-456", "Other Bank", NowUtc.AddMinutes(5)));
+
+        Assert.Equal(BankConnectionErrors.ConnectionInvalidStateTransition, exception.Code);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void CreatePending_WithEmptyExternalUserId_ThrowsDomainException()
+    {
+        var exception = Assert.Throws<BankConnectionDomainException>(
+            () => BankConnection.CreatePending(
+                Guid.NewGuid(),
+                Guid.NewGuid(),
+                "",
+                "session-1",
+                NowUtc));
+
+        Assert.Equal(BankConnectionErrors.ValidationError, exception.Code);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void CreatePending_WithEmptyConsentSessionId_ThrowsDomainException()
+    {
+        var exception = Assert.Throws<BankConnectionDomainException>(
+            () => BankConnection.CreatePending(
+                Guid.NewGuid(),
+                Guid.NewGuid(),
+                "ext-user-1",
+                "",
+                NowUtc));
+
+        Assert.Equal(BankConnectionErrors.ValidationError, exception.Code);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void CreatePending_SetsStatusToPending()
+    {
+        var connection = BankConnection.CreatePending(
+            Guid.NewGuid(),
+            Guid.NewGuid(),
+            "ext-user-1",
+            "session-1",
+            NowUtc);
+
+        Assert.Equal(BankConnectionStatus.Pending, connection.Status);
+        Assert.Equal(NowUtc, connection.CreatedAtUtc);
+    }
+}

--- a/backend/tests/MoneyTracker.Modules.BankConnections.Tests/Integration/BasiqBankProviderAdapterTests.cs
+++ b/backend/tests/MoneyTracker.Modules.BankConnections.Tests/Integration/BasiqBankProviderAdapterTests.cs
@@ -1,0 +1,247 @@
+using System.Net;
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using MoneyTracker.Modules.BankConnections.Application.CreateLinkSession;
+using MoneyTracker.Modules.BankConnections.Application.ProcessCallback;
+using MoneyTracker.Modules.BankConnections.Domain;
+using MoneyTracker.Modules.BankConnections.Infrastructure;
+
+namespace MoneyTracker.Modules.BankConnections.Tests.Integration;
+
+public sealed class BasiqBankProviderAdapterTests
+{
+    [Fact]
+    [Trait("Category", "Integration")]
+    public async Task CreateConsentSession_AgainstStub_ReturnsConsentUrl()
+    {
+        // P3-1-INT-01: BasiqBankProviderAdapter creates consent session against stub
+        var handler = new StubHttpHandler(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(
+                JsonSerializer.Serialize(new { id = "session-1", url = "https://consent.basiq.io/session-1" }),
+                System.Text.Encoding.UTF8,
+                "application/json")
+        });
+        var httpClient = new HttpClient(handler) { BaseAddress = new Uri("https://au-api.basiq.io") };
+        var adapter = new BasiqBankProviderAdapter(
+            httpClient,
+            NullLogger<BasiqBankProviderAdapter>.Instance,
+            TimeProvider.System);
+
+        var result = await adapter.CreateConsentSessionAsync("ext-user-1", CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal("session-1", result.SessionId);
+        Assert.Equal("https://consent.basiq.io/session-1", result.ConsentUrl);
+
+        // Verify correct parameters were sent
+        Assert.NotNull(handler.LastRequest);
+        Assert.Equal(HttpMethod.Post, handler.LastRequest.Method);
+        Assert.Contains("/users/ext-user-1/auth_link", handler.LastRequest.RequestUri!.ToString());
+        Assert.True(handler.LastRequest.Headers.Contains("X-Correlation-Id"));
+    }
+
+    [Fact]
+    [Trait("Category", "Integration")]
+    public async Task CreateConsentSession_Timeout_RetriesWithBackoff()
+    {
+        // P3-1-INT-02: Basiq API timeout during consent creation
+        var handler = new TimeoutThenSuccessHandler(
+            timeoutsBeforeSuccess: 2,
+            successResponse: new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(
+                    JsonSerializer.Serialize(new { id = "session-2", url = "https://consent.basiq.io/session-2" }),
+                    System.Text.Encoding.UTF8,
+                    "application/json")
+            });
+        var httpClient = new HttpClient(handler) { BaseAddress = new Uri("https://au-api.basiq.io") };
+        var adapter = new BasiqBankProviderAdapter(
+            httpClient,
+            NullLogger<BasiqBankProviderAdapter>.Instance,
+            TimeProvider.System);
+
+        var result = await adapter.CreateConsentSessionAsync("ext-user-1", CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal("session-2", result.SessionId);
+        Assert.Equal(3, handler.AttemptCount); // 2 timeouts + 1 success
+    }
+
+    [Fact]
+    [Trait("Category", "Integration")]
+    public async Task CreateConsentSession_Repeated5xx_RetriesWithExponentialBackoff()
+    {
+        // P3-1-NF-01: Basiq adapter under repeated 5xx
+        var handler = new RepeatedErrorHandler(HttpStatusCode.ServiceUnavailable);
+        var httpClient = new HttpClient(handler) { BaseAddress = new Uri("https://au-api.basiq.io") };
+        var adapter = new BasiqBankProviderAdapter(
+            httpClient,
+            NullLogger<BasiqBankProviderAdapter>.Instance,
+            TimeProvider.System);
+
+        var result = await adapter.CreateConsentSessionAsync("ext-user-1", CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(BankConnectionErrors.ConnectionProviderError, result.ErrorCode);
+        // Max retries is 3, so total attempts = 4 (initial + 3 retries)
+        Assert.Equal(4, handler.AttemptCount);
+    }
+
+    [Fact]
+    [Trait("Category", "Integration")]
+    public async Task FullLinkSessionThenCallback_ConnectionPersistedAsActive()
+    {
+        // P3-1-INT-03: Full link-session then callback flow
+        var stubAdapter = new StubBankProviderAdapterForFlow();
+        var repository = new InMemoryBankConnectionRepository();
+        var nowUtc = DateTimeOffset.Parse("2026-03-01T00:00:00Z");
+        var timeProvider = new FakeTimeProvider(nowUtc);
+
+        // Step 1: Create link session
+        var createHandler = new CreateLinkSessionHandler(
+            repository,
+            stubAdapter,
+            new AllowedHouseholdAccessService(),
+            timeProvider);
+
+        var householdId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        var createResult = await createHandler.HandleAsync(
+            new CreateLinkSessionCommand(householdId, userId),
+            CancellationToken.None);
+
+        Assert.True(createResult.IsSuccess);
+        Assert.NotNull(createResult.ConsentUrl);
+
+        // Step 2: Process callback
+        var callbackHandler = new ProcessCallbackHandler(
+            repository,
+            stubAdapter,
+            timeProvider);
+
+        var callbackResult = await callbackHandler.HandleAsync(
+            new ProcessCallbackCommand("session-flow-1"),
+            CancellationToken.None);
+
+        Assert.True(callbackResult.IsSuccess);
+        Assert.NotNull(callbackResult.Connection);
+        Assert.Equal(BankConnectionStatus.Active, callbackResult.Connection!.Status);
+        Assert.Equal("conn-flow-1", callbackResult.Connection.ExternalConnectionId);
+        Assert.Equal("Flow Bank", callbackResult.Connection.InstitutionName);
+    }
+}
+
+internal sealed class StubHttpHandler : HttpMessageHandler
+{
+    private readonly HttpResponseMessage _response;
+    public HttpRequestMessage? LastRequest { get; private set; }
+
+    public StubHttpHandler(HttpResponseMessage response)
+    {
+        _response = response;
+    }
+
+    protected override Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request,
+        CancellationToken cancellationToken)
+    {
+        LastRequest = request;
+        return Task.FromResult(_response);
+    }
+}
+
+internal sealed class TimeoutThenSuccessHandler : HttpMessageHandler
+{
+    private readonly int _timeoutsBeforeSuccess;
+    private readonly HttpResponseMessage _successResponse;
+    public int AttemptCount { get; private set; }
+
+    public TimeoutThenSuccessHandler(int timeoutsBeforeSuccess, HttpResponseMessage successResponse)
+    {
+        _timeoutsBeforeSuccess = timeoutsBeforeSuccess;
+        _successResponse = successResponse;
+    }
+
+    protected override Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request,
+        CancellationToken cancellationToken)
+    {
+        AttemptCount++;
+        if (AttemptCount <= _timeoutsBeforeSuccess)
+        {
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.ServiceUnavailable));
+        }
+
+        return Task.FromResult(_successResponse);
+    }
+}
+
+internal sealed class RepeatedErrorHandler : HttpMessageHandler
+{
+    private readonly HttpStatusCode _statusCode;
+    public int AttemptCount { get; private set; }
+
+    public RepeatedErrorHandler(HttpStatusCode statusCode)
+    {
+        _statusCode = statusCode;
+    }
+
+    protected override Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request,
+        CancellationToken cancellationToken)
+    {
+        AttemptCount++;
+        return Task.FromResult(new HttpResponseMessage(_statusCode)
+        {
+            Content = new StringContent($"{{\"error\": \"service unavailable attempt {AttemptCount}\"}}")
+        });
+    }
+}
+
+internal sealed class FakeTimeProvider(DateTimeOffset utcNow) : TimeProvider
+{
+    public override DateTimeOffset GetUtcNow() => utcNow;
+}
+
+internal sealed class AllowedHouseholdAccessService : SharedKernel.Households.IHouseholdAccessService
+{
+    public Task<SharedKernel.Households.HouseholdAccessResult> CheckMemberAsync(
+        Guid householdId,
+        Guid userId,
+        CancellationToken cancellationToken)
+    {
+        return Task.FromResult(SharedKernel.Households.HouseholdAccessResult.Allowed());
+    }
+
+    public Task<IReadOnlyCollection<Guid>> GetMemberIdsAsync(Guid householdId, CancellationToken cancellationToken)
+    {
+        return Task.FromResult<IReadOnlyCollection<Guid>>(Array.Empty<Guid>());
+    }
+}
+
+internal sealed class StubBankProviderAdapterForFlow : IBankProviderAdapter
+{
+    public Task<CreateUserResult> CreateUserAsync(Guid householdId, Guid userId, CancellationToken cancellationToken)
+    {
+        return Task.FromResult(new CreateUserResult(true, "ext-user-flow-1", null, null));
+    }
+
+    public Task<CreateConsentSessionResult> CreateConsentSessionAsync(string externalUserId, CancellationToken cancellationToken)
+    {
+        return Task.FromResult(new CreateConsentSessionResult(
+            true, "session-flow-1", "https://consent.basiq.io/flow-1", null, null));
+    }
+
+    public Task<GetConnectionResult> GetConnectionAsync(string externalUserId, string consentSessionId, CancellationToken cancellationToken)
+    {
+        return Task.FromResult(new GetConnectionResult(
+            true, "conn-flow-1", "Flow Bank", "active", null, null));
+    }
+
+    public Task<GetAccountsResult> GetAccountsAsync(string externalConnectionId, CancellationToken cancellationToken)
+    {
+        return Task.FromResult(new GetAccountsResult(true, Array.Empty<BankAccountInfo>(), null, null));
+    }
+}

--- a/backend/tests/MoneyTracker.Modules.BankConnections.Tests/Integration/BasiqBankProviderAdapterTests.cs
+++ b/backend/tests/MoneyTracker.Modules.BankConnections.Tests/Integration/BasiqBankProviderAdapterTests.cs
@@ -26,8 +26,7 @@ public sealed class BasiqBankProviderAdapterTests
         var httpClient = new HttpClient(handler) { BaseAddress = new Uri("https://au-api.basiq.io") };
         var adapter = new BasiqBankProviderAdapter(
             httpClient,
-            NullLogger<BasiqBankProviderAdapter>.Instance,
-            TimeProvider.System);
+            NullLogger<BasiqBankProviderAdapter>.Instance);
 
         var result = await adapter.CreateConsentSessionAsync("ext-user-1", CancellationToken.None);
 
@@ -59,8 +58,7 @@ public sealed class BasiqBankProviderAdapterTests
         var httpClient = new HttpClient(handler) { BaseAddress = new Uri("https://au-api.basiq.io") };
         var adapter = new BasiqBankProviderAdapter(
             httpClient,
-            NullLogger<BasiqBankProviderAdapter>.Instance,
-            TimeProvider.System);
+            NullLogger<BasiqBankProviderAdapter>.Instance);
 
         var result = await adapter.CreateConsentSessionAsync("ext-user-1", CancellationToken.None);
 
@@ -78,8 +76,7 @@ public sealed class BasiqBankProviderAdapterTests
         var httpClient = new HttpClient(handler) { BaseAddress = new Uri("https://au-api.basiq.io") };
         var adapter = new BasiqBankProviderAdapter(
             httpClient,
-            NullLogger<BasiqBankProviderAdapter>.Instance,
-            TimeProvider.System);
+            NullLogger<BasiqBankProviderAdapter>.Instance);
 
         var result = await adapter.CreateConsentSessionAsync("ext-user-1", CancellationToken.None);
 

--- a/backend/tests/MoneyTracker.Modules.BankConnections.Tests/MoneyTracker.Modules.BankConnections.Tests.csproj
+++ b/backend/tests/MoneyTracker.Modules.BankConnections.Tests/MoneyTracker.Modules.BankConnections.Tests.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Modules\BankConnections\MoneyTracker.Modules.BankConnections.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Summary
- Implements full BankConnections vertical-slice module with domain state machine (Pending -> Active/Failed, Active -> Revoked), application handlers for link session creation, callback processing, and connection listing
- Adds Basiq HTTP adapter with timeout, exponential backoff retry, and correlation-ID logging, plus InMemory adapter for dev/test
- Registers three new endpoints: POST /bank/link-session, POST /bank/callback, GET /bank/connections with OpenAPI metadata and ProblemDetails error responses
- Includes 25 tests covering unit (domain state transitions, handler validation), integration (adapter retry/backoff), component (HTTP endpoint behavior), and E2E (full auth-to-connection flow)

## Test plan
- [x] All 17 BankConnections module unit/integration tests pass
- [x] All 8 new API component/E2E tests pass
- [x] All 59 existing API tests still pass (no regressions)
- [x] All other module test projects pass (BillReminders, Budgets, Households, Transactions)
- [ ] Manual verification of endpoint metadata in OpenAPI spec

Closes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added bank account linking functionality, enabling users to securely connect their financial institutions through a guided authentication workflow.
* Added ability to view and monitor linked bank accounts with status tracking (pending, active, failed, revoked).
* Integrated support for multiple banking institutions through the Basiq banking provider.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->