### PR TITLE
[P4-2] Add entitlement evaluation API and feature gating

### DIFF
--- a/backend/src/Modules/SharedKernel/Subscriptions/ISubscriptionEntitlementService.cs
+++ b/backend/src/Modules/SharedKernel/Subscriptions/ISubscriptionEntitlementService.cs
@@ -1,0 +1,14 @@
+namespace MoneyTracker.Modules.SharedKernel.Subscriptions;
+
+/// <summary>
+/// Anti-corruption interface for cross-module entitlement checks.
+/// Other modules depend on this interface to gate premium features
+/// without taking a direct dependency on the Subscriptions module.
+/// </summary>
+public interface ISubscriptionEntitlementService
+{
+    Task<bool> IsFeatureAllowedAsync(
+        Guid householdId,
+        string featureKey,
+        CancellationToken cancellationToken);
+}

--- a/backend/src/Modules/Subscriptions/Application/CheckFeatureAccess/CheckFeatureAccessHandler.cs
+++ b/backend/src/Modules/Subscriptions/Application/CheckFeatureAccess/CheckFeatureAccessHandler.cs
@@ -1,0 +1,26 @@
+using MoneyTracker.Modules.Subscriptions.Domain;
+
+namespace MoneyTracker.Modules.Subscriptions.Application.CheckFeatureAccess;
+
+public sealed class CheckFeatureAccessHandler(
+    ISubscriptionEntitlementService entitlementService)
+{
+    public async Task<CheckFeatureAccessResult> HandleAsync(
+        CheckFeatureAccessQuery query,
+        CancellationToken cancellationToken)
+    {
+        var entitlement = await entitlementService.GetEntitlementsAsync(
+            query.HouseholdId,
+            cancellationToken);
+
+        var entitlementSet = EntitlementSet.ForTier(entitlement.Tier);
+        var tierName = entitlement.Tier.ToString();
+
+        if (entitlementSet.HasFeature(query.Feature))
+        {
+            return CheckFeatureAccessResult.Allowed(tierName);
+        }
+
+        return CheckFeatureAccessResult.Denied(tierName);
+    }
+}

--- a/backend/src/Modules/Subscriptions/Application/CheckFeatureAccess/CheckFeatureAccessQuery.cs
+++ b/backend/src/Modules/Subscriptions/Application/CheckFeatureAccess/CheckFeatureAccessQuery.cs
@@ -1,0 +1,5 @@
+using MoneyTracker.Modules.Subscriptions.Domain;
+
+namespace MoneyTracker.Modules.Subscriptions.Application.CheckFeatureAccess;
+
+public sealed record CheckFeatureAccessQuery(Guid HouseholdId, FeatureKey Feature);

--- a/backend/src/Modules/Subscriptions/Application/CheckFeatureAccess/CheckFeatureAccessResult.cs
+++ b/backend/src/Modules/Subscriptions/Application/CheckFeatureAccess/CheckFeatureAccessResult.cs
@@ -1,0 +1,34 @@
+namespace MoneyTracker.Modules.Subscriptions.Application.CheckFeatureAccess;
+
+public sealed class CheckFeatureAccessResult
+{
+    private CheckFeatureAccessResult(
+        bool isAllowed,
+        string tier,
+        bool upgradeRequired)
+    {
+        IsAllowed = isAllowed;
+        Tier = tier;
+        UpgradeRequired = upgradeRequired;
+    }
+
+    public bool IsAllowed { get; }
+    public string Tier { get; }
+    public bool UpgradeRequired { get; }
+
+    public static CheckFeatureAccessResult Allowed(string tier)
+    {
+        return new CheckFeatureAccessResult(
+            isAllowed: true,
+            tier: tier,
+            upgradeRequired: false);
+    }
+
+    public static CheckFeatureAccessResult Denied(string tier)
+    {
+        return new CheckFeatureAccessResult(
+            isAllowed: false,
+            tier: tier,
+            upgradeRequired: true);
+    }
+}

--- a/backend/src/Modules/Subscriptions/Application/GetEntitlements/GetEntitlementsHandler.cs
+++ b/backend/src/Modules/Subscriptions/Application/GetEntitlements/GetEntitlementsHandler.cs
@@ -1,0 +1,35 @@
+using MoneyTracker.Modules.SharedKernel.Households;
+using MoneyTracker.Modules.Subscriptions.Domain;
+
+namespace MoneyTracker.Modules.Subscriptions.Application.GetEntitlements;
+
+public sealed class GetEntitlementsHandler(
+    ISubscriptionEntitlementService entitlementService,
+    IHouseholdAccessService householdAccess)
+{
+    public async Task<GetEntitlementsResult> HandleAsync(
+        GetEntitlementsQuery query,
+        CancellationToken cancellationToken)
+    {
+        var accessResult = await householdAccess.CheckMemberAsync(
+            query.HouseholdId,
+            query.UserId,
+            cancellationToken);
+
+        if (!accessResult.HouseholdExists)
+        {
+            return GetEntitlementsResult.HouseholdNotFound();
+        }
+
+        if (!accessResult.IsMember)
+        {
+            return GetEntitlementsResult.AccessDenied();
+        }
+
+        var entitlement = await entitlementService.GetEntitlementsAsync(
+            query.HouseholdId,
+            cancellationToken);
+
+        return GetEntitlementsResult.Success(entitlement);
+    }
+}

--- a/backend/src/Modules/Subscriptions/Application/GetEntitlements/GetEntitlementsQuery.cs
+++ b/backend/src/Modules/Subscriptions/Application/GetEntitlements/GetEntitlementsQuery.cs
@@ -1,0 +1,3 @@
+namespace MoneyTracker.Modules.Subscriptions.Application.GetEntitlements;
+
+public sealed record GetEntitlementsQuery(Guid HouseholdId, Guid UserId);

--- a/backend/src/Modules/Subscriptions/Application/GetEntitlements/GetEntitlementsResult.cs
+++ b/backend/src/Modules/Subscriptions/Application/GetEntitlements/GetEntitlementsResult.cs
@@ -1,0 +1,64 @@
+using MoneyTracker.Modules.Subscriptions.Domain;
+
+namespace MoneyTracker.Modules.Subscriptions.Application.GetEntitlements;
+
+public sealed class GetEntitlementsResult
+{
+    private GetEntitlementsResult(
+        string? tier,
+        string[]? featureKeys,
+        DateTimeOffset? trialExpiresAtUtc,
+        DateTimeOffset? currentPeriodEndUtc,
+        string? errorCode,
+        string? errorMessage)
+    {
+        Tier = tier;
+        FeatureKeys = featureKeys;
+        TrialExpiresAtUtc = trialExpiresAtUtc;
+        CurrentPeriodEndUtc = currentPeriodEndUtc;
+        ErrorCode = errorCode;
+        ErrorMessage = errorMessage;
+    }
+
+    public string? Tier { get; }
+    public string[]? FeatureKeys { get; }
+    public DateTimeOffset? TrialExpiresAtUtc { get; }
+    public DateTimeOffset? CurrentPeriodEndUtc { get; }
+    public string? ErrorCode { get; }
+    public string? ErrorMessage { get; }
+    public bool IsSuccess => ErrorCode is null;
+
+    public static GetEntitlementsResult Success(
+        EntitlementResult entitlement)
+    {
+        return new GetEntitlementsResult(
+            entitlement.Tier.ToString(),
+            entitlement.FeatureKeys.Select(fk => fk.ToString()).ToArray(),
+            entitlement.TrialExpiresAtUtc,
+            entitlement.CurrentPeriodEndUtc,
+            errorCode: null,
+            errorMessage: null);
+    }
+
+    public static GetEntitlementsResult HouseholdNotFound()
+    {
+        return new GetEntitlementsResult(
+            tier: null,
+            featureKeys: null,
+            trialExpiresAtUtc: null,
+            currentPeriodEndUtc: null,
+            SubscriptionErrors.HouseholdNotFound,
+            "The household was not found.");
+    }
+
+    public static GetEntitlementsResult AccessDenied()
+    {
+        return new GetEntitlementsResult(
+            tier: null,
+            featureKeys: null,
+            trialExpiresAtUtc: null,
+            currentPeriodEndUtc: null,
+            SubscriptionErrors.AccessDenied,
+            "You do not have access to this household.");
+    }
+}

--- a/backend/src/Modules/Subscriptions/Domain/EntitlementSet.cs
+++ b/backend/src/Modules/Subscriptions/Domain/EntitlementSet.cs
@@ -1,0 +1,36 @@
+namespace MoneyTracker.Modules.Subscriptions.Domain;
+
+public sealed class EntitlementSet
+{
+    private static readonly IReadOnlySet<FeatureKey> PremiumFeatures = new HashSet<FeatureKey>
+    {
+        FeatureKey.BankSync,
+        FeatureKey.PremiumInsights,
+        FeatureKey.UnlimitedBudgets,
+        FeatureKey.UnlimitedBillReminders,
+        FeatureKey.ExportData
+    };
+
+    private static readonly IReadOnlySet<FeatureKey> FreeFeatures =
+        new HashSet<FeatureKey>();
+
+    private EntitlementSet(SubscriptionTier tier, IReadOnlySet<FeatureKey> featureKeys)
+    {
+        Tier = tier;
+        FeatureKeys = featureKeys;
+    }
+
+    public SubscriptionTier Tier { get; }
+
+    public IReadOnlySet<FeatureKey> FeatureKeys { get; }
+
+    public bool HasFeature(FeatureKey feature) => FeatureKeys.Contains(feature);
+
+    public static EntitlementSet ForTier(SubscriptionTier tier) => tier switch
+    {
+        SubscriptionTier.Premium => new EntitlementSet(tier, PremiumFeatures),
+        SubscriptionTier.Trial => new EntitlementSet(tier, PremiumFeatures),
+        SubscriptionTier.Free => new EntitlementSet(tier, FreeFeatures),
+        _ => new EntitlementSet(SubscriptionTier.Free, FreeFeatures)
+    };
+}

--- a/backend/src/Modules/Subscriptions/Domain/FeatureKey.cs
+++ b/backend/src/Modules/Subscriptions/Domain/FeatureKey.cs
@@ -1,0 +1,10 @@
+namespace MoneyTracker.Modules.Subscriptions.Domain;
+
+public enum FeatureKey
+{
+    BankSync,
+    PremiumInsights,
+    UnlimitedBudgets,
+    UnlimitedBillReminders,
+    ExportData
+}

--- a/backend/src/Modules/Subscriptions/Domain/ISubscriptionEntitlementService.cs
+++ b/backend/src/Modules/Subscriptions/Domain/ISubscriptionEntitlementService.cs
@@ -1,0 +1,14 @@
+namespace MoneyTracker.Modules.Subscriptions.Domain;
+
+public sealed record EntitlementResult(
+    SubscriptionTier Tier,
+    IReadOnlySet<FeatureKey> FeatureKeys,
+    DateTimeOffset? TrialExpiresAtUtc,
+    DateTimeOffset? CurrentPeriodEndUtc);
+
+public interface ISubscriptionEntitlementService
+{
+    Task<EntitlementResult> GetEntitlementsAsync(
+        Guid householdId,
+        CancellationToken cancellationToken);
+}

--- a/backend/src/Modules/Subscriptions/Domain/SubscriptionTier.cs
+++ b/backend/src/Modules/Subscriptions/Domain/SubscriptionTier.cs
@@ -1,0 +1,8 @@
+namespace MoneyTracker.Modules.Subscriptions.Domain;
+
+public enum SubscriptionTier
+{
+    Free,
+    Trial,
+    Premium
+}

--- a/backend/src/Modules/Subscriptions/Infrastructure/SubscriptionEntitlementService.cs
+++ b/backend/src/Modules/Subscriptions/Infrastructure/SubscriptionEntitlementService.cs
@@ -1,0 +1,65 @@
+using MoneyTracker.Modules.Subscriptions.Domain;
+
+namespace MoneyTracker.Modules.Subscriptions.Infrastructure;
+
+public sealed class SubscriptionEntitlementService(
+    ISubscriptionRepository repository)
+    : Domain.ISubscriptionEntitlementService,
+      SharedKernel.Subscriptions.ISubscriptionEntitlementService
+{
+    public async Task<EntitlementResult> GetEntitlementsAsync(
+        Guid householdId,
+        CancellationToken cancellationToken)
+    {
+        var subscription = await repository.GetByHouseholdIdAsync(
+            householdId,
+            cancellationToken);
+
+        if (subscription is null)
+        {
+            var freeSet = EntitlementSet.ForTier(SubscriptionTier.Free);
+            return new EntitlementResult(
+                SubscriptionTier.Free,
+                freeSet.FeatureKeys,
+                TrialExpiresAtUtc: null,
+                CurrentPeriodEndUtc: null);
+        }
+
+        var tier = MapStatusToTier(subscription.Status);
+        var entitlementSet = EntitlementSet.ForTier(tier);
+
+        DateTimeOffset? trialExpiresAtUtc = tier == SubscriptionTier.Trial
+            ? subscription.CurrentPeriodEndUtc
+            : null;
+
+        return new EntitlementResult(
+            tier,
+            entitlementSet.FeatureKeys,
+            trialExpiresAtUtc,
+            subscription.CurrentPeriodEndUtc);
+    }
+
+    public async Task<bool> IsFeatureAllowedAsync(
+        Guid householdId,
+        string featureKey,
+        CancellationToken cancellationToken)
+    {
+        if (!Enum.TryParse<FeatureKey>(featureKey, ignoreCase: true, out var feature))
+        {
+            return false;
+        }
+
+        var entitlement = await GetEntitlementsAsync(householdId, cancellationToken);
+        var entitlementSet = EntitlementSet.ForTier(entitlement.Tier);
+        return entitlementSet.HasFeature(feature);
+    }
+
+    private static SubscriptionTier MapStatusToTier(SubscriptionStatus status) => status switch
+    {
+        SubscriptionStatus.Active => SubscriptionTier.Premium,
+        SubscriptionStatus.Trial => SubscriptionTier.Trial,
+        SubscriptionStatus.BillingIssue => SubscriptionTier.Premium,
+        SubscriptionStatus.Cancelled => SubscriptionTier.Premium,
+        _ => SubscriptionTier.Free
+    };
+}

--- a/backend/src/Modules/Subscriptions/Presentation/SubscriptionEndpoints.cs
+++ b/backend/src/Modules/Subscriptions/Presentation/SubscriptionEndpoints.cs
@@ -4,9 +4,12 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
+using MoneyTracker.Modules.Subscriptions.Application.CheckFeatureAccess;
+using MoneyTracker.Modules.Subscriptions.Application.GetEntitlements;
 using MoneyTracker.Modules.Subscriptions.Application.GetSubscription;
 using MoneyTracker.Modules.Subscriptions.Application.ProcessWebhook;
 using MoneyTracker.Modules.Subscriptions.Domain;
+using MoneyTracker.Modules.SharedKernel.Households;
 using MoneyTracker.Modules.SharedKernel.Presentation;
 
 namespace MoneyTracker.Modules.Subscriptions.Presentation;
@@ -21,6 +24,14 @@ public static class SubscriptionEndpoints
         services.AddScoped<ProcessRevenueCatWebhookHandler>();
         services.AddScoped<GetSubscriptionHandler>();
 
+        services.AddSingleton<Infrastructure.SubscriptionEntitlementService>();
+        services.AddSingleton<Domain.ISubscriptionEntitlementService>(sp =>
+            sp.GetRequiredService<Infrastructure.SubscriptionEntitlementService>());
+        services.AddSingleton<SharedKernel.Subscriptions.ISubscriptionEntitlementService>(sp =>
+            sp.GetRequiredService<Infrastructure.SubscriptionEntitlementService>());
+        services.AddScoped<GetEntitlementsHandler>();
+        services.AddScoped<CheckFeatureAccessHandler>();
+
         return services;
     }
 
@@ -34,6 +45,17 @@ public static class SubscriptionEndpoints
             .Produces(StatusCodes.Status204NoContent)
             .ProducesProblem(StatusCodes.Status401Unauthorized)
             .ProducesProblem(StatusCodes.Status400BadRequest);
+
+        var entitlementsEndpoint = (RouteHandlerBuilder)app.MapGet("/subscriptions/entitlements", GetEntitlements);
+        entitlementsEndpoint
+            .WithName("GetEntitlements")
+            .WithSummary("Get entitlements for a household.")
+            .WithDescription("Returns the subscription tier and enabled feature keys for the specified household.")
+            .Produces<EntitlementsResponse>(StatusCodes.Status200OK)
+            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status401Unauthorized)
+            .ProducesProblem(StatusCodes.Status403Forbidden)
+            .ProducesProblem(StatusCodes.Status404NotFound);
 
         return app;
     }
@@ -130,6 +152,66 @@ public static class SubscriptionEndpoints
 
         httpContext.Response.StatusCode = StatusCodes.Status204NoContent;
     }
+
+    private static async Task GetEntitlements(HttpContext httpContext)
+    {
+        var authResult = await EndpointHelpers.ResolveAuthenticatedUser(httpContext);
+        if (!authResult.Success)
+        {
+            await authResult.Problem!.ExecuteAsync(httpContext);
+            return;
+        }
+
+        if (!TryGetGuidQuery(httpContext, "householdId", out var householdId))
+        {
+            await EndpointHelpers.WriteProblemAsync(
+                httpContext,
+                StatusCodes.Status400BadRequest,
+                "Validation failed.",
+                "householdId query parameter is required.",
+                SubscriptionErrors.ValidationError,
+                SubscriptionErrors.ValidationError);
+            return;
+        }
+
+        var handler = httpContext.RequestServices.GetRequiredService<GetEntitlementsHandler>();
+        var result = await handler.HandleAsync(
+            new GetEntitlementsQuery(householdId, authResult.AuthenticatedUser!.UserId),
+            httpContext.RequestAborted);
+
+        if (!result.IsSuccess)
+        {
+            var statusCode = result.ErrorCode switch
+            {
+                SubscriptionErrors.HouseholdNotFound => StatusCodes.Status404NotFound,
+                SubscriptionErrors.AccessDenied => StatusCodes.Status403Forbidden,
+                _ => StatusCodes.Status400BadRequest
+            };
+
+            await EndpointHelpers.WriteProblemAsync(
+                httpContext,
+                statusCode,
+                statusCode == StatusCodes.Status403Forbidden ? "Access denied." : "Validation failed.",
+                result.ErrorMessage ?? "Request rejected.",
+                result.ErrorCode,
+                SubscriptionErrors.ValidationError);
+            return;
+        }
+
+        var response = new EntitlementsResponse(
+            result.Tier!,
+            result.FeatureKeys!,
+            result.TrialExpiresAtUtc,
+            result.CurrentPeriodEndUtc);
+        await TypedResults.Ok(response).ExecuteAsync(httpContext);
+    }
+
+    private static bool TryGetGuidQuery(HttpContext httpContext, string key, out Guid value)
+    {
+        value = Guid.Empty;
+        var raw = httpContext.Request.Query[key].FirstOrDefault();
+        return raw is not null && Guid.TryParse(raw, out value);
+    }
 }
 
 internal sealed record RevenueCatWebhookPayload
@@ -164,3 +246,9 @@ internal sealed record RevenueCatEvent
     [JsonPropertyName("cancellation_date_ms")]
     public long? CancellationDateMs { get; init; }
 }
+
+public sealed record EntitlementsResponse(
+    string Tier,
+    string[] FeatureKeys,
+    DateTimeOffset? TrialExpiresAtUtc,
+    DateTimeOffset? CurrentPeriodEndUtc);

--- a/backend/tests/MoneyTracker.Modules.Subscriptions.Tests/Application/CheckFeatureAccessHandlerTests.cs
+++ b/backend/tests/MoneyTracker.Modules.Subscriptions.Tests/Application/CheckFeatureAccessHandlerTests.cs
@@ -1,0 +1,107 @@
+using MoneyTracker.Modules.Subscriptions.Application.CheckFeatureAccess;
+using MoneyTracker.Modules.Subscriptions.Domain;
+
+namespace MoneyTracker.Modules.Subscriptions.Tests.Application;
+
+public sealed class CheckFeatureAccessHandlerTests
+{
+    private static readonly Guid HouseholdId = Guid.NewGuid();
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task HandleAsync_PremiumTier_BankSync_ReturnsAllowed()
+    {
+        // P4-2-UNIT-04: CheckFeatureAccess with Premium tier and BankSync returns IsAllowed=true
+        var entitlementService = new StubEntitlementService(
+            new EntitlementResult(
+                SubscriptionTier.Premium,
+                EntitlementSet.ForTier(SubscriptionTier.Premium).FeatureKeys,
+                TrialExpiresAtUtc: null,
+                CurrentPeriodEndUtc: DateTimeOffset.UtcNow.AddDays(30)));
+
+        var handler = new CheckFeatureAccessHandler(entitlementService);
+        var result = await handler.HandleAsync(
+            new CheckFeatureAccessQuery(HouseholdId, FeatureKey.BankSync),
+            CancellationToken.None);
+
+        Assert.True(result.IsAllowed);
+        Assert.Equal("Premium", result.Tier);
+        Assert.False(result.UpgradeRequired);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task HandleAsync_FreeTier_BankSync_ReturnsDenied()
+    {
+        // P4-2-UNIT-05: CheckFeatureAccess with Free tier and BankSync returns IsAllowed=false, UpgradeRequired=true
+        var entitlementService = new StubEntitlementService(
+            new EntitlementResult(
+                SubscriptionTier.Free,
+                EntitlementSet.ForTier(SubscriptionTier.Free).FeatureKeys,
+                TrialExpiresAtUtc: null,
+                CurrentPeriodEndUtc: null));
+
+        var handler = new CheckFeatureAccessHandler(entitlementService);
+        var result = await handler.HandleAsync(
+            new CheckFeatureAccessQuery(HouseholdId, FeatureKey.BankSync),
+            CancellationToken.None);
+
+        Assert.False(result.IsAllowed);
+        Assert.Equal("Free", result.Tier);
+        Assert.True(result.UpgradeRequired);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task HandleAsync_TrialTier_PremiumInsights_ReturnsAllowed()
+    {
+        var entitlementService = new StubEntitlementService(
+            new EntitlementResult(
+                SubscriptionTier.Trial,
+                EntitlementSet.ForTier(SubscriptionTier.Trial).FeatureKeys,
+                TrialExpiresAtUtc: DateTimeOffset.UtcNow.AddDays(14),
+                CurrentPeriodEndUtc: DateTimeOffset.UtcNow.AddDays(14)));
+
+        var handler = new CheckFeatureAccessHandler(entitlementService);
+        var result = await handler.HandleAsync(
+            new CheckFeatureAccessQuery(HouseholdId, FeatureKey.PremiumInsights),
+            CancellationToken.None);
+
+        Assert.True(result.IsAllowed);
+        Assert.Equal("Trial", result.Tier);
+        Assert.False(result.UpgradeRequired);
+    }
+
+    [Theory]
+    [Trait("Category", "Unit")]
+    [InlineData(FeatureKey.BankSync)]
+    [InlineData(FeatureKey.PremiumInsights)]
+    [InlineData(FeatureKey.UnlimitedBudgets)]
+    [InlineData(FeatureKey.UnlimitedBillReminders)]
+    [InlineData(FeatureKey.ExportData)]
+    public async Task HandleAsync_FreeTier_AllPremiumFeatures_ReturnsDenied(FeatureKey feature)
+    {
+        var entitlementService = new StubEntitlementService(
+            new EntitlementResult(
+                SubscriptionTier.Free,
+                EntitlementSet.ForTier(SubscriptionTier.Free).FeatureKeys,
+                TrialExpiresAtUtc: null,
+                CurrentPeriodEndUtc: null));
+
+        var handler = new CheckFeatureAccessHandler(entitlementService);
+        var result = await handler.HandleAsync(
+            new CheckFeatureAccessQuery(HouseholdId, feature),
+            CancellationToken.None);
+
+        Assert.False(result.IsAllowed);
+        Assert.True(result.UpgradeRequired);
+    }
+
+    private sealed class StubEntitlementService(EntitlementResult result) : ISubscriptionEntitlementService
+    {
+        public Task<EntitlementResult> GetEntitlementsAsync(Guid householdId, CancellationToken cancellationToken)
+        {
+            return Task.FromResult(result);
+        }
+    }
+}

--- a/backend/tests/MoneyTracker.Modules.Subscriptions.Tests/Application/GetEntitlementsHandlerTests.cs
+++ b/backend/tests/MoneyTracker.Modules.Subscriptions.Tests/Application/GetEntitlementsHandlerTests.cs
@@ -1,0 +1,156 @@
+using MoneyTracker.Modules.SharedKernel.Households;
+using MoneyTracker.Modules.Subscriptions.Application.GetEntitlements;
+using MoneyTracker.Modules.Subscriptions.Domain;
+
+namespace MoneyTracker.Modules.Subscriptions.Tests.Application;
+
+public sealed class GetEntitlementsHandlerTests
+{
+    private static readonly Guid HouseholdId = Guid.NewGuid();
+    private static readonly Guid UserId = Guid.NewGuid();
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task HandleAsync_ActiveSubscription_ReturnsPremiumTierWithAllFeatures()
+    {
+        // P4-2-UNIT-06: GetEntitlements with Active subscription returns Premium tier
+        var entitlementService = new StubEntitlementService(
+            new EntitlementResult(
+                SubscriptionTier.Premium,
+                EntitlementSet.ForTier(SubscriptionTier.Premium).FeatureKeys,
+                TrialExpiresAtUtc: null,
+                CurrentPeriodEndUtc: DateTimeOffset.UtcNow.AddDays(30)));
+
+        var householdAccess = new StubHouseholdAccessService(HouseholdAccessResult.Allowed());
+
+        var handler = new GetEntitlementsHandler(entitlementService, householdAccess);
+        var result = await handler.HandleAsync(
+            new GetEntitlementsQuery(HouseholdId, UserId),
+            CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal("Premium", result.Tier);
+        Assert.NotNull(result.FeatureKeys);
+        Assert.Contains("BankSync", result.FeatureKeys!);
+        Assert.Contains("PremiumInsights", result.FeatureKeys!);
+        Assert.Contains("UnlimitedBudgets", result.FeatureKeys!);
+        Assert.Contains("UnlimitedBillReminders", result.FeatureKeys!);
+        Assert.Contains("ExportData", result.FeatureKeys!);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task HandleAsync_NoSubscription_ReturnsFreeTier()
+    {
+        // P4-2-UNIT-07: GetEntitlements with no subscription returns Free tier
+        var entitlementService = new StubEntitlementService(
+            new EntitlementResult(
+                SubscriptionTier.Free,
+                EntitlementSet.ForTier(SubscriptionTier.Free).FeatureKeys,
+                TrialExpiresAtUtc: null,
+                CurrentPeriodEndUtc: null));
+
+        var householdAccess = new StubHouseholdAccessService(HouseholdAccessResult.Allowed());
+
+        var handler = new GetEntitlementsHandler(entitlementService, householdAccess);
+        var result = await handler.HandleAsync(
+            new GetEntitlementsQuery(HouseholdId, UserId),
+            CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal("Free", result.Tier);
+        Assert.NotNull(result.FeatureKeys);
+        Assert.Empty(result.FeatureKeys!);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task HandleAsync_TrialSubscription_ReturnsTrialTierWithAllFeatures()
+    {
+        var trialExpiry = DateTimeOffset.UtcNow.AddDays(14);
+        var entitlementService = new StubEntitlementService(
+            new EntitlementResult(
+                SubscriptionTier.Trial,
+                EntitlementSet.ForTier(SubscriptionTier.Trial).FeatureKeys,
+                TrialExpiresAtUtc: trialExpiry,
+                CurrentPeriodEndUtc: trialExpiry));
+
+        var householdAccess = new StubHouseholdAccessService(HouseholdAccessResult.Allowed());
+
+        var handler = new GetEntitlementsHandler(entitlementService, householdAccess);
+        var result = await handler.HandleAsync(
+            new GetEntitlementsQuery(HouseholdId, UserId),
+            CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal("Trial", result.Tier);
+        Assert.NotNull(result.FeatureKeys);
+        Assert.Equal(5, result.FeatureKeys!.Length);
+        Assert.Equal(trialExpiry, result.TrialExpiresAtUtc);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task HandleAsync_HouseholdNotFound_ReturnsHouseholdNotFound()
+    {
+        var entitlementService = new StubEntitlementService(
+            new EntitlementResult(
+                SubscriptionTier.Free,
+                EntitlementSet.ForTier(SubscriptionTier.Free).FeatureKeys,
+                TrialExpiresAtUtc: null,
+                CurrentPeriodEndUtc: null));
+
+        var householdAccess = new StubHouseholdAccessService(HouseholdAccessResult.NotFound());
+
+        var handler = new GetEntitlementsHandler(entitlementService, householdAccess);
+        var result = await handler.HandleAsync(
+            new GetEntitlementsQuery(HouseholdId, UserId),
+            CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(SubscriptionErrors.HouseholdNotFound, result.ErrorCode);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task HandleAsync_AccessDenied_ReturnsAccessDenied()
+    {
+        var entitlementService = new StubEntitlementService(
+            new EntitlementResult(
+                SubscriptionTier.Free,
+                EntitlementSet.ForTier(SubscriptionTier.Free).FeatureKeys,
+                TrialExpiresAtUtc: null,
+                CurrentPeriodEndUtc: null));
+
+        var householdAccess = new StubHouseholdAccessService(HouseholdAccessResult.Denied());
+
+        var handler = new GetEntitlementsHandler(entitlementService, householdAccess);
+        var result = await handler.HandleAsync(
+            new GetEntitlementsQuery(HouseholdId, UserId),
+            CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(SubscriptionErrors.AccessDenied, result.ErrorCode);
+    }
+
+    private sealed class StubEntitlementService(EntitlementResult result) : ISubscriptionEntitlementService
+    {
+        public Task<EntitlementResult> GetEntitlementsAsync(Guid householdId, CancellationToken cancellationToken)
+        {
+            return Task.FromResult(result);
+        }
+    }
+
+    private sealed class StubHouseholdAccessService(HouseholdAccessResult accessResult) : IHouseholdAccessService
+    {
+        public Task<HouseholdAccessResult> CheckMemberAsync(Guid householdId, Guid userId, CancellationToken cancellationToken)
+        {
+            return Task.FromResult(accessResult);
+        }
+
+        public Task<IReadOnlyCollection<Guid>> GetMemberIdsAsync(Guid householdId, CancellationToken cancellationToken)
+        {
+            return Task.FromResult<IReadOnlyCollection<Guid>>(Array.Empty<Guid>());
+        }
+    }
+}

--- a/backend/tests/MoneyTracker.Modules.Subscriptions.Tests/Domain/EntitlementSetTests.cs
+++ b/backend/tests/MoneyTracker.Modules.Subscriptions.Tests/Domain/EntitlementSetTests.cs
@@ -1,0 +1,91 @@
+using MoneyTracker.Modules.Subscriptions.Domain;
+
+namespace MoneyTracker.Modules.Subscriptions.Tests.Domain;
+
+public sealed class EntitlementSetTests
+{
+    private static readonly FeatureKey[] AllPremiumFeatures =
+    [
+        FeatureKey.BankSync,
+        FeatureKey.PremiumInsights,
+        FeatureKey.UnlimitedBudgets,
+        FeatureKey.UnlimitedBillReminders,
+        FeatureKey.ExportData
+    ];
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void ForTier_Premium_ContainsAllPremiumFeatureKeys()
+    {
+        // P4-2-UNIT-01: EntitlementSet.ForTier(Premium) contains all 5 premium feature keys
+        var entitlementSet = EntitlementSet.ForTier(SubscriptionTier.Premium);
+
+        Assert.Equal(SubscriptionTier.Premium, entitlementSet.Tier);
+        Assert.Equal(AllPremiumFeatures.Length, entitlementSet.FeatureKeys.Count);
+        foreach (var feature in AllPremiumFeatures)
+        {
+            Assert.True(entitlementSet.HasFeature(feature),
+                $"Premium tier should include {feature}");
+        }
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void ForTier_Free_ContainsNoPremiumFeatureKeys()
+    {
+        // P4-2-UNIT-02: EntitlementSet.ForTier(Free) contains no premium feature keys
+        var entitlementSet = EntitlementSet.ForTier(SubscriptionTier.Free);
+
+        Assert.Equal(SubscriptionTier.Free, entitlementSet.Tier);
+        Assert.Empty(entitlementSet.FeatureKeys);
+        foreach (var feature in AllPremiumFeatures)
+        {
+            Assert.False(entitlementSet.HasFeature(feature),
+                $"Free tier should not include {feature}");
+        }
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void ForTier_Trial_ContainsAllPremiumFeatureKeys()
+    {
+        // P4-2-UNIT-03: EntitlementSet.ForTier(Trial) contains all premium feature keys (same as Premium)
+        var entitlementSet = EntitlementSet.ForTier(SubscriptionTier.Trial);
+
+        Assert.Equal(SubscriptionTier.Trial, entitlementSet.Tier);
+        Assert.Equal(AllPremiumFeatures.Length, entitlementSet.FeatureKeys.Count);
+        foreach (var feature in AllPremiumFeatures)
+        {
+            Assert.True(entitlementSet.HasFeature(feature),
+                $"Trial tier should include {feature}");
+        }
+    }
+
+    [Theory]
+    [Trait("Category", "Unit")]
+    [InlineData(FeatureKey.BankSync)]
+    [InlineData(FeatureKey.PremiumInsights)]
+    [InlineData(FeatureKey.UnlimitedBudgets)]
+    [InlineData(FeatureKey.UnlimitedBillReminders)]
+    [InlineData(FeatureKey.ExportData)]
+    public void HasFeature_Premium_ReturnsTrueForEachFeature(FeatureKey feature)
+    {
+        var entitlementSet = EntitlementSet.ForTier(SubscriptionTier.Premium);
+
+        Assert.True(entitlementSet.HasFeature(feature));
+    }
+
+    [Theory]
+    [Trait("Category", "Unit")]
+    [InlineData(FeatureKey.BankSync)]
+    [InlineData(FeatureKey.PremiumInsights)]
+    [InlineData(FeatureKey.UnlimitedBudgets)]
+    [InlineData(FeatureKey.UnlimitedBillReminders)]
+    [InlineData(FeatureKey.ExportData)]
+    public void HasFeature_Free_ReturnsFalseForEachFeature(FeatureKey feature)
+    {
+        var entitlementSet = EntitlementSet.ForTier(SubscriptionTier.Free);
+
+        Assert.False(entitlementSet.HasFeature(feature));
+    }
+}

--- a/backend/tests/MoneyTracker.Modules.Subscriptions.Tests/Infrastructure/SubscriptionEntitlementServiceTests.cs
+++ b/backend/tests/MoneyTracker.Modules.Subscriptions.Tests/Infrastructure/SubscriptionEntitlementServiceTests.cs
@@ -1,0 +1,185 @@
+using MoneyTracker.Modules.Subscriptions.Domain;
+using MoneyTracker.Modules.Subscriptions.Infrastructure;
+
+namespace MoneyTracker.Modules.Subscriptions.Tests.Infrastructure;
+
+public sealed class SubscriptionEntitlementServiceTests
+{
+    private static readonly DateTimeOffset NowUtc = DateTimeOffset.Parse("2026-03-01T00:00:00Z");
+    private static readonly Guid HouseholdId = Guid.NewGuid();
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task GetEntitlementsAsync_NoSubscription_ReturnsFreeWithNoFeatures()
+    {
+        var repository = new StubSubscriptionRepository(subscription: null);
+        var service = new SubscriptionEntitlementService(repository);
+
+        var result = await service.GetEntitlementsAsync(HouseholdId, CancellationToken.None);
+
+        Assert.Equal(SubscriptionTier.Free, result.Tier);
+        Assert.Empty(result.FeatureKeys);
+        Assert.Null(result.TrialExpiresAtUtc);
+        Assert.Null(result.CurrentPeriodEndUtc);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task GetEntitlementsAsync_ActiveSubscription_ReturnsPremiumWithAllFeatures()
+    {
+        var subscription = CreateActiveSubscription();
+        var repository = new StubSubscriptionRepository(subscription);
+        var service = new SubscriptionEntitlementService(repository);
+
+        var result = await service.GetEntitlementsAsync(HouseholdId, CancellationToken.None);
+
+        Assert.Equal(SubscriptionTier.Premium, result.Tier);
+        Assert.Equal(5, result.FeatureKeys.Count);
+        Assert.Contains(FeatureKey.BankSync, result.FeatureKeys);
+        Assert.Contains(FeatureKey.PremiumInsights, result.FeatureKeys);
+        Assert.Contains(FeatureKey.UnlimitedBudgets, result.FeatureKeys);
+        Assert.Contains(FeatureKey.UnlimitedBillReminders, result.FeatureKeys);
+        Assert.Contains(FeatureKey.ExportData, result.FeatureKeys);
+        Assert.Null(result.TrialExpiresAtUtc);
+        Assert.NotNull(result.CurrentPeriodEndUtc);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task GetEntitlementsAsync_TrialSubscription_ReturnsTrialWithAllFeaturesAndExpiry()
+    {
+        var trialEnd = NowUtc.AddDays(14);
+        var subscription = Subscription.CreateTrial(
+            HouseholdId,
+            "app-user-1",
+            "premium_monthly",
+            NowUtc,
+            trialEnd,
+            NowUtc);
+        var repository = new StubSubscriptionRepository(subscription);
+        var service = new SubscriptionEntitlementService(repository);
+
+        var result = await service.GetEntitlementsAsync(HouseholdId, CancellationToken.None);
+
+        Assert.Equal(SubscriptionTier.Trial, result.Tier);
+        Assert.Equal(5, result.FeatureKeys.Count);
+        Assert.Equal(trialEnd, result.TrialExpiresAtUtc);
+        Assert.Equal(trialEnd, result.CurrentPeriodEndUtc);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task GetEntitlementsAsync_ExpiredSubscription_ReturnsFree()
+    {
+        var subscription = CreateActiveSubscription();
+        subscription.Expire("evt-expire-1", NowUtc.AddDays(30));
+        var repository = new StubSubscriptionRepository(subscription);
+        var service = new SubscriptionEntitlementService(repository);
+
+        var result = await service.GetEntitlementsAsync(HouseholdId, CancellationToken.None);
+
+        Assert.Equal(SubscriptionTier.Free, result.Tier);
+        Assert.Empty(result.FeatureKeys);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task GetEntitlementsAsync_CancelledSubscription_ReturnsPremium()
+    {
+        // Cancelled subscriptions remain active until period end
+        var subscription = CreateActiveSubscription();
+        subscription.Cancel(NowUtc.AddDays(15), "evt-cancel-1", NowUtc.AddDays(15));
+        var repository = new StubSubscriptionRepository(subscription);
+        var service = new SubscriptionEntitlementService(repository);
+
+        var result = await service.GetEntitlementsAsync(HouseholdId, CancellationToken.None);
+
+        Assert.Equal(SubscriptionTier.Premium, result.Tier);
+        Assert.Equal(5, result.FeatureKeys.Count);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task GetEntitlementsAsync_BillingIssue_ReturnsPremium()
+    {
+        // Billing issue keeps access until expiration
+        var subscription = CreateActiveSubscription();
+        subscription.MarkBillingIssue(NowUtc.AddDays(20), "evt-billing-1", NowUtc.AddDays(20));
+        var repository = new StubSubscriptionRepository(subscription);
+        var service = new SubscriptionEntitlementService(repository);
+
+        var result = await service.GetEntitlementsAsync(HouseholdId, CancellationToken.None);
+
+        Assert.Equal(SubscriptionTier.Premium, result.Tier);
+        Assert.Equal(5, result.FeatureKeys.Count);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task IsFeatureAllowedAsync_PremiumWithBankSync_ReturnsTrue()
+    {
+        var subscription = CreateActiveSubscription();
+        var repository = new StubSubscriptionRepository(subscription);
+        var service = new SubscriptionEntitlementService(repository);
+
+        var result = await service.IsFeatureAllowedAsync(HouseholdId, "BankSync", CancellationToken.None);
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task IsFeatureAllowedAsync_FreeWithBankSync_ReturnsFalse()
+    {
+        var repository = new StubSubscriptionRepository(subscription: null);
+        var service = new SubscriptionEntitlementService(repository);
+
+        var result = await service.IsFeatureAllowedAsync(HouseholdId, "BankSync", CancellationToken.None);
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task IsFeatureAllowedAsync_InvalidFeatureKey_ReturnsFalse()
+    {
+        var subscription = CreateActiveSubscription();
+        var repository = new StubSubscriptionRepository(subscription);
+        var service = new SubscriptionEntitlementService(repository);
+
+        var result = await service.IsFeatureAllowedAsync(HouseholdId, "NonExistentFeature", CancellationToken.None);
+
+        Assert.False(result);
+    }
+
+    private static Subscription CreateActiveSubscription()
+    {
+        var sub = Subscription.CreateTrial(
+            HouseholdId,
+            "app-user-1",
+            "premium_monthly",
+            NowUtc,
+            NowUtc.AddDays(7),
+            NowUtc);
+        sub.Activate(NowUtc, NowUtc.AddDays(30), NowUtc, "evt-1", NowUtc.AddMinutes(1));
+        return sub;
+    }
+
+    private sealed class StubSubscriptionRepository(Subscription? subscription) : ISubscriptionRepository
+    {
+        public Task AddAsync(Subscription subscription, CancellationToken cancellationToken)
+            => Task.CompletedTask;
+
+        public Task UpdateAsync(Subscription subscription, CancellationToken cancellationToken)
+            => Task.CompletedTask;
+
+        public Task<Subscription?> GetByIdAsync(SubscriptionId id, CancellationToken cancellationToken)
+            => Task.FromResult(subscription);
+
+        public Task<Subscription?> GetByHouseholdIdAsync(Guid householdId, CancellationToken cancellationToken)
+            => Task.FromResult(subscription);
+
+        public Task<Subscription?> GetByRevenueCatAppUserIdAsync(string appUserId, CancellationToken cancellationToken)
+            => Task.FromResult(subscription);
+    }
+}

--- a/mobile/lib/features/subscriptions/application/entitlement_provider.dart
+++ b/mobile/lib/features/subscriptions/application/entitlement_provider.dart
@@ -1,0 +1,53 @@
+import 'package:flutter/foundation.dart';
+import '../domain/entitlement_set.dart';
+import '../domain/feature_key.dart';
+import '../infrastructure/subscription_gateway.dart';
+
+class EntitlementProvider extends ChangeNotifier {
+  EntitlementProvider({
+    required SubscriptionGateway gateway,
+    Duration cacheTtl = const Duration(minutes: 5),
+  })  : _gateway = gateway,
+        _cacheTtl = cacheTtl;
+
+  final SubscriptionGateway _gateway;
+  final Duration _cacheTtl;
+
+  EntitlementSet _entitlements = EntitlementSet.free();
+  DateTime? _lastFetchedAt;
+  bool _isLoading = false;
+
+  EntitlementSet get entitlements => _entitlements;
+  bool get isLoading => _isLoading;
+
+  bool get _isCacheValid {
+    if (_lastFetchedAt == null) return false;
+    return DateTime.now().difference(_lastFetchedAt!) < _cacheTtl;
+  }
+
+  bool hasFeature(FeatureKey feature) => _entitlements.hasFeature(feature);
+
+  Future<EntitlementSet> fetchEntitlements(String householdId) async {
+    if (_isCacheValid) {
+      return _entitlements;
+    }
+
+    _isLoading = true;
+    notifyListeners();
+
+    try {
+      final result = await _gateway.getEntitlements(householdId);
+      _entitlements = result;
+      _lastFetchedAt = DateTime.now();
+    } finally {
+      _isLoading = false;
+      notifyListeners();
+    }
+
+    return _entitlements;
+  }
+
+  void invalidateCache() {
+    _lastFetchedAt = null;
+  }
+}

--- a/mobile/lib/features/subscriptions/domain/entitlement_set.dart
+++ b/mobile/lib/features/subscriptions/domain/entitlement_set.dart
@@ -1,0 +1,67 @@
+import 'feature_key.dart';
+import 'subscription_tier.dart';
+
+class EntitlementSet {
+  const EntitlementSet._({
+    required this.tier,
+    required this.featureKeys,
+    this.trialExpiresAtUtc,
+    this.currentPeriodEndUtc,
+  });
+
+  final SubscriptionTier tier;
+  final Set<FeatureKey> featureKeys;
+  final DateTime? trialExpiresAtUtc;
+  final DateTime? currentPeriodEndUtc;
+
+  bool hasFeature(FeatureKey feature) => featureKeys.contains(feature);
+
+  factory EntitlementSet.forTier(SubscriptionTier tier) {
+    switch (tier) {
+      case SubscriptionTier.premium:
+      case SubscriptionTier.trial:
+        return EntitlementSet._(
+          tier: tier,
+          featureKeys: const {
+            FeatureKey.bankSync,
+            FeatureKey.premiumInsights,
+            FeatureKey.unlimitedBudgets,
+            FeatureKey.unlimitedBillReminders,
+            FeatureKey.exportData,
+          },
+        );
+      case SubscriptionTier.free:
+        return EntitlementSet._(
+          tier: tier,
+          featureKeys: const {},
+        );
+    }
+  }
+
+  factory EntitlementSet.fromApiResponse({
+    required String tier,
+    required List<String> featureKeys,
+    DateTime? trialExpiresAtUtc,
+    DateTime? currentPeriodEndUtc,
+  }) {
+    final parsedTier = SubscriptionTier.fromString(tier);
+    final parsedFeatures = <FeatureKey>{};
+    for (final key in featureKeys) {
+      final parsed = FeatureKey.fromString(key);
+      if (parsed != null) {
+        parsedFeatures.add(parsed);
+      }
+    }
+
+    return EntitlementSet._(
+      tier: parsedTier,
+      featureKeys: parsedFeatures,
+      trialExpiresAtUtc: trialExpiresAtUtc,
+      currentPeriodEndUtc: currentPeriodEndUtc,
+    );
+  }
+
+  factory EntitlementSet.free() {
+    return EntitlementSet.forTier(SubscriptionTier.free);
+  }
+}

--- a/mobile/lib/features/subscriptions/domain/feature_key.dart
+++ b/mobile/lib/features/subscriptions/domain/feature_key.dart
@@ -1,0 +1,29 @@
+enum FeatureKey {
+  bankSync,
+  premiumInsights,
+  unlimitedBudgets,
+  unlimitedBillReminders,
+  exportData;
+
+  static FeatureKey? fromString(String value) {
+    final normalized = value.toLowerCase();
+    for (final key in FeatureKey.values) {
+      if (key.name.toLowerCase() == normalized) {
+        return key;
+      }
+    }
+    // Handle PascalCase from API (e.g., "BankSync" -> bankSync)
+    final camelCase = value[0].toLowerCase() + value.substring(1);
+    for (final key in FeatureKey.values) {
+      if (key.name == camelCase) {
+        return key;
+      }
+    }
+    return null;
+  }
+
+  String toApiString() {
+    // Convert camelCase to PascalCase for API
+    return name[0].toUpperCase() + name.substring(1);
+  }
+}

--- a/mobile/lib/features/subscriptions/domain/subscription_tier.dart
+++ b/mobile/lib/features/subscriptions/domain/subscription_tier.dart
@@ -1,0 +1,12 @@
+enum SubscriptionTier {
+  free,
+  trial,
+  premium;
+
+  static SubscriptionTier fromString(String value) {
+    return SubscriptionTier.values.firstWhere(
+      (tier) => tier.name.toLowerCase() == value.toLowerCase(),
+      orElse: () => SubscriptionTier.free,
+    );
+  }
+}

--- a/mobile/lib/features/subscriptions/infrastructure/subscription_gateway.dart
+++ b/mobile/lib/features/subscriptions/infrastructure/subscription_gateway.dart
@@ -1,0 +1,91 @@
+import 'dart:convert';
+import 'package:flutter/foundation.dart';
+import '../domain/entitlement_set.dart';
+
+class SubscriptionGateway {
+  SubscriptionGateway({
+    required Uri apiBaseUrl,
+    required String Function() tokenProvider,
+    @visibleForTesting HttpClientAdapter? httpClient,
+  })  : _apiBaseUrl = apiBaseUrl,
+        _tokenProvider = tokenProvider,
+        _httpClient = httpClient;
+
+  final Uri _apiBaseUrl;
+  final String Function() _tokenProvider;
+  final HttpClientAdapter? _httpClient;
+
+  Future<EntitlementSet> getEntitlements(String householdId) async {
+    final uri = _apiBaseUrl.replace(
+      path: '/subscriptions/entitlements',
+      queryParameters: {'householdId': householdId},
+    );
+
+    final response = await _performGet(uri);
+
+    if (response.statusCode != 200) {
+      throw SubscriptionGatewayException(
+        'Failed to fetch entitlements: ${response.statusCode}',
+      );
+    }
+
+    final body = jsonDecode(response.body) as Map<String, dynamic>;
+
+    final tier = body['tier'] as String;
+    final featureKeys = (body['featureKeys'] as List<dynamic>)
+        .map((e) => e as String)
+        .toList();
+    final trialExpiresAtUtc = body['trialExpiresAtUtc'] != null
+        ? DateTime.parse(body['trialExpiresAtUtc'] as String)
+        : null;
+    final currentPeriodEndUtc = body['currentPeriodEndUtc'] != null
+        ? DateTime.parse(body['currentPeriodEndUtc'] as String)
+        : null;
+
+    return EntitlementSet.fromApiResponse(
+      tier: tier,
+      featureKeys: featureKeys,
+      trialExpiresAtUtc: trialExpiresAtUtc,
+      currentPeriodEndUtc: currentPeriodEndUtc,
+    );
+  }
+
+  Future<HttpResponse> _performGet(Uri uri) async {
+    if (_httpClient != null) {
+      return _httpClient!.get(uri, headers: _buildHeaders());
+    }
+
+    // Default implementation would use dart:io HttpClient
+    // For now, throw if no adapter is provided (will be wired in app bootstrap)
+    throw UnimplementedError(
+      'HTTP client not configured. Provide an HttpClientAdapter.',
+    );
+  }
+
+  Map<String, String> _buildHeaders() {
+    return {
+      'Authorization': 'Bearer ${_tokenProvider()}',
+      'Content-Type': 'application/json',
+    };
+  }
+}
+
+class SubscriptionGatewayException implements Exception {
+  SubscriptionGatewayException(this.message);
+
+  final String message;
+
+  @override
+  String toString() => 'SubscriptionGatewayException: $message';
+}
+
+class HttpResponse {
+  const HttpResponse({required this.statusCode, required this.body});
+
+  final int statusCode;
+  final String body;
+}
+
+abstract class HttpClientAdapter {
+  Future<HttpResponse> get(Uri uri, {Map<String, String>? headers});
+}

--- a/mobile/lib/features/subscriptions/presentation/feature_gate.dart
+++ b/mobile/lib/features/subscriptions/presentation/feature_gate.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/widgets.dart';
+import '../application/entitlement_provider.dart';
+import '../domain/feature_key.dart';
+
+class FeatureGate extends StatelessWidget {
+  const FeatureGate({
+    super.key,
+    required this.feature,
+    required this.entitlementProvider,
+    required this.entitled,
+    required this.fallback,
+  });
+
+  final FeatureKey feature;
+  final EntitlementProvider entitlementProvider;
+  final Widget entitled;
+  final Widget fallback;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListenableBuilder(
+      listenable: entitlementProvider,
+      builder: (context, _) {
+        if (entitlementProvider.hasFeature(feature)) {
+          return entitled;
+        }
+        return fallback;
+      },
+    );
+  }
+}

--- a/mobile/test/unit/entitlement_provider_test.dart
+++ b/mobile/test/unit/entitlement_provider_test.dart
@@ -1,0 +1,170 @@
+import 'dart:convert';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:money_tracker/features/subscriptions/application/entitlement_provider.dart';
+import 'package:money_tracker/features/subscriptions/domain/entitlement_set.dart';
+import 'package:money_tracker/features/subscriptions/domain/feature_key.dart';
+import 'package:money_tracker/features/subscriptions/domain/subscription_tier.dart';
+import 'package:money_tracker/features/subscriptions/infrastructure/subscription_gateway.dart';
+
+class StubHttpClient implements HttpClientAdapter {
+  StubHttpClient({
+    required this.statusCode,
+    required this.responseBody,
+  });
+
+  final int statusCode;
+  final String responseBody;
+  int callCount = 0;
+
+  @override
+  Future<HttpResponse> get(Uri uri, {Map<String, String>? headers}) async {
+    callCount++;
+    return HttpResponse(statusCode: statusCode, body: responseBody);
+  }
+}
+
+void main() {
+  late StubHttpClient httpClient;
+  late SubscriptionGateway gateway;
+  late EntitlementProvider provider;
+
+  final premiumResponse = jsonEncode({
+    'tier': 'Premium',
+    'featureKeys': [
+      'BankSync',
+      'PremiumInsights',
+      'UnlimitedBudgets',
+      'UnlimitedBillReminders',
+      'ExportData',
+    ],
+    'trialExpiresAtUtc': null,
+    'currentPeriodEndUtc': '2026-04-01T00:00:00Z',
+  });
+
+  final freeResponse = jsonEncode({
+    'tier': 'Free',
+    'featureKeys': <String>[],
+    'trialExpiresAtUtc': null,
+    'currentPeriodEndUtc': null,
+  });
+
+  setUp(() {
+    httpClient = StubHttpClient(
+      statusCode: 200,
+      responseBody: premiumResponse,
+    );
+    gateway = SubscriptionGateway(
+      apiBaseUrl: Uri.parse('https://api.example.com'),
+      tokenProvider: () => 'test-token',
+      httpClient: httpClient,
+    );
+    provider = EntitlementProvider(
+      gateway: gateway,
+      cacheTtl: const Duration(minutes: 5),
+    );
+  });
+
+  group('EntitlementProvider', () {
+    test('starts with Free tier entitlements', () {
+      expect(provider.entitlements.tier, SubscriptionTier.free);
+      expect(provider.hasFeature(FeatureKey.bankSync), false);
+    });
+
+    test('fetchEntitlements returns entitlements from API', () async {
+      final result = await provider.fetchEntitlements('household-1');
+
+      expect(result.tier, SubscriptionTier.premium);
+      expect(result.hasFeature(FeatureKey.bankSync), true);
+      expect(result.hasFeature(FeatureKey.premiumInsights), true);
+      expect(result.hasFeature(FeatureKey.unlimitedBudgets), true);
+      expect(result.hasFeature(FeatureKey.unlimitedBillReminders), true);
+      expect(result.hasFeature(FeatureKey.exportData), true);
+      expect(httpClient.callCount, 1);
+    });
+
+    test('cache hit within TTL does not make API call', () async {
+      // P4-2-UNIT-08: EntitlementProvider cache hit within TTL returns cached result
+      await provider.fetchEntitlements('household-1');
+      expect(httpClient.callCount, 1);
+
+      // Second call should use cache
+      final result = await provider.fetchEntitlements('household-1');
+      expect(httpClient.callCount, 1);
+      expect(result.tier, SubscriptionTier.premium);
+    });
+
+    test('invalidateCache forces fresh API call', () async {
+      // P4-2-UNIT-09: EntitlementProvider cache miss after TTL makes API call
+      await provider.fetchEntitlements('household-1');
+      expect(httpClient.callCount, 1);
+
+      provider.invalidateCache();
+
+      await provider.fetchEntitlements('household-1');
+      expect(httpClient.callCount, 2);
+    });
+
+    test('hasFeature reflects current entitlements', () async {
+      expect(provider.hasFeature(FeatureKey.bankSync), false);
+
+      await provider.fetchEntitlements('household-1');
+
+      expect(provider.hasFeature(FeatureKey.bankSync), true);
+      expect(provider.hasFeature(FeatureKey.exportData), true);
+    });
+
+    test('notifies listeners on fetch', () async {
+      int notifyCount = 0;
+      provider.addListener(() => notifyCount++);
+
+      await provider.fetchEntitlements('household-1');
+
+      // Should notify at least twice: loading start and loading end
+      expect(notifyCount, greaterThanOrEqualTo(2));
+    });
+
+    test('isLoading is false after fetch completes', () async {
+      await provider.fetchEntitlements('household-1');
+
+      expect(provider.isLoading, false);
+    });
+  });
+
+  group('EntitlementSet.fromApiResponse', () {
+    test('parses premium response correctly', () {
+      final set = EntitlementSet.fromApiResponse(
+        tier: 'Premium',
+        featureKeys: ['BankSync', 'PremiumInsights', 'UnlimitedBudgets',
+            'UnlimitedBillReminders', 'ExportData'],
+      );
+
+      expect(set.tier, SubscriptionTier.premium);
+      expect(set.featureKeys.length, 5);
+      expect(set.hasFeature(FeatureKey.bankSync), true);
+    });
+
+    test('parses free response correctly', () {
+      final set = EntitlementSet.fromApiResponse(
+        tier: 'Free',
+        featureKeys: [],
+      );
+
+      expect(set.tier, SubscriptionTier.free);
+      expect(set.featureKeys.isEmpty, true);
+    });
+
+    test('parses trial response with expiry', () {
+      final expiry = DateTime.parse('2026-03-15T00:00:00Z');
+      final set = EntitlementSet.fromApiResponse(
+        tier: 'Trial',
+        featureKeys: ['BankSync', 'PremiumInsights', 'UnlimitedBudgets',
+            'UnlimitedBillReminders', 'ExportData'],
+        trialExpiresAtUtc: expiry,
+      );
+
+      expect(set.tier, SubscriptionTier.trial);
+      expect(set.trialExpiresAtUtc, expiry);
+      expect(set.featureKeys.length, 5);
+    });
+  });
+}

--- a/mobile/test/unit/feature_gate_test.dart
+++ b/mobile/test/unit/feature_gate_test.dart
@@ -1,0 +1,159 @@
+import 'dart:convert';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:money_tracker/features/subscriptions/application/entitlement_provider.dart';
+import 'package:money_tracker/features/subscriptions/domain/feature_key.dart';
+import 'package:money_tracker/features/subscriptions/infrastructure/subscription_gateway.dart';
+import 'package:money_tracker/features/subscriptions/presentation/feature_gate.dart';
+
+class StubHttpClient implements HttpClientAdapter {
+  StubHttpClient({required this.responseBody});
+
+  final String responseBody;
+
+  @override
+  Future<HttpResponse> get(Uri uri, {Map<String, String>? headers}) async {
+    return HttpResponse(statusCode: 200, body: responseBody);
+  }
+}
+
+void main() {
+  final premiumResponse = jsonEncode({
+    'tier': 'Premium',
+    'featureKeys': [
+      'BankSync',
+      'PremiumInsights',
+      'UnlimitedBudgets',
+      'UnlimitedBillReminders',
+      'ExportData',
+    ],
+    'trialExpiresAtUtc': null,
+    'currentPeriodEndUtc': '2026-04-01T00:00:00Z',
+  });
+
+  final freeResponse = jsonEncode({
+    'tier': 'Free',
+    'featureKeys': <String>[],
+    'trialExpiresAtUtc': null,
+    'currentPeriodEndUtc': null,
+  });
+
+  group('FeatureGate', () {
+    testWidgets('renders entitled widget when feature is available',
+        (tester) async {
+      // P4-2-UNIT-10: FeatureGate with entitled user renders premium content widget
+      final gateway = SubscriptionGateway(
+        apiBaseUrl: Uri.parse('https://api.example.com'),
+        tokenProvider: () => 'test-token',
+        httpClient: StubHttpClient(responseBody: premiumResponse),
+      );
+      final provider = EntitlementProvider(gateway: gateway);
+      addTearDown(provider.dispose);
+
+      await provider.fetchEntitlements('household-1');
+
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: FeatureGate(
+            feature: FeatureKey.bankSync,
+            entitlementProvider: provider,
+            entitled: const Text('Premium Content'),
+            fallback: const Text('Upgrade Now'),
+          ),
+        ),
+      );
+
+      expect(find.text('Premium Content'), findsOneWidget);
+      expect(find.text('Upgrade Now'), findsNothing);
+    });
+
+    testWidgets('renders fallback widget when feature is not available',
+        (tester) async {
+      // P4-2-UNIT-11: FeatureGate with non-entitled user renders upgrade CTA widget
+      final gateway = SubscriptionGateway(
+        apiBaseUrl: Uri.parse('https://api.example.com'),
+        tokenProvider: () => 'test-token',
+        httpClient: StubHttpClient(responseBody: freeResponse),
+      );
+      final provider = EntitlementProvider(gateway: gateway);
+      addTearDown(provider.dispose);
+
+      await provider.fetchEntitlements('household-1');
+
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: FeatureGate(
+            feature: FeatureKey.bankSync,
+            entitlementProvider: provider,
+            entitled: const Text('Premium Content'),
+            fallback: const Text('Upgrade Now'),
+          ),
+        ),
+      );
+
+      expect(find.text('Upgrade Now'), findsOneWidget);
+      expect(find.text('Premium Content'), findsNothing);
+    });
+
+    testWidgets('renders fallback by default before entitlements are fetched',
+        (tester) async {
+      final gateway = SubscriptionGateway(
+        apiBaseUrl: Uri.parse('https://api.example.com'),
+        tokenProvider: () => 'test-token',
+        httpClient: StubHttpClient(responseBody: premiumResponse),
+      );
+      final provider = EntitlementProvider(gateway: gateway);
+      addTearDown(provider.dispose);
+
+      // Do NOT fetch entitlements - should default to free
+
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: FeatureGate(
+            feature: FeatureKey.bankSync,
+            entitlementProvider: provider,
+            entitled: const Text('Premium Content'),
+            fallback: const Text('Upgrade Now'),
+          ),
+        ),
+      );
+
+      expect(find.text('Upgrade Now'), findsOneWidget);
+      expect(find.text('Premium Content'), findsNothing);
+    });
+
+    testWidgets('updates when entitlements change', (tester) async {
+      final gateway = SubscriptionGateway(
+        apiBaseUrl: Uri.parse('https://api.example.com'),
+        tokenProvider: () => 'test-token',
+        httpClient: StubHttpClient(responseBody: premiumResponse),
+      );
+      final provider = EntitlementProvider(gateway: gateway);
+      addTearDown(provider.dispose);
+
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: FeatureGate(
+            feature: FeatureKey.bankSync,
+            entitlementProvider: provider,
+            entitled: const Text('Premium Content'),
+            fallback: const Text('Upgrade Now'),
+          ),
+        ),
+      );
+
+      // Initially free
+      expect(find.text('Upgrade Now'), findsOneWidget);
+
+      // Fetch entitlements (becomes premium)
+      await provider.fetchEntitlements('household-1');
+      await tester.pump();
+
+      expect(find.text('Premium Content'), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Adds tier-based entitlement evaluation system (Free/Trial/Premium) that maps subscription state to feature keys
- Implements GET /subscriptions/entitlements endpoint with auth and household access checks
- Backend CheckFeatureAccessHandler for programmatic feature gating across modules
- SharedKernel ISubscriptionEntitlementService anti-corruption interface for cross-module use
- Mobile EntitlementProvider with configurable cache TTL for responsive UI
- Mobile FeatureGate widget for conditional rendering based on entitlements

## Changes
- Backend: FeatureKey enum, SubscriptionTier enum, EntitlementSet value object
- Backend: GetEntitlements and CheckFeatureAccess handlers
- Backend: SubscriptionEntitlementService implementation
- Backend: SharedKernel ISubscriptionEntitlementService interface
- Mobile: Subscription feature with entitlement provider, gateway, and FeatureGate widget

## Test Evidence
- Backend: 85 subscription tests passing (32 new)
- Mobile: 44 tests passing (14 new)
- All existing tests continue to pass

## Risk Notes
- Additive changes only
- Builds on P4-1 Subscription entity from PR #89

Closes #76