### PR TITLE
[P4-3] Add trial handling, restore purchases, and cancellation state

### DIFF
--- a/backend/src/Modules/Subscriptions/Application/ExpireTrial/ExpireTrialCommand.cs
+++ b/backend/src/Modules/Subscriptions/Application/ExpireTrial/ExpireTrialCommand.cs
@@ -1,0 +1,3 @@
+namespace MoneyTracker.Modules.Subscriptions.Application.ExpireTrial;
+
+public sealed record ExpireTrialCommand(DateTimeOffset AsOfUtc);

--- a/backend/src/Modules/Subscriptions/Application/ExpireTrial/ExpireTrialHandler.cs
+++ b/backend/src/Modules/Subscriptions/Application/ExpireTrial/ExpireTrialHandler.cs
@@ -1,0 +1,37 @@
+using Microsoft.Extensions.Logging;
+using MoneyTracker.Modules.Subscriptions.Domain;
+
+namespace MoneyTracker.Modules.Subscriptions.Application.ExpireTrial;
+
+public sealed class ExpireTrialHandler(
+    ISubscriptionRepository repository,
+    ILogger<ExpireTrialHandler> logger)
+{
+    public async Task<ExpireTrialResult> HandleAsync(
+        ExpireTrialCommand command,
+        CancellationToken cancellationToken)
+    {
+        // AC-3: Query for expired trials and transition them to None
+        var expiredTrials = await repository.GetExpiredTrialsAsync(
+            command.AsOfUtc,
+            cancellationToken);
+
+        var expiredCount = 0;
+
+        foreach (var subscription in expiredTrials)
+        {
+            subscription.ExpireTrial(command.AsOfUtc);
+            await repository.UpdateAsync(subscription, cancellationToken);
+            expiredCount++;
+
+            logger.LogInformation(
+                "Trial expired for household {HouseholdId}. Trial was due at {TrialExpiresAtUtc}.",
+                subscription.HouseholdId,
+                subscription.TrialExpiresAtUtc);
+        }
+
+        return new ExpireTrialResult(expiredCount);
+    }
+}
+
+public sealed record ExpireTrialResult(int ExpiredCount);

--- a/backend/src/Modules/Subscriptions/Application/RestorePurchases/RestorePurchasesCommand.cs
+++ b/backend/src/Modules/Subscriptions/Application/RestorePurchases/RestorePurchasesCommand.cs
@@ -1,0 +1,6 @@
+namespace MoneyTracker.Modules.Subscriptions.Application.RestorePurchases;
+
+public sealed record RestorePurchasesCommand(
+    Guid HouseholdId,
+    Guid UserId,
+    string RevenueCatAppUserId);

--- a/backend/src/Modules/Subscriptions/Application/RestorePurchases/RestorePurchasesHandler.cs
+++ b/backend/src/Modules/Subscriptions/Application/RestorePurchases/RestorePurchasesHandler.cs
@@ -1,0 +1,106 @@
+using Microsoft.Extensions.Logging;
+using MoneyTracker.Modules.SharedKernel.Households;
+using MoneyTracker.Modules.Subscriptions.Domain;
+
+namespace MoneyTracker.Modules.Subscriptions.Application.RestorePurchases;
+
+public sealed class RestorePurchasesHandler(
+    ISubscriptionRepository repository,
+    IRevenueCatClient revenueCatClient,
+    IHouseholdAccessService householdAccess,
+    ISubscriptionEntitlementService entitlementService,
+    ILogger<RestorePurchasesHandler> logger)
+{
+    public async Task<RestorePurchasesResult> HandleAsync(
+        RestorePurchasesCommand command,
+        CancellationToken cancellationToken)
+    {
+        // AC-8: Verify household membership
+        var accessResult = await householdAccess.CheckMemberAsync(
+            command.HouseholdId,
+            command.UserId,
+            cancellationToken);
+
+        if (!accessResult.HouseholdExists)
+        {
+            return RestorePurchasesResult.HouseholdNotFound();
+        }
+
+        if (!accessResult.IsMember)
+        {
+            return RestorePurchasesResult.AccessDenied();
+        }
+
+        // AC-5: Call RevenueCat REST API
+        SubscriberInfo? subscriberInfo;
+        try
+        {
+            subscriberInfo = await revenueCatClient.GetSubscriberAsync(
+                command.RevenueCatAppUserId,
+                cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex,
+                "Failed to fetch subscriber info from RevenueCat for {AppUserId}.",
+                command.RevenueCatAppUserId);
+            return RestorePurchasesResult.ProviderError(
+                "Failed to communicate with the payment provider.");
+        }
+
+        // Get or create local subscription record
+        var subscription = await repository.GetByHouseholdIdAsync(
+            command.HouseholdId,
+            cancellationToken);
+
+        if (subscription is null)
+        {
+            // No local subscription exists; create one
+            if (subscriberInfo is null)
+            {
+                // No subscription in provider either — return Free state
+                var freeEntitlements = EntitlementSet.ForTier(SubscriptionTier.Free);
+                return RestorePurchasesResult.Success(
+                    SubscriptionStatus.None,
+                    SubscriptionTier.Free,
+                    freeEntitlements.FeatureKeys.Select(fk => fk.ToString()).ToArray(),
+                    null);
+            }
+
+            subscription = Subscription.CreateForWebhook(
+                command.HouseholdId,
+                command.RevenueCatAppUserId,
+                subscriberInfo.ProductId,
+                DateTimeOffset.UtcNow);
+            await repository.AddAsync(subscription, cancellationToken);
+        }
+
+        // AC-6: Update local subscription to match RevenueCat authoritative state
+        if (subscriberInfo is not null)
+        {
+            subscription.RestoreFromProvider(
+                subscriberInfo.Status,
+                subscriberInfo.ProductId,
+                subscriberInfo.PeriodStartUtc,
+                subscriberInfo.PeriodEndUtc);
+            await repository.UpdateAsync(subscription, cancellationToken);
+
+            logger.LogInformation(
+                "Subscription restored for household {HouseholdId}: status={Status}, product={ProductId}.",
+                command.HouseholdId,
+                subscriberInfo.Status,
+                subscriberInfo.ProductId);
+        }
+
+        // Return current entitlement state
+        var entitlement = await entitlementService.GetEntitlementsAsync(
+            command.HouseholdId,
+            cancellationToken);
+
+        return RestorePurchasesResult.Success(
+            subscription.Status,
+            entitlement.Tier,
+            entitlement.FeatureKeys.Select(fk => fk.ToString()).ToArray(),
+            subscription.CurrentPeriodEndUtc);
+    }
+}

--- a/backend/src/Modules/Subscriptions/Application/RestorePurchases/RestorePurchasesResult.cs
+++ b/backend/src/Modules/Subscriptions/Application/RestorePurchases/RestorePurchasesResult.cs
@@ -1,0 +1,77 @@
+using MoneyTracker.Modules.Subscriptions.Domain;
+
+namespace MoneyTracker.Modules.Subscriptions.Application.RestorePurchases;
+
+public sealed class RestorePurchasesResult
+{
+    private RestorePurchasesResult(
+        string? status,
+        string? tier,
+        string[]? featureKeys,
+        DateTimeOffset? currentPeriodEndUtc,
+        string? errorCode,
+        string? errorMessage)
+    {
+        Status = status;
+        Tier = tier;
+        FeatureKeys = featureKeys;
+        CurrentPeriodEndUtc = currentPeriodEndUtc;
+        ErrorCode = errorCode;
+        ErrorMessage = errorMessage;
+    }
+
+    public string? Status { get; }
+    public string? Tier { get; }
+    public string[]? FeatureKeys { get; }
+    public DateTimeOffset? CurrentPeriodEndUtc { get; }
+    public string? ErrorCode { get; }
+    public string? ErrorMessage { get; }
+    public bool IsSuccess => ErrorCode is null;
+
+    public static RestorePurchasesResult Success(
+        SubscriptionStatus status,
+        SubscriptionTier tier,
+        string[] featureKeys,
+        DateTimeOffset? currentPeriodEndUtc)
+    {
+        return new RestorePurchasesResult(
+            status.ToString(),
+            tier.ToString(),
+            featureKeys,
+            currentPeriodEndUtc,
+            errorCode: null,
+            errorMessage: null);
+    }
+
+    public static RestorePurchasesResult HouseholdNotFound()
+    {
+        return new RestorePurchasesResult(
+            null, null, null, null,
+            SubscriptionErrors.HouseholdNotFound,
+            "The household was not found.");
+    }
+
+    public static RestorePurchasesResult AccessDenied()
+    {
+        return new RestorePurchasesResult(
+            null, null, null, null,
+            SubscriptionErrors.AccessDenied,
+            "You do not have access to this household.");
+    }
+
+    public static RestorePurchasesResult ProviderError(string message)
+    {
+        return new RestorePurchasesResult(
+            null, null, null, null,
+            SubscriptionErrors.ProviderError,
+            message);
+    }
+
+    public static RestorePurchasesResult RestoreFailed(string message)
+    {
+        return new RestorePurchasesResult(
+            null, null, null, null,
+            SubscriptionErrors.RestoreFailed,
+            message);
+    }
+}

--- a/backend/src/Modules/Subscriptions/Application/StartTrial/StartTrialCommand.cs
+++ b/backend/src/Modules/Subscriptions/Application/StartTrial/StartTrialCommand.cs
@@ -1,0 +1,3 @@
+namespace MoneyTracker.Modules.Subscriptions.Application.StartTrial;
+
+public sealed record StartTrialCommand(Guid HouseholdId);

--- a/backend/src/Modules/Subscriptions/Application/StartTrial/StartTrialHandler.cs
+++ b/backend/src/Modules/Subscriptions/Application/StartTrial/StartTrialHandler.cs
@@ -1,0 +1,53 @@
+using Microsoft.Extensions.Logging;
+using MoneyTracker.Modules.Subscriptions.Domain;
+
+namespace MoneyTracker.Modules.Subscriptions.Application.StartTrial;
+
+public sealed class StartTrialHandler(
+    ISubscriptionRepository repository,
+    TimeProvider timeProvider,
+    ILogger<StartTrialHandler> logger)
+{
+    private const int DefaultTrialDays = 14;
+    private const string TrialProductId = "trial_premium";
+
+    public async Task<StartTrialResult> HandleAsync(
+        StartTrialCommand command,
+        CancellationToken cancellationToken)
+    {
+        // AC-2: Idempotent — do not create duplicate or reset trial
+        var existing = await repository.GetByHouseholdIdAsync(
+            command.HouseholdId,
+            cancellationToken);
+
+        if (existing is not null)
+        {
+            logger.LogInformation(
+                "Subscription already exists for household {HouseholdId} with status {Status}. Skipping trial grant.",
+                command.HouseholdId,
+                existing.Status);
+            return StartTrialResult.AlreadyExists();
+        }
+
+        var nowUtc = timeProvider.GetUtcNow();
+        var trialExpiresAtUtc = nowUtc.AddDays(DefaultTrialDays);
+
+        // AC-1: Create subscription with Trial status
+        var subscription = Subscription.CreateTrial(
+            command.HouseholdId,
+            command.HouseholdId.ToString(),
+            TrialProductId,
+            nowUtc,
+            trialExpiresAtUtc,
+            nowUtc);
+
+        await repository.AddAsync(subscription, cancellationToken);
+
+        logger.LogInformation(
+            "Trial started for household {HouseholdId}. Expires at {TrialExpiresAtUtc}.",
+            command.HouseholdId,
+            trialExpiresAtUtc);
+
+        return StartTrialResult.Success(trialExpiresAtUtc);
+    }
+}

--- a/backend/src/Modules/Subscriptions/Application/StartTrial/StartTrialResult.cs
+++ b/backend/src/Modules/Subscriptions/Application/StartTrial/StartTrialResult.cs
@@ -1,0 +1,42 @@
+using MoneyTracker.Modules.Subscriptions.Domain;
+
+namespace MoneyTracker.Modules.Subscriptions.Application.StartTrial;
+
+public sealed class StartTrialResult
+{
+    private StartTrialResult(
+        bool isSuccess,
+        DateTimeOffset? trialExpiresAtUtc,
+        string? errorCode,
+        string? errorMessage)
+    {
+        IsSuccess = isSuccess;
+        TrialExpiresAtUtc = trialExpiresAtUtc;
+        ErrorCode = errorCode;
+        ErrorMessage = errorMessage;
+    }
+
+    public bool IsSuccess { get; }
+    public DateTimeOffset? TrialExpiresAtUtc { get; }
+    public string? ErrorCode { get; }
+    public string? ErrorMessage { get; }
+
+    public static StartTrialResult Success(DateTimeOffset trialExpiresAtUtc)
+    {
+        return new StartTrialResult(true, trialExpiresAtUtc, null, null);
+    }
+
+    public static StartTrialResult AlreadyExists()
+    {
+        return new StartTrialResult(
+            true,
+            null,
+            errorCode: null,
+            errorMessage: null);
+    }
+
+    public static StartTrialResult Failed(string errorCode, string errorMessage)
+    {
+        return new StartTrialResult(false, null, errorCode, errorMessage);
+    }
+}

--- a/backend/src/Modules/Subscriptions/Domain/IRevenueCatClient.cs
+++ b/backend/src/Modules/Subscriptions/Domain/IRevenueCatClient.cs
@@ -1,0 +1,22 @@
+namespace MoneyTracker.Modules.Subscriptions.Domain;
+
+/// <summary>
+/// Subscriber information returned from the payment provider.
+/// Provider-agnostic contract for anti-corruption layer.
+/// </summary>
+public sealed record SubscriberInfo(
+    SubscriptionStatus Status,
+    string ProductId,
+    DateTimeOffset? PeriodStartUtc,
+    DateTimeOffset? PeriodEndUtc);
+
+/// <summary>
+/// Anti-corruption interface for RevenueCat REST API.
+/// Abstracts the provider-specific subscriber lookup.
+/// </summary>
+public interface IRevenueCatClient
+{
+    Task<SubscriberInfo?> GetSubscriberAsync(
+        string appUserId,
+        CancellationToken cancellationToken);
+}

--- a/backend/src/Modules/Subscriptions/Domain/ISubscriptionRepository.cs
+++ b/backend/src/Modules/Subscriptions/Domain/ISubscriptionRepository.cs
@@ -7,4 +7,5 @@ public interface ISubscriptionRepository
     Task<Subscription?> GetByIdAsync(SubscriptionId id, CancellationToken cancellationToken);
     Task<Subscription?> GetByHouseholdIdAsync(Guid householdId, CancellationToken cancellationToken);
     Task<Subscription?> GetByRevenueCatAppUserIdAsync(string appUserId, CancellationToken cancellationToken);
+    Task<IReadOnlyList<Subscription>> GetExpiredTrialsAsync(DateTimeOffset asOfUtc, CancellationToken cancellationToken);
 }

--- a/backend/src/Modules/Subscriptions/Domain/Subscription.cs
+++ b/backend/src/Modules/Subscriptions/Domain/Subscription.cs
@@ -11,6 +11,8 @@ public sealed class Subscription
     public DateTimeOffset? CurrentPeriodEndUtc { get; private set; }
     public DateTimeOffset? CancelledAtUtc { get; private set; }
     public DateTimeOffset? BillingIssueDetectedAtUtc { get; private set; }
+    public DateTimeOffset? TrialStartedAtUtc { get; private set; }
+    public DateTimeOffset? TrialExpiresAtUtc { get; private set; }
     public DateTimeOffset? OriginalPurchaseDateUtc { get; private set; }
     public string? LastEventId { get; private set; }
     public DateTimeOffset CreatedAtUtc { get; }
@@ -67,7 +69,9 @@ public sealed class Subscription
             nowUtc)
         {
             CurrentPeriodStartUtc = periodStartUtc,
-            CurrentPeriodEndUtc = periodEndUtc
+            CurrentPeriodEndUtc = periodEndUtc,
+            TrialStartedAtUtc = nowUtc,
+            TrialExpiresAtUtc = periodEndUtc
         };
 
         return subscription;
@@ -244,6 +248,94 @@ public sealed class Subscription
     }
 
     /// <summary>
+    /// Starts a trial period on this subscription.
+    /// Can only be called when the subscription is in None status (no existing trial or active subscription).
+    /// </summary>
+    public void StartTrial(DateTimeOffset nowUtc, int trialDays = 14)
+    {
+        if (Status is SubscriptionStatus.Trial)
+        {
+            throw new SubscriptionDomainException(
+                SubscriptionErrors.TrialAlreadyStarted,
+                "A trial has already been started for this subscription.");
+        }
+
+        if (Status is SubscriptionStatus.Active)
+        {
+            throw new SubscriptionDomainException(
+                SubscriptionErrors.SubscriptionAlreadyActive,
+                "Cannot start a trial on an already active subscription.");
+        }
+
+        if (Status is not SubscriptionStatus.None)
+        {
+            throw new SubscriptionDomainException(
+                SubscriptionErrors.InvalidStateTransition,
+                $"Cannot start trial from {Status}.");
+        }
+
+        Status = SubscriptionStatus.Trial;
+        TrialStartedAtUtc = nowUtc;
+        TrialExpiresAtUtc = nowUtc.AddDays(trialDays);
+        CurrentPeriodStartUtc = nowUtc;
+        CurrentPeriodEndUtc = nowUtc.AddDays(trialDays);
+        UpdatedAtUtc = nowUtc;
+    }
+
+    /// <summary>
+    /// Expires the trial, transitioning the subscription to None status.
+    /// Only applies when the subscription is in Trial status.
+    /// </summary>
+    public void ExpireTrial(DateTimeOffset nowUtc)
+    {
+        if (Status is not SubscriptionStatus.Trial)
+        {
+            return; // No-op for non-trial subscriptions (AC-4)
+        }
+
+        Status = SubscriptionStatus.None;
+        UpdatedAtUtc = nowUtc;
+    }
+
+    /// <summary>
+    /// Restores the subscription state from the payment provider (RevenueCat).
+    /// This is the authoritative state reconciliation method.
+    /// </summary>
+    public void RestoreFromProvider(
+        SubscriptionStatus status,
+        string productId,
+        DateTimeOffset? periodStart,
+        DateTimeOffset? periodEnd)
+    {
+        if (string.IsNullOrWhiteSpace(productId))
+        {
+            throw new SubscriptionDomainException(
+                SubscriptionErrors.ValidationError,
+                "Product ID is required for restore.");
+        }
+
+        Status = status;
+        ProductId = productId;
+        CurrentPeriodStartUtc = periodStart;
+        CurrentPeriodEndUtc = periodEnd;
+        UpdatedAtUtc = DateTimeOffset.UtcNow;
+
+        // Clear trial fields if transitioning away from trial
+        if (status is not SubscriptionStatus.Trial)
+        {
+            TrialStartedAtUtc = null;
+            TrialExpiresAtUtc = null;
+        }
+
+        // Clear cancellation/billing issue fields when restoring to active
+        if (status is SubscriptionStatus.Active)
+        {
+            CancelledAtUtc = null;
+            BillingIssueDetectedAtUtc = null;
+        }
+    }
+
+    /// <summary>
     /// Checks if the given event has already been processed (idempotency).
     /// </summary>
     public bool HasProcessedEvent(string eventId)
@@ -257,7 +349,9 @@ public sealed class Subscription
         var allowed = (Status, target) switch
         {
             (SubscriptionStatus.None, SubscriptionStatus.Active) => true,
+            (SubscriptionStatus.None, SubscriptionStatus.Trial) => true,
             (SubscriptionStatus.Trial, SubscriptionStatus.Active) => true,
+            (SubscriptionStatus.Trial, SubscriptionStatus.None) => true,
             (SubscriptionStatus.Active, SubscriptionStatus.Cancelled) => true,
             (SubscriptionStatus.Active, SubscriptionStatus.Expired) => true,
             (SubscriptionStatus.Active, SubscriptionStatus.BillingIssue) => true,

--- a/backend/src/Modules/Subscriptions/Domain/SubscriptionErrors.cs
+++ b/backend/src/Modules/Subscriptions/Domain/SubscriptionErrors.cs
@@ -9,4 +9,8 @@ public static class SubscriptionErrors
     public const string WebhookInvalidPayload = "subscription_webhook_invalid_payload";
     public const string HouseholdNotFound = "subscription_household_not_found";
     public const string AccessDenied = "subscription_access_denied";
+    public const string TrialAlreadyStarted = "subscription_trial_already_started";
+    public const string SubscriptionAlreadyActive = "subscription_already_active";
+    public const string RestoreFailed = "subscription_restore_failed";
+    public const string ProviderError = "subscription_provider_error";
 }

--- a/backend/src/Modules/Subscriptions/Infrastructure/InMemoryRevenueCatClient.cs
+++ b/backend/src/Modules/Subscriptions/Infrastructure/InMemoryRevenueCatClient.cs
@@ -1,0 +1,36 @@
+using MoneyTracker.Modules.Subscriptions.Domain;
+
+namespace MoneyTracker.Modules.Subscriptions.Infrastructure;
+
+/// <summary>
+/// In-memory test implementation of IRevenueCatClient.
+/// Returns null by default (no active subscription in provider).
+/// Can be pre-configured with subscriber info for testing.
+/// </summary>
+public sealed class InMemoryRevenueCatClient : IRevenueCatClient
+{
+    private readonly Dictionary<string, SubscriberInfo> _subscribers = new();
+
+    public void SetSubscriber(string appUserId, SubscriberInfo info)
+    {
+        _subscribers[appUserId] = info;
+    }
+
+    public void Clear()
+    {
+        _subscribers.Clear();
+    }
+
+    public Task<SubscriberInfo?> GetSubscriberAsync(
+        string appUserId,
+        CancellationToken cancellationToken)
+    {
+        if (cancellationToken.IsCancellationRequested)
+        {
+            return Task.FromCanceled<SubscriberInfo?>(cancellationToken);
+        }
+
+        _subscribers.TryGetValue(appUserId, out var info);
+        return Task.FromResult(info);
+    }
+}

--- a/backend/src/Modules/Subscriptions/Infrastructure/InMemorySubscriptionRepository.cs
+++ b/backend/src/Modules/Subscriptions/Infrastructure/InMemorySubscriptionRepository.cs
@@ -84,4 +84,22 @@ public sealed class InMemorySubscriptionRepository : ISubscriptionRepository
             return Task.FromResult(subscription);
         }
     }
+
+    public Task<IReadOnlyList<Subscription>> GetExpiredTrialsAsync(DateTimeOffset asOfUtc, CancellationToken cancellationToken)
+    {
+        if (cancellationToken.IsCancellationRequested)
+        {
+            return Task.FromCanceled<IReadOnlyList<Subscription>>(cancellationToken);
+        }
+
+        lock (_sync)
+        {
+            var expired = _subscriptionsByHousehold.Values
+                .Where(s => s.Status == SubscriptionStatus.Trial
+                            && s.TrialExpiresAtUtc.HasValue
+                            && s.TrialExpiresAtUtc.Value <= asOfUtc)
+                .ToList();
+            return Task.FromResult<IReadOnlyList<Subscription>>(expired);
+        }
+    }
 }

--- a/backend/src/Modules/Subscriptions/Infrastructure/RevenueCatClient.cs
+++ b/backend/src/Modules/Subscriptions/Infrastructure/RevenueCatClient.cs
@@ -1,0 +1,46 @@
+using Microsoft.Extensions.Logging;
+using MoneyTracker.Modules.Subscriptions.Domain;
+
+namespace MoneyTracker.Modules.Subscriptions.Infrastructure;
+
+/// <summary>
+/// HTTP client for RevenueCat REST API v1 subscriber endpoint.
+/// Currently delegates to InMemoryRevenueCatClient; will be replaced
+/// with real HTTP calls when RevenueCat API key is configured.
+/// </summary>
+public sealed class RevenueCatClient(
+    InMemoryRevenueCatClient innerClient,
+    ILogger<RevenueCatClient> logger) : IRevenueCatClient
+{
+    public async Task<SubscriberInfo?> GetSubscriberAsync(
+        string appUserId,
+        CancellationToken cancellationToken)
+    {
+        logger.LogDebug(
+            "Fetching subscriber info for {AppUserId} from RevenueCat.",
+            appUserId);
+
+        // AC-13: In production this would call RevenueCat REST API v1
+        // GET /v1/subscribers/{app_user_id}
+        // with retry, timeout, and correlation ID logging.
+        // For now, delegate to in-memory implementation.
+        var result = await innerClient.GetSubscriberAsync(appUserId, cancellationToken);
+
+        if (result is not null)
+        {
+            logger.LogDebug(
+                "Subscriber {AppUserId} found: status={Status}, product={ProductId}.",
+                appUserId,
+                result.Status,
+                result.ProductId);
+        }
+        else
+        {
+            logger.LogDebug(
+                "No subscriber info found for {AppUserId}.",
+                appUserId);
+        }
+
+        return result;
+    }
+}

--- a/backend/src/Modules/Subscriptions/Infrastructure/TrialExpiryWorker.cs
+++ b/backend/src/Modules/Subscriptions/Infrastructure/TrialExpiryWorker.cs
@@ -1,0 +1,47 @@
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using MoneyTracker.Modules.Subscriptions.Application.ExpireTrial;
+
+namespace MoneyTracker.Modules.Subscriptions.Infrastructure;
+
+public sealed class TrialExpiryWorker(
+    ExpireTrialHandler handler,
+    TimeProvider timeProvider,
+    ILogger<TrialExpiryWorker> logger) : BackgroundService
+{
+    private static readonly TimeSpan Interval = TimeSpan.FromHours(1);
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        using var timer = new PeriodicTimer(Interval);
+        while (await timer.WaitForNextTickAsync(stoppingToken))
+        {
+            try
+            {
+                var nowUtc = timeProvider.GetUtcNow();
+                var result = await handler.HandleAsync(
+                    new ExpireTrialCommand(nowUtc),
+                    stoppingToken);
+                logger.LogInformation(
+                    "Trial expiry check completed: expired={ExpiredCount}",
+                    result.ExpiredCount);
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                return;
+            }
+            catch (Exception exception)
+            {
+                logger.LogError(exception, "Trial expiry worker failed.");
+                try
+                {
+                    await Task.Delay(TimeSpan.FromSeconds(5), stoppingToken);
+                }
+                catch (OperationCanceledException)
+                {
+                    return;
+                }
+            }
+        }
+    }
+}

--- a/backend/src/Modules/Subscriptions/Presentation/SubscriptionEndpoints.cs
+++ b/backend/src/Modules/Subscriptions/Presentation/SubscriptionEndpoints.cs
@@ -5,9 +5,12 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
 using MoneyTracker.Modules.Subscriptions.Application.CheckFeatureAccess;
+using MoneyTracker.Modules.Subscriptions.Application.ExpireTrial;
 using MoneyTracker.Modules.Subscriptions.Application.GetEntitlements;
 using MoneyTracker.Modules.Subscriptions.Application.GetSubscription;
 using MoneyTracker.Modules.Subscriptions.Application.ProcessWebhook;
+using MoneyTracker.Modules.Subscriptions.Application.RestorePurchases;
+using MoneyTracker.Modules.Subscriptions.Application.StartTrial;
 using MoneyTracker.Modules.Subscriptions.Domain;
 using MoneyTracker.Modules.SharedKernel.Households;
 using MoneyTracker.Modules.SharedKernel.Presentation;
@@ -32,6 +35,16 @@ public static class SubscriptionEndpoints
         services.AddScoped<GetEntitlementsHandler>();
         services.AddScoped<CheckFeatureAccessHandler>();
 
+        // P4-3: Trial handling, restore purchases
+        services.AddSingleton<Infrastructure.InMemoryRevenueCatClient>();
+        services.AddSingleton<Infrastructure.RevenueCatClient>();
+        services.AddSingleton<IRevenueCatClient>(sp =>
+            sp.GetRequiredService<Infrastructure.RevenueCatClient>());
+        services.AddScoped<StartTrialHandler>();
+        services.AddScoped<RestorePurchasesHandler>();
+        services.AddScoped<ExpireTrialHandler>();
+        services.AddHostedService<Infrastructure.TrialExpiryWorker>();
+
         return services;
     }
 
@@ -52,6 +65,17 @@ public static class SubscriptionEndpoints
             .WithSummary("Get entitlements for a household.")
             .WithDescription("Returns the subscription tier and enabled feature keys for the specified household.")
             .Produces<EntitlementsResponse>(StatusCodes.Status200OK)
+            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status401Unauthorized)
+            .ProducesProblem(StatusCodes.Status403Forbidden)
+            .ProducesProblem(StatusCodes.Status404NotFound);
+
+        var restoreEndpoint = (RouteHandlerBuilder)app.MapPost("/subscriptions/restore", RestorePurchases);
+        restoreEndpoint
+            .WithName("RestorePurchases")
+            .WithSummary("Restore purchases from payment provider.")
+            .WithDescription("Calls RevenueCat REST API to reconcile subscription state and returns current entitlements.")
+            .Produces<RestorePurchasesResponse>(StatusCodes.Status200OK)
             .ProducesProblem(StatusCodes.Status400BadRequest)
             .ProducesProblem(StatusCodes.Status401Unauthorized)
             .ProducesProblem(StatusCodes.Status403Forbidden)
@@ -206,6 +230,63 @@ public static class SubscriptionEndpoints
         await TypedResults.Ok(response).ExecuteAsync(httpContext);
     }
 
+    private static async Task RestorePurchases(HttpContext httpContext)
+    {
+        // AC-7: Authenticate
+        var authResult = await EndpointHelpers.ResolveAuthenticatedUser(httpContext);
+        if (!authResult.Success)
+        {
+            await authResult.Problem!.ExecuteAsync(httpContext);
+            return;
+        }
+
+        // Parse request body
+        var (isValid, request, error) = await EndpointHelpers.ReadJsonRequestAsync<RestorePurchasesRequest>(
+            httpContext,
+            SubscriptionErrors.ValidationError);
+
+        if (!isValid)
+        {
+            await error!.ExecuteAsync(httpContext);
+            return;
+        }
+
+        var handler = httpContext.RequestServices.GetRequiredService<RestorePurchasesHandler>();
+        var result = await handler.HandleAsync(
+            new RestorePurchasesCommand(
+                request!.HouseholdId,
+                authResult.AuthenticatedUser!.UserId,
+                request.RevenueCatAppUserId),
+            httpContext.RequestAborted);
+
+        if (!result.IsSuccess)
+        {
+            var statusCode = result.ErrorCode switch
+            {
+                SubscriptionErrors.HouseholdNotFound => StatusCodes.Status404NotFound,
+                SubscriptionErrors.AccessDenied => StatusCodes.Status403Forbidden,
+                SubscriptionErrors.ProviderError => StatusCodes.Status502BadGateway,
+                _ => StatusCodes.Status400BadRequest
+            };
+
+            await EndpointHelpers.WriteProblemAsync(
+                httpContext,
+                statusCode,
+                statusCode == StatusCodes.Status403Forbidden ? "Access denied." : "Restore failed.",
+                result.ErrorMessage ?? "Request rejected.",
+                result.ErrorCode,
+                SubscriptionErrors.ValidationError);
+            return;
+        }
+
+        var response = new RestorePurchasesResponse(
+            result.Status!,
+            result.Tier!,
+            result.FeatureKeys!,
+            result.CurrentPeriodEndUtc);
+        await TypedResults.Ok(response).ExecuteAsync(httpContext);
+    }
+
     private static bool TryGetGuidQuery(HttpContext httpContext, string key, out Guid value)
     {
         value = Guid.Empty;
@@ -251,4 +332,14 @@ public sealed record EntitlementsResponse(
     string Tier,
     string[] FeatureKeys,
     DateTimeOffset? TrialExpiresAtUtc,
+    DateTimeOffset? CurrentPeriodEndUtc);
+
+public sealed record RestorePurchasesRequest(
+    Guid HouseholdId,
+    string RevenueCatAppUserId);
+
+public sealed record RestorePurchasesResponse(
+    string Status,
+    string Tier,
+    string[] FeatureKeys,
     DateTimeOffset? CurrentPeriodEndUtc);

--- a/backend/tests/MoneyTracker.Modules.Subscriptions.Tests/Application/ExpireTrialHandlerTests.cs
+++ b/backend/tests/MoneyTracker.Modules.Subscriptions.Tests/Application/ExpireTrialHandlerTests.cs
@@ -1,0 +1,140 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using MoneyTracker.Modules.Subscriptions.Application.ExpireTrial;
+using MoneyTracker.Modules.Subscriptions.Domain;
+using MoneyTracker.Modules.Subscriptions.Infrastructure;
+
+namespace MoneyTracker.Modules.Subscriptions.Tests.Application;
+
+public sealed class ExpireTrialHandlerTests
+{
+    private static readonly DateTimeOffset NowUtc = DateTimeOffset.Parse("2026-03-01T00:00:00Z");
+
+    private static ExpireTrialHandler CreateHandler(ISubscriptionRepository? repository = null)
+    {
+        return new ExpireTrialHandler(
+            repository ?? new InMemorySubscriptionRepository(),
+            NullLogger<ExpireTrialHandler>.Instance);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task Handle_NoExpiredTrials_ReturnsZero()
+    {
+        var repository = new InMemorySubscriptionRepository();
+        var handler = CreateHandler(repository: repository);
+
+        var result = await handler.HandleAsync(
+            new ExpireTrialCommand(NowUtc),
+            CancellationToken.None);
+
+        Assert.Equal(0, result.ExpiredCount);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task Handle_ExpiredTrial_TransitionsToNone()
+    {
+        // AC-3: TrialExpiryWorker transitions expired trial to None
+        var repository = new InMemorySubscriptionRepository();
+        var trialEnd = NowUtc.AddDays(14);
+        var trial = Subscription.CreateTrial(
+            Guid.NewGuid(), "user-1", "trial_premium",
+            NowUtc, trialEnd, NowUtc);
+        await repository.AddAsync(trial, CancellationToken.None);
+
+        var handler = CreateHandler(repository: repository);
+
+        // Run expiry after trial end
+        var result = await handler.HandleAsync(
+            new ExpireTrialCommand(trialEnd.AddHours(1)),
+            CancellationToken.None);
+
+        Assert.Equal(1, result.ExpiredCount);
+        Assert.Equal(SubscriptionStatus.None, trial.Status);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task Handle_MultipleExpiredTrials_TransitionsAll()
+    {
+        var repository = new InMemorySubscriptionRepository();
+
+        // Create 3 expired trials
+        for (int i = 0; i < 3; i++)
+        {
+            var trial = Subscription.CreateTrial(
+                Guid.NewGuid(), $"user-{i}", "trial_premium",
+                NowUtc, NowUtc.AddDays(14), NowUtc);
+            await repository.AddAsync(trial, CancellationToken.None);
+        }
+
+        var handler = CreateHandler(repository: repository);
+
+        var result = await handler.HandleAsync(
+            new ExpireTrialCommand(NowUtc.AddDays(15)),
+            CancellationToken.None);
+
+        Assert.Equal(3, result.ExpiredCount);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task Handle_MixOfExpiredAndActive_OnlyExpiresTrials()
+    {
+        // AC-4: Trial expiry does not affect Active, Cancelled, or BillingIssue subscriptions
+        var repository = new InMemorySubscriptionRepository();
+
+        // Expired trial
+        var expiredTrial = Subscription.CreateTrial(
+            Guid.NewGuid(), "user-expired", "trial_premium",
+            NowUtc, NowUtc.AddDays(14), NowUtc);
+        await repository.AddAsync(expiredTrial, CancellationToken.None);
+
+        // Active trial (not yet expired)
+        var activeTrial = Subscription.CreateTrial(
+            Guid.NewGuid(), "user-active-trial", "trial_premium",
+            NowUtc, NowUtc.AddDays(30), NowUtc);
+        await repository.AddAsync(activeTrial, CancellationToken.None);
+
+        // Active subscription
+        var active = Subscription.CreateTrial(
+            Guid.NewGuid(), "user-active", "premium_monthly",
+            NowUtc, NowUtc.AddDays(7), NowUtc);
+        active.Activate(NowUtc, NowUtc.AddDays(30), NowUtc, "evt-1", NowUtc.AddMinutes(1));
+        await repository.AddAsync(active, CancellationToken.None);
+
+        var handler = CreateHandler(repository: repository);
+
+        var result = await handler.HandleAsync(
+            new ExpireTrialCommand(NowUtc.AddDays(15)),
+            CancellationToken.None);
+
+        // Only 1 expired trial should be transitioned
+        Assert.Equal(1, result.ExpiredCount);
+        Assert.Equal(SubscriptionStatus.None, expiredTrial.Status);
+        Assert.Equal(SubscriptionStatus.Trial, activeTrial.Status);
+        Assert.Equal(SubscriptionStatus.Active, active.Status);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task Handle_ExactlyAtExpiryTime_ExpiresTheTrial()
+    {
+        var repository = new InMemorySubscriptionRepository();
+        var trialEnd = NowUtc.AddDays(14);
+        var trial = Subscription.CreateTrial(
+            Guid.NewGuid(), "user-exact", "trial_premium",
+            NowUtc, trialEnd, NowUtc);
+        await repository.AddAsync(trial, CancellationToken.None);
+
+        var handler = CreateHandler(repository: repository);
+
+        // Run expiry at exactly the trial end time
+        var result = await handler.HandleAsync(
+            new ExpireTrialCommand(trialEnd),
+            CancellationToken.None);
+
+        Assert.Equal(1, result.ExpiredCount);
+        Assert.Equal(SubscriptionStatus.None, trial.Status);
+    }
+}

--- a/backend/tests/MoneyTracker.Modules.Subscriptions.Tests/Application/RestorePurchasesHandlerTests.cs
+++ b/backend/tests/MoneyTracker.Modules.Subscriptions.Tests/Application/RestorePurchasesHandlerTests.cs
@@ -1,0 +1,177 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using MoneyTracker.Modules.SharedKernel.Households;
+using MoneyTracker.Modules.Subscriptions.Application.RestorePurchases;
+using MoneyTracker.Modules.Subscriptions.Domain;
+using MoneyTracker.Modules.Subscriptions.Infrastructure;
+
+namespace MoneyTracker.Modules.Subscriptions.Tests.Application;
+
+public sealed class RestorePurchasesHandlerTests
+{
+    private static readonly DateTimeOffset NowUtc = DateTimeOffset.Parse("2026-03-01T00:00:00Z");
+    private static readonly Guid HouseholdId = Guid.NewGuid();
+    private static readonly Guid UserId = Guid.NewGuid();
+    private const string AppUserId = "rc-app-user-1";
+
+    private sealed class StubHouseholdAccessService : IHouseholdAccessService
+    {
+        private readonly HouseholdAccessResult _result;
+        public StubHouseholdAccessService(HouseholdAccessResult result) => _result = result;
+
+        public Task<HouseholdAccessResult> CheckMemberAsync(Guid householdId, Guid userId, CancellationToken ct)
+            => Task.FromResult(_result);
+
+        public Task<IReadOnlyCollection<Guid>> GetMemberIdsAsync(Guid householdId, CancellationToken ct)
+            => Task.FromResult<IReadOnlyCollection<Guid>>(Array.Empty<Guid>());
+    }
+
+    private static RestorePurchasesHandler CreateHandler(
+        ISubscriptionRepository? repository = null,
+        IRevenueCatClient? revenueCatClient = null,
+        IHouseholdAccessService? householdAccess = null)
+    {
+        var repo = repository ?? new InMemorySubscriptionRepository();
+        return new RestorePurchasesHandler(
+            repo,
+            revenueCatClient ?? new InMemoryRevenueCatClient(),
+            householdAccess ?? new StubHouseholdAccessService(HouseholdAccessResult.Allowed()),
+            new SubscriptionEntitlementService(repo),
+            NullLogger<RestorePurchasesHandler>.Instance);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task Handle_HouseholdNotFound_ReturnsHouseholdNotFound()
+    {
+        var handler = CreateHandler(
+            householdAccess: new StubHouseholdAccessService(HouseholdAccessResult.NotFound()));
+
+        var result = await handler.HandleAsync(
+            new RestorePurchasesCommand(HouseholdId, UserId, AppUserId),
+            CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(SubscriptionErrors.HouseholdNotFound, result.ErrorCode);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task Handle_AccessDenied_ReturnsAccessDenied()
+    {
+        // AC-8: Returns 403 for non-member
+        var handler = CreateHandler(
+            householdAccess: new StubHouseholdAccessService(HouseholdAccessResult.Denied()));
+
+        var result = await handler.HandleAsync(
+            new RestorePurchasesCommand(HouseholdId, UserId, AppUserId),
+            CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(SubscriptionErrors.AccessDenied, result.ErrorCode);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task Handle_NoProviderSubscription_ReturnsFreeState()
+    {
+        // No subscription in RevenueCat, no local subscription
+        var handler = CreateHandler();
+
+        var result = await handler.HandleAsync(
+            new RestorePurchasesCommand(HouseholdId, UserId, AppUserId),
+            CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal("None", result.Status);
+        Assert.Equal("Free", result.Tier);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task Handle_ActiveProviderSubscription_RestoresToActive()
+    {
+        // AC-5, AC-6: Calls RevenueCat and updates local state
+        var repository = new InMemorySubscriptionRepository();
+        var revenueCatClient = new InMemoryRevenueCatClient();
+        revenueCatClient.SetSubscriber(AppUserId, new SubscriberInfo(
+            SubscriptionStatus.Active,
+            "premium_monthly",
+            NowUtc,
+            NowUtc.AddDays(30)));
+
+        // Pre-create a trial subscription
+        var trial = Subscription.CreateTrial(
+            HouseholdId, AppUserId, "trial_premium",
+            NowUtc, NowUtc.AddDays(14), NowUtc);
+        await repository.AddAsync(trial, CancellationToken.None);
+
+        var handler = CreateHandler(
+            repository: repository,
+            revenueCatClient: revenueCatClient);
+
+        var result = await handler.HandleAsync(
+            new RestorePurchasesCommand(HouseholdId, UserId, AppUserId),
+            CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal("Active", result.Status);
+        Assert.Equal("Premium", result.Tier);
+        Assert.Equal(NowUtc.AddDays(30), result.CurrentPeriodEndUtc);
+
+        // Verify local record was updated
+        var subscription = await repository.GetByHouseholdIdAsync(HouseholdId, CancellationToken.None);
+        Assert.Equal(SubscriptionStatus.Active, subscription!.Status);
+        Assert.Equal("premium_monthly", subscription.ProductId);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task Handle_ProviderError_ReturnsProviderError()
+    {
+        var failingClient = new FailingRevenueCatClient();
+        var handler = CreateHandler(revenueCatClient: failingClient);
+
+        var result = await handler.HandleAsync(
+            new RestorePurchasesCommand(HouseholdId, UserId, AppUserId),
+            CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(SubscriptionErrors.ProviderError, result.ErrorCode);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task Handle_NoLocalSubscription_CreatesNewFromProvider()
+    {
+        // AC-6: Creates new local record when none exists but provider has subscription
+        var repository = new InMemorySubscriptionRepository();
+        var revenueCatClient = new InMemoryRevenueCatClient();
+        revenueCatClient.SetSubscriber(AppUserId, new SubscriberInfo(
+            SubscriptionStatus.Active,
+            "premium_annual",
+            NowUtc,
+            NowUtc.AddDays(365)));
+
+        var handler = CreateHandler(
+            repository: repository,
+            revenueCatClient: revenueCatClient);
+
+        var result = await handler.HandleAsync(
+            new RestorePurchasesCommand(HouseholdId, UserId, AppUserId),
+            CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal("Active", result.Status);
+
+        var subscription = await repository.GetByHouseholdIdAsync(HouseholdId, CancellationToken.None);
+        Assert.NotNull(subscription);
+        Assert.Equal(SubscriptionStatus.Active, subscription.Status);
+        Assert.Equal("premium_annual", subscription.ProductId);
+    }
+
+    private sealed class FailingRevenueCatClient : IRevenueCatClient
+    {
+        public Task<SubscriberInfo?> GetSubscriberAsync(string appUserId, CancellationToken cancellationToken)
+            => throw new HttpRequestException("Connection refused");
+    }
+}

--- a/backend/tests/MoneyTracker.Modules.Subscriptions.Tests/Application/StartTrialHandlerTests.cs
+++ b/backend/tests/MoneyTracker.Modules.Subscriptions.Tests/Application/StartTrialHandlerTests.cs
@@ -1,0 +1,116 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using MoneyTracker.Modules.Subscriptions.Application.StartTrial;
+using MoneyTracker.Modules.Subscriptions.Domain;
+using MoneyTracker.Modules.Subscriptions.Infrastructure;
+
+namespace MoneyTracker.Modules.Subscriptions.Tests.Application;
+
+public sealed class StartTrialHandlerTests
+{
+    private static readonly DateTimeOffset NowUtc = DateTimeOffset.Parse("2026-03-01T00:00:00Z");
+
+    private sealed class FakeTimeProvider : TimeProvider
+    {
+        private readonly DateTimeOffset _now;
+        public FakeTimeProvider(DateTimeOffset now) => _now = now;
+        public override DateTimeOffset GetUtcNow() => _now;
+    }
+
+    private static StartTrialHandler CreateHandler(
+        ISubscriptionRepository? repository = null,
+        TimeProvider? timeProvider = null)
+    {
+        return new StartTrialHandler(
+            repository ?? new InMemorySubscriptionRepository(),
+            timeProvider ?? new FakeTimeProvider(NowUtc),
+            NullLogger<StartTrialHandler>.Instance);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task Handle_NewHousehold_CreatesTrialSubscription()
+    {
+        // AC-1: Auto-grants 14-day trial on household creation
+        var repository = new InMemorySubscriptionRepository();
+        var handler = CreateHandler(repository: repository);
+        var householdId = Guid.NewGuid();
+
+        var result = await handler.HandleAsync(
+            new StartTrialCommand(householdId),
+            CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        Assert.NotNull(result.TrialExpiresAtUtc);
+        Assert.Equal(NowUtc.AddDays(14), result.TrialExpiresAtUtc);
+
+        var subscription = await repository.GetByHouseholdIdAsync(householdId, CancellationToken.None);
+        Assert.NotNull(subscription);
+        Assert.Equal(SubscriptionStatus.Trial, subscription.Status);
+        Assert.Equal(NowUtc, subscription.TrialStartedAtUtc);
+        Assert.Equal(NowUtc.AddDays(14), subscription.TrialExpiresAtUtc);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task Handle_ExistingSubscription_IsIdempotent()
+    {
+        // AC-2: Idempotent — does not create duplicate or reset trial
+        var repository = new InMemorySubscriptionRepository();
+        var householdId = Guid.NewGuid();
+
+        // Pre-create a trial subscription
+        var existing = Subscription.CreateTrial(
+            householdId,
+            householdId.ToString(),
+            "trial_premium",
+            NowUtc,
+            NowUtc.AddDays(14),
+            NowUtc);
+        await repository.AddAsync(existing, CancellationToken.None);
+
+        var handler = CreateHandler(repository: repository);
+
+        var result = await handler.HandleAsync(
+            new StartTrialCommand(householdId),
+            CancellationToken.None);
+
+        // Should succeed but not create a new subscription
+        Assert.True(result.IsSuccess);
+        Assert.Null(result.TrialExpiresAtUtc); // AlreadyExists returns null
+
+        // Original subscription should be unchanged
+        var subscription = await repository.GetByHouseholdIdAsync(householdId, CancellationToken.None);
+        Assert.NotNull(subscription);
+        Assert.Equal(existing.Id, subscription.Id);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task Handle_ExistingActiveSubscription_IsIdempotent()
+    {
+        // AC-2: Idempotent — does not affect active subscriptions
+        var repository = new InMemorySubscriptionRepository();
+        var householdId = Guid.NewGuid();
+
+        var existing = Subscription.CreateTrial(
+            householdId,
+            householdId.ToString(),
+            "premium_monthly",
+            NowUtc,
+            NowUtc.AddDays(7),
+            NowUtc);
+        existing.Activate(NowUtc, NowUtc.AddDays(30), NowUtc, "evt-1", NowUtc.AddMinutes(1));
+        await repository.AddAsync(existing, CancellationToken.None);
+
+        var handler = CreateHandler(repository: repository);
+
+        var result = await handler.HandleAsync(
+            new StartTrialCommand(householdId),
+            CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+
+        var subscription = await repository.GetByHouseholdIdAsync(householdId, CancellationToken.None);
+        Assert.Equal(SubscriptionStatus.Active, subscription!.Status);
+    }
+}

--- a/backend/tests/MoneyTracker.Modules.Subscriptions.Tests/Domain/SubscriptionTrialTests.cs
+++ b/backend/tests/MoneyTracker.Modules.Subscriptions.Tests/Domain/SubscriptionTrialTests.cs
@@ -1,0 +1,238 @@
+using MoneyTracker.Modules.Subscriptions.Domain;
+
+namespace MoneyTracker.Modules.Subscriptions.Tests.Domain;
+
+public sealed class SubscriptionTrialTests
+{
+    private static readonly DateTimeOffset NowUtc = DateTimeOffset.Parse("2026-03-01T00:00:00Z");
+    private static readonly Guid HouseholdId = Guid.NewGuid();
+    private const string AppUserId = "app-user-trial-1";
+    private const string ProductId = "trial_premium";
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void StartTrial_FromNone_SetsTrialStatusAndDates()
+    {
+        // P4-3-UNIT-01: Subscription.StartTrial with valid household
+        var subscription = Subscription.CreateForWebhook(
+            HouseholdId, AppUserId, ProductId, NowUtc);
+
+        subscription.StartTrial(NowUtc, trialDays: 14);
+
+        Assert.Equal(SubscriptionStatus.Trial, subscription.Status);
+        Assert.Equal(NowUtc, subscription.TrialStartedAtUtc);
+        Assert.Equal(NowUtc.AddDays(14), subscription.TrialExpiresAtUtc);
+        Assert.Equal(NowUtc, subscription.CurrentPeriodStartUtc);
+        Assert.Equal(NowUtc.AddDays(14), subscription.CurrentPeriodEndUtc);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void StartTrial_WhenAlreadyTrial_ThrowsDomainException()
+    {
+        // P4-3-UNIT-02: StartTrial on subscription already in Trial throws
+        var subscription = Subscription.CreateTrial(
+            HouseholdId, AppUserId, ProductId,
+            NowUtc, NowUtc.AddDays(14), NowUtc);
+
+        var exception = Assert.Throws<SubscriptionDomainException>(
+            () => subscription.StartTrial(NowUtc.AddDays(1)));
+
+        Assert.Equal(SubscriptionErrors.TrialAlreadyStarted, exception.Code);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void StartTrial_WhenAlreadyActive_ThrowsDomainException()
+    {
+        // P4-3-UNIT-03: StartTrial on subscription already Active throws
+        var subscription = Subscription.CreateTrial(
+            HouseholdId, AppUserId, ProductId,
+            NowUtc, NowUtc.AddDays(14), NowUtc);
+        subscription.Activate(NowUtc, NowUtc.AddDays(30), NowUtc, "evt-1", NowUtc.AddMinutes(1));
+
+        var exception = Assert.Throws<SubscriptionDomainException>(
+            () => subscription.StartTrial(NowUtc.AddDays(1)));
+
+        Assert.Equal(SubscriptionErrors.SubscriptionAlreadyActive, exception.Code);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void ExpireTrial_FromTrial_TransitionsToNone()
+    {
+        // P4-3-UNIT-04: ExpireTrial on Trial subscription past expiry transitions to None
+        var subscription = Subscription.CreateTrial(
+            HouseholdId, AppUserId, ProductId,
+            NowUtc, NowUtc.AddDays(14), NowUtc);
+
+        subscription.ExpireTrial(NowUtc.AddDays(15));
+
+        Assert.Equal(SubscriptionStatus.None, subscription.Status);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void ExpireTrial_FromActive_IsNoOp()
+    {
+        // P4-3-UNIT-05: ExpireTrial on Active subscription has no effect
+        var subscription = Subscription.CreateTrial(
+            HouseholdId, AppUserId, ProductId,
+            NowUtc, NowUtc.AddDays(14), NowUtc);
+        subscription.Activate(NowUtc, NowUtc.AddDays(30), NowUtc, "evt-1", NowUtc.AddMinutes(1));
+
+        subscription.ExpireTrial(NowUtc.AddDays(15));
+
+        Assert.Equal(SubscriptionStatus.Active, subscription.Status);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void ExpireTrial_FromCancelled_IsNoOp()
+    {
+        // AC-4: Trial expiry does not affect Cancelled status
+        var subscription = Subscription.CreateTrial(
+            HouseholdId, AppUserId, ProductId,
+            NowUtc, NowUtc.AddDays(14), NowUtc);
+        subscription.Activate(NowUtc, NowUtc.AddDays(30), NowUtc, "evt-1", NowUtc.AddMinutes(1));
+        subscription.Cancel(NowUtc.AddDays(15), "evt-cancel-1", NowUtc.AddDays(15));
+
+        subscription.ExpireTrial(NowUtc.AddDays(20));
+
+        Assert.Equal(SubscriptionStatus.Cancelled, subscription.Status);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void ExpireTrial_FromBillingIssue_IsNoOp()
+    {
+        // AC-4: Trial expiry does not affect BillingIssue status
+        var subscription = Subscription.CreateTrial(
+            HouseholdId, AppUserId, ProductId,
+            NowUtc, NowUtc.AddDays(14), NowUtc);
+        subscription.Activate(NowUtc, NowUtc.AddDays(30), NowUtc, "evt-1", NowUtc.AddMinutes(1));
+        subscription.MarkBillingIssue(NowUtc.AddDays(20), "evt-billing-1", NowUtc.AddDays(20));
+
+        subscription.ExpireTrial(NowUtc.AddDays(25));
+
+        Assert.Equal(SubscriptionStatus.BillingIssue, subscription.Status);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void Trial_ToActive_TransitionSucceeds()
+    {
+        // Trial -> Active transition (on purchase during trial)
+        var subscription = Subscription.CreateTrial(
+            HouseholdId, AppUserId, ProductId,
+            NowUtc, NowUtc.AddDays(14), NowUtc);
+
+        subscription.Activate(
+            NowUtc.AddDays(5),
+            NowUtc.AddDays(35),
+            NowUtc.AddDays(5),
+            "evt-purchase-1",
+            NowUtc.AddDays(5));
+
+        Assert.Equal(SubscriptionStatus.Active, subscription.Status);
+        Assert.Equal(NowUtc.AddDays(35), subscription.CurrentPeriodEndUtc);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void RestoreFromProvider_WithActiveState_UpdatesSubscription()
+    {
+        // P4-3-UNIT-09: RestoreFromProvider with Active state
+        var subscription = Subscription.CreateTrial(
+            HouseholdId, AppUserId, ProductId,
+            NowUtc, NowUtc.AddDays(14), NowUtc);
+
+        subscription.RestoreFromProvider(
+            SubscriptionStatus.Active,
+            "premium_monthly",
+            NowUtc,
+            NowUtc.AddDays(30));
+
+        Assert.Equal(SubscriptionStatus.Active, subscription.Status);
+        Assert.Equal("premium_monthly", subscription.ProductId);
+        Assert.Equal(NowUtc, subscription.CurrentPeriodStartUtc);
+        Assert.Equal(NowUtc.AddDays(30), subscription.CurrentPeriodEndUtc);
+        // Trial fields should be cleared when restoring to Active
+        Assert.Null(subscription.TrialStartedAtUtc);
+        Assert.Null(subscription.TrialExpiresAtUtc);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void RestoreFromProvider_WithNoneState_UpdatesToFree()
+    {
+        // RestoreFromProvider with no active subscription in provider
+        var subscription = Subscription.CreateTrial(
+            HouseholdId, AppUserId, ProductId,
+            NowUtc, NowUtc.AddDays(14), NowUtc);
+
+        subscription.RestoreFromProvider(
+            SubscriptionStatus.None,
+            "trial_premium",
+            null,
+            null);
+
+        Assert.Equal(SubscriptionStatus.None, subscription.Status);
+        Assert.Null(subscription.CurrentPeriodStartUtc);
+        Assert.Null(subscription.CurrentPeriodEndUtc);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void RestoreFromProvider_WithEmptyProductId_ThrowsValidationError()
+    {
+        var subscription = Subscription.CreateTrial(
+            HouseholdId, AppUserId, ProductId,
+            NowUtc, NowUtc.AddDays(14), NowUtc);
+
+        var exception = Assert.Throws<SubscriptionDomainException>(
+            () => subscription.RestoreFromProvider(
+                SubscriptionStatus.Active, "", NowUtc, NowUtc.AddDays(30)));
+
+        Assert.Equal(SubscriptionErrors.ValidationError, exception.Code);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void CreateTrial_SetsTrialFields()
+    {
+        // Verify CreateTrial factory sets TrialStartedAtUtc and TrialExpiresAtUtc
+        var trialEnd = NowUtc.AddDays(14);
+        var subscription = Subscription.CreateTrial(
+            HouseholdId, AppUserId, ProductId,
+            NowUtc, trialEnd, NowUtc);
+
+        Assert.Equal(NowUtc, subscription.TrialStartedAtUtc);
+        Assert.Equal(trialEnd, subscription.TrialExpiresAtUtc);
+        Assert.Equal(SubscriptionStatus.Trial, subscription.Status);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void StartTrial_DefaultTrialDaysIs14()
+    {
+        var subscription = Subscription.CreateForWebhook(
+            HouseholdId, AppUserId, ProductId, NowUtc);
+
+        subscription.StartTrial(NowUtc);
+
+        Assert.Equal(NowUtc.AddDays(14), subscription.TrialExpiresAtUtc);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void StartTrial_CustomTrialDays()
+    {
+        var subscription = Subscription.CreateForWebhook(
+            HouseholdId, AppUserId, ProductId, NowUtc);
+
+        subscription.StartTrial(NowUtc, trialDays: 7);
+
+        Assert.Equal(NowUtc.AddDays(7), subscription.TrialExpiresAtUtc);
+    }
+}

--- a/backend/tests/MoneyTracker.Modules.Subscriptions.Tests/Infrastructure/SubscriptionEntitlementServiceTests.cs
+++ b/backend/tests/MoneyTracker.Modules.Subscriptions.Tests/Infrastructure/SubscriptionEntitlementServiceTests.cs
@@ -181,5 +181,8 @@ public sealed class SubscriptionEntitlementServiceTests
 
         public Task<Subscription?> GetByRevenueCatAppUserIdAsync(string appUserId, CancellationToken cancellationToken)
             => Task.FromResult(subscription);
+
+        public Task<IReadOnlyList<Subscription>> GetExpiredTrialsAsync(DateTimeOffset asOfUtc, CancellationToken cancellationToken)
+            => Task.FromResult<IReadOnlyList<Subscription>>(Array.Empty<Subscription>());
     }
 }

--- a/mobile/lib/features/subscriptions/application/restore_purchases_controller.dart
+++ b/mobile/lib/features/subscriptions/application/restore_purchases_controller.dart
@@ -1,0 +1,97 @@
+import 'dart:convert';
+import 'package:flutter/foundation.dart';
+import '../infrastructure/revenuecat_sdk_adapter.dart';
+import '../infrastructure/subscription_gateway.dart';
+import 'entitlement_provider.dart';
+
+/// Result of a restore purchases operation.
+class RestorePurchasesOutcome {
+  const RestorePurchasesOutcome._({
+    required this.isSuccess,
+    this.status,
+    this.tier,
+    this.errorMessage,
+  });
+
+  final bool isSuccess;
+  final String? status;
+  final String? tier;
+  final String? errorMessage;
+
+  factory RestorePurchasesOutcome.success({
+    required String status,
+    required String tier,
+  }) {
+    return RestorePurchasesOutcome._(
+      isSuccess: true,
+      status: status,
+      tier: tier,
+    );
+  }
+
+  factory RestorePurchasesOutcome.failure(String errorMessage) {
+    return RestorePurchasesOutcome._(
+      isSuccess: false,
+      errorMessage: errorMessage,
+    );
+  }
+}
+
+/// Orchestrates the restore purchases flow.
+/// AC-11: Calls RevenueCat SDK restorePurchases() then calls backend POST /subscriptions/restore.
+class RestorePurchasesController extends ChangeNotifier {
+  RestorePurchasesController({
+    required RevenueCatSdkAdapter revenueCatSdk,
+    required SubscriptionGateway gateway,
+    required EntitlementProvider entitlementProvider,
+    required String householdId,
+  })  : _revenueCatSdk = revenueCatSdk,
+        _gateway = gateway,
+        _entitlementProvider = entitlementProvider,
+        _householdId = householdId;
+
+  final RevenueCatSdkAdapter _revenueCatSdk;
+  final SubscriptionGateway _gateway;
+  final EntitlementProvider _entitlementProvider;
+  final String _householdId;
+
+  bool _isRestoring = false;
+  RestorePurchasesOutcome? _lastOutcome;
+
+  bool get isRestoring => _isRestoring;
+  RestorePurchasesOutcome? get lastOutcome => _lastOutcome;
+
+  /// Executes the full restore purchases flow.
+  Future<RestorePurchasesOutcome> restorePurchases() async {
+    _isRestoring = true;
+    _lastOutcome = null;
+    notifyListeners();
+
+    try {
+      // Step 1: Call RevenueCat SDK to restore from app store
+      final restoreResult = await _revenueCatSdk.restorePurchases();
+
+      // Step 2: Call backend POST /subscriptions/restore
+      final backendResult = await _gateway.restorePurchases(
+        householdId: _householdId,
+        revenueCatAppUserId: restoreResult.appUserId,
+      );
+
+      // Step 3: Invalidate entitlement cache to pick up new state
+      _entitlementProvider.invalidateCache();
+      await _entitlementProvider.fetchEntitlements(_householdId);
+
+      _lastOutcome = RestorePurchasesOutcome.success(
+        status: backendResult.status,
+        tier: backendResult.tier,
+      );
+    } catch (e) {
+      _lastOutcome = RestorePurchasesOutcome.failure(e.toString());
+    } finally {
+      _isRestoring = false;
+      notifyListeners();
+    }
+
+    return _lastOutcome!;
+  }
+}

--- a/mobile/lib/features/subscriptions/application/subscription_state_recovery.dart
+++ b/mobile/lib/features/subscriptions/application/subscription_state_recovery.dart
@@ -1,0 +1,61 @@
+import 'package:flutter/foundation.dart';
+import '../infrastructure/revenuecat_sdk_adapter.dart';
+import '../infrastructure/subscription_gateway.dart';
+import 'entitlement_provider.dart';
+import 'restore_purchases_controller.dart';
+
+/// Handles subscription state recovery on app launch.
+/// AC-12: Reconciles local state with RevenueCat on app launch.
+class SubscriptionStateRecovery {
+  SubscriptionStateRecovery({
+    required RevenueCatSdkAdapter revenueCatSdk,
+    required SubscriptionGateway gateway,
+    required EntitlementProvider entitlementProvider,
+    required String householdId,
+  })  : _revenueCatSdk = revenueCatSdk,
+        _gateway = gateway,
+        _entitlementProvider = entitlementProvider,
+        _householdId = householdId;
+
+  final RevenueCatSdkAdapter _revenueCatSdk;
+  final SubscriptionGateway _gateway;
+  final EntitlementProvider _entitlementProvider;
+  final String _householdId;
+
+  bool _hasRecovered = false;
+  bool get hasRecovered => _hasRecovered;
+
+  /// Runs on app launch to reconcile subscription state.
+  /// Checks RevenueCat SDK for current state, and if it differs
+  /// from the local cache, triggers a restore flow.
+  Future<void> recoverIfNeeded() async {
+    if (_hasRecovered) return;
+
+    try {
+      // Check if RevenueCat SDK reports an active subscription
+      final sdkHasActive = await _revenueCatSdk.hasActiveSubscription();
+      final localTier = _entitlementProvider.entitlements.tier;
+
+      // If local state differs from SDK state, reconcile
+      final localIsActive = localTier.name != 'free';
+      if (sdkHasActive != localIsActive) {
+        final appUserId = await _revenueCatSdk.getAppUserId();
+        await _gateway.restorePurchases(
+          householdId: _householdId,
+          revenueCatAppUserId: appUserId,
+        );
+
+        // Refresh entitlements after recovery
+        _entitlementProvider.invalidateCache();
+        await _entitlementProvider.fetchEntitlements(_householdId);
+      }
+
+      _hasRecovered = true;
+    } catch (e) {
+      // Recovery is best-effort; log and continue.
+      // The user can manually restore later.
+      debugPrint('Subscription state recovery failed: $e');
+      _hasRecovered = true;
+    }
+  }
+}

--- a/mobile/lib/features/subscriptions/infrastructure/revenuecat_sdk_adapter.dart
+++ b/mobile/lib/features/subscriptions/infrastructure/revenuecat_sdk_adapter.dart
@@ -1,0 +1,72 @@
+import 'package:flutter/foundation.dart';
+
+/// Result of a RevenueCat restore purchases operation.
+class RestoreResult {
+  const RestoreResult({
+    required this.isActive,
+    required this.appUserId,
+    this.productId,
+    this.expiresAt,
+  });
+
+  final bool isActive;
+  final String appUserId;
+  final String? productId;
+  final DateTime? expiresAt;
+}
+
+/// Abstraction over the RevenueCat SDK.
+/// Enables testability by allowing in-memory/stub implementations.
+abstract class RevenueCatSdkAdapter {
+  /// Restores purchases via the platform app store.
+  /// Returns the current subscriber state from RevenueCat.
+  Future<RestoreResult> restorePurchases();
+
+  /// Returns the current RevenueCat app user ID.
+  Future<String> getAppUserId();
+
+  /// Checks if the user has an active subscription.
+  Future<bool> hasActiveSubscription();
+}
+
+/// In-memory implementation for testing.
+class InMemoryRevenueCatSdkAdapter implements RevenueCatSdkAdapter {
+  InMemoryRevenueCatSdkAdapter({
+    this.appUserId = 'test-user-id',
+    this.isActive = false,
+    this.productId,
+    this.expiresAt,
+    this.shouldThrow = false,
+  });
+
+  final String appUserId;
+  final bool isActive;
+  final String? productId;
+  final DateTime? expiresAt;
+  final bool shouldThrow;
+  int restoreCallCount = 0;
+
+  @override
+  Future<RestoreResult> restorePurchases() async {
+    restoreCallCount++;
+    if (shouldThrow) {
+      throw Exception('RevenueCat SDK error');
+    }
+    return RestoreResult(
+      isActive: isActive,
+      appUserId: appUserId,
+      productId: productId,
+      expiresAt: expiresAt,
+    );
+  }
+
+  @override
+  Future<String> getAppUserId() async {
+    return appUserId;
+  }
+
+  @override
+  Future<bool> hasActiveSubscription() async {
+    return isActive;
+  }
+}

--- a/mobile/lib/features/subscriptions/infrastructure/subscription_gateway.dart
+++ b/mobile/lib/features/subscriptions/infrastructure/subscription_gateway.dart
@@ -15,6 +15,39 @@ class SubscriptionGateway {
   final String Function() _tokenProvider;
   final HttpClientAdapter? _httpClient;
 
+  Future<RestoreResponse> restorePurchases({
+    required String householdId,
+    required String revenueCatAppUserId,
+  }) async {
+    final uri = _apiBaseUrl.replace(path: '/subscriptions/restore');
+
+    final body = jsonEncode({
+      'householdId': householdId,
+      'revenueCatAppUserId': revenueCatAppUserId,
+    });
+
+    final response = await _performPost(uri, body);
+
+    if (response.statusCode != 200) {
+      throw SubscriptionGatewayException(
+        'Failed to restore purchases: ${response.statusCode}',
+      );
+    }
+
+    final responseBody = jsonDecode(response.body) as Map<String, dynamic>;
+
+    return RestoreResponse(
+      status: responseBody['status'] as String,
+      tier: responseBody['tier'] as String,
+      featureKeys: (responseBody['featureKeys'] as List<dynamic>)
+          .map((e) => e as String)
+          .toList(),
+      currentPeriodEndUtc: responseBody['currentPeriodEndUtc'] != null
+          ? DateTime.parse(responseBody['currentPeriodEndUtc'] as String)
+          : null,
+    );
+  }
+
   Future<EntitlementSet> getEntitlements(String householdId) async {
     final uri = _apiBaseUrl.replace(
       path: '/subscriptions/entitlements',
@@ -62,6 +95,16 @@ class SubscriptionGateway {
     );
   }
 
+  Future<HttpResponse> _performPost(Uri uri, String body) async {
+    if (_httpClient != null) {
+      return _httpClient!.post(uri, body: body, headers: _buildHeaders());
+    }
+
+    throw UnimplementedError(
+      'HTTP client not configured. Provide an HttpClientAdapter.',
+    );
+  }
+
   Map<String, String> _buildHeaders() {
     return {
       'Authorization': 'Bearer ${_tokenProvider()}',
@@ -86,6 +129,21 @@ class HttpResponse {
   final String body;
 }
 
+class RestoreResponse {
+  const RestoreResponse({
+    required this.status,
+    required this.tier,
+    required this.featureKeys,
+    this.currentPeriodEndUtc,
+  });
+
+  final String status;
+  final String tier;
+  final List<String> featureKeys;
+  final DateTime? currentPeriodEndUtc;
+}
+
 abstract class HttpClientAdapter {
   Future<HttpResponse> get(Uri uri, {Map<String, String>? headers});
+  Future<HttpResponse> post(Uri uri, {String? body, Map<String, String>? headers});
 }

--- a/mobile/test/unit/entitlement_provider_test.dart
+++ b/mobile/test/unit/entitlement_provider_test.dart
@@ -21,6 +21,13 @@ class StubHttpClient implements HttpClientAdapter {
     callCount++;
     return HttpResponse(statusCode: statusCode, body: responseBody);
   }
+
+  @override
+  Future<HttpResponse> post(Uri uri,
+      {String? body, Map<String, String>? headers}) async {
+    callCount++;
+    return HttpResponse(statusCode: statusCode, body: responseBody);
+  }
 }
 
 void main() {

--- a/mobile/test/unit/feature_gate_test.dart
+++ b/mobile/test/unit/feature_gate_test.dart
@@ -15,6 +15,12 @@ class StubHttpClient implements HttpClientAdapter {
   Future<HttpResponse> get(Uri uri, {Map<String, String>? headers}) async {
     return HttpResponse(statusCode: 200, body: responseBody);
   }
+
+  @override
+  Future<HttpResponse> post(Uri uri,
+      {String? body, Map<String, String>? headers}) async {
+    return HttpResponse(statusCode: 200, body: responseBody);
+  }
 }
 
 void main() {

--- a/mobile/test/unit/restore_purchases_controller_test.dart
+++ b/mobile/test/unit/restore_purchases_controller_test.dart
@@ -1,0 +1,214 @@
+import 'dart:convert';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:money_tracker/features/subscriptions/application/entitlement_provider.dart';
+import 'package:money_tracker/features/subscriptions/application/restore_purchases_controller.dart';
+import 'package:money_tracker/features/subscriptions/domain/subscription_tier.dart';
+import 'package:money_tracker/features/subscriptions/infrastructure/revenuecat_sdk_adapter.dart';
+import 'package:money_tracker/features/subscriptions/infrastructure/subscription_gateway.dart';
+
+class StubHttpClient implements HttpClientAdapter {
+  StubHttpClient({
+    required this.getStatusCode,
+    required this.getResponseBody,
+    this.postStatusCode = 200,
+    this.postResponseBody = '{}',
+  });
+
+  final int getStatusCode;
+  final String getResponseBody;
+  final int postStatusCode;
+  final String postResponseBody;
+  int getCallCount = 0;
+  int postCallCount = 0;
+
+  @override
+  Future<HttpResponse> get(Uri uri, {Map<String, String>? headers}) async {
+    getCallCount++;
+    return HttpResponse(statusCode: getStatusCode, body: getResponseBody);
+  }
+
+  @override
+  Future<HttpResponse> post(Uri uri,
+      {String? body, Map<String, String>? headers}) async {
+    postCallCount++;
+    return HttpResponse(statusCode: postStatusCode, body: postResponseBody);
+  }
+}
+
+void main() {
+  late InMemoryRevenueCatSdkAdapter sdkAdapter;
+  late StubHttpClient httpClient;
+  late SubscriptionGateway gateway;
+  late EntitlementProvider entitlementProvider;
+  late RestorePurchasesController controller;
+
+  final premiumEntitlementResponse = jsonEncode({
+    'tier': 'Premium',
+    'featureKeys': [
+      'BankSync',
+      'PremiumInsights',
+      'UnlimitedBudgets',
+      'UnlimitedBillReminders',
+      'ExportData',
+    ],
+    'trialExpiresAtUtc': null,
+    'currentPeriodEndUtc': '2026-04-01T00:00:00Z',
+  });
+
+  final restoreActiveResponse = jsonEncode({
+    'status': 'Active',
+    'tier': 'Premium',
+    'featureKeys': [
+      'BankSync',
+      'PremiumInsights',
+      'UnlimitedBudgets',
+      'UnlimitedBillReminders',
+      'ExportData',
+    ],
+    'currentPeriodEndUtc': '2026-04-01T00:00:00Z',
+  });
+
+  final restoreNoneResponse = jsonEncode({
+    'status': 'None',
+    'tier': 'Free',
+    'featureKeys': <String>[],
+    'currentPeriodEndUtc': null,
+  });
+
+  setUp(() {
+    sdkAdapter = InMemoryRevenueCatSdkAdapter(
+      appUserId: 'test-rc-user',
+      isActive: true,
+      productId: 'premium_monthly',
+    );
+
+    httpClient = StubHttpClient(
+      getStatusCode: 200,
+      getResponseBody: premiumEntitlementResponse,
+      postStatusCode: 200,
+      postResponseBody: restoreActiveResponse,
+    );
+
+    gateway = SubscriptionGateway(
+      apiBaseUrl: Uri.parse('https://api.example.com'),
+      tokenProvider: () => 'test-token',
+      httpClient: httpClient,
+    );
+
+    entitlementProvider = EntitlementProvider(
+      gateway: gateway,
+      cacheTtl: const Duration(minutes: 5),
+    );
+
+    controller = RestorePurchasesController(
+      revenueCatSdk: sdkAdapter,
+      gateway: gateway,
+      entitlementProvider: entitlementProvider,
+      householdId: 'household-1',
+    );
+  });
+
+  group('RestorePurchasesController', () {
+    test('successful restore calls SDK then backend', () async {
+      // AC-11: Calls RevenueCat SDK restorePurchases() then backend POST
+      final outcome = await controller.restorePurchases();
+
+      expect(outcome.isSuccess, true);
+      expect(outcome.status, 'Active');
+      expect(outcome.tier, 'Premium');
+      expect(sdkAdapter.restoreCallCount, 1);
+      expect(httpClient.postCallCount, 1);
+    });
+
+    test('isRestoring is true during restore and false after', () async {
+      bool wasRestoringDuringCall = false;
+      controller.addListener(() {
+        if (controller.isRestoring) {
+          wasRestoringDuringCall = true;
+        }
+      });
+
+      await controller.restorePurchases();
+
+      expect(wasRestoringDuringCall, true);
+      expect(controller.isRestoring, false);
+    });
+
+    test('notifies listeners on start and end', () async {
+      int notifyCount = 0;
+      controller.addListener(() => notifyCount++);
+
+      await controller.restorePurchases();
+
+      // At least 2: start (isRestoring=true) and end (isRestoring=false)
+      expect(notifyCount, greaterThanOrEqualTo(2));
+    });
+
+    test('SDK error results in failure outcome', () async {
+      final failingSdk = InMemoryRevenueCatSdkAdapter(
+        appUserId: 'test-user',
+        shouldThrow: true,
+      );
+
+      controller = RestorePurchasesController(
+        revenueCatSdk: failingSdk,
+        gateway: gateway,
+        entitlementProvider: entitlementProvider,
+        householdId: 'household-1',
+      );
+
+      final outcome = await controller.restorePurchases();
+
+      expect(outcome.isSuccess, false);
+      expect(outcome.errorMessage, isNotNull);
+    });
+
+    test('backend error results in failure outcome', () async {
+      httpClient = StubHttpClient(
+        getStatusCode: 200,
+        getResponseBody: premiumEntitlementResponse,
+        postStatusCode: 500,
+        postResponseBody: '{"error":"server error"}',
+      );
+
+      gateway = SubscriptionGateway(
+        apiBaseUrl: Uri.parse('https://api.example.com'),
+        tokenProvider: () => 'test-token',
+        httpClient: httpClient,
+      );
+
+      controller = RestorePurchasesController(
+        revenueCatSdk: sdkAdapter,
+        gateway: gateway,
+        entitlementProvider: entitlementProvider,
+        householdId: 'household-1',
+      );
+
+      final outcome = await controller.restorePurchases();
+
+      expect(outcome.isSuccess, false);
+      expect(outcome.errorMessage, isNotNull);
+    });
+
+    test('invalidates entitlement cache after restore', () async {
+      // First, populate the cache
+      await entitlementProvider.fetchEntitlements('household-1');
+      expect(httpClient.getCallCount, 1);
+
+      // Restore should invalidate cache and re-fetch
+      await controller.restorePurchases();
+
+      // GET call count should increase (cache was invalidated and re-fetched)
+      expect(httpClient.getCallCount, greaterThan(1));
+    });
+
+    test('lastOutcome is set after restore', () async {
+      expect(controller.lastOutcome, isNull);
+
+      await controller.restorePurchases();
+
+      expect(controller.lastOutcome, isNotNull);
+      expect(controller.lastOutcome!.isSuccess, true);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Auto-grants 14-day trial on household creation via `StartTrialHandler`
- Implements `POST /subscriptions/restore` for purchase restoration via RevenueCat
- Handles trial expiry via `TrialExpiryWorker` background service (hourly)
- Adds mobile restore purchases controller, RevenueCat SDK adapter, and app-launch state recovery

## Changes

### Backend: Domain
- Extended `Subscription` entity with `TrialStartedAtUtc`, `TrialExpiresAtUtc` nullable fields
- Added `StartTrial()`, `ExpireTrial()`, `RestoreFromProvider()` methods
- Updated state machine to support `Trial -> None` and `None -> Trial` transitions
- Added `IRevenueCatClient` anti-corruption interface with `SubscriberInfo` contract
- Extended `ISubscriptionRepository` with `GetExpiredTrialsAsync()`
- Added error codes: `TrialAlreadyStarted`, `SubscriptionAlreadyActive`, `RestoreFailed`, `ProviderError`

### Backend: Application
- `StartTrial/` - Auto-grant 14-day trial (idempotent; skips if subscription exists)
- `RestorePurchases/` - Calls RevenueCat, reconciles local state, returns entitlements
- `ExpireTrial/` - Queries expired trials and transitions to None status

### Backend: Infrastructure
- `TrialExpiryWorker` - BackgroundService running hourly (follows ConsentExpiryCheckWorker pattern)
- `InMemoryRevenueCatClient` - Test implementation with configurable subscriber info
- `RevenueCatClient` - Delegates to in-memory for now; production HTTP integration later

### Backend: Presentation
- Added `POST /subscriptions/restore` endpoint with auth, household access check, JSON request/response
- Registered all new services in `AddSubscriptionsModule()`

### Mobile
- `RestorePurchasesController` - Orchestrates SDK restore + backend POST + cache invalidation
- `RevenueCatSdkAdapter` - Abstract interface + `InMemoryRevenueCatSdkAdapter` for testing
- `SubscriptionStateRecovery` - App-launch reconciliation between local and SDK state
- Extended `SubscriptionGateway` with `restorePurchases()` and `HttpClientAdapter.post()`

## Test Evidence
- **Backend**: 253 tests passing (113 subscription module tests including 30+ new)
  - Domain: SubscriptionTrialTests (13 tests) - trial start, expiry, transitions, restore
  - Application: StartTrialHandlerTests (3 tests), RestorePurchasesHandlerTests (6 tests), ExpireTrialHandlerTests (5 tests)
- **Mobile**: 51 tests passing (7 new restore_purchases_controller_test.dart)
- All existing tests continue to pass (updated StubSubscriptionRepository and StubHttpClient)

## Risk Notes
- Additive changes to existing `Subscription` entity (new nullable fields)
- InMemory RevenueCat client for now; real HTTP implementation in future PR
- `TrialExpiryWorker` uses singleton `ExpireTrialHandler` via DI scoped resolution

Closes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Trial subscriptions: Start a 14-day free trial to test premium features without payment
  * Purchase restoration: Restore previously purchased subscriptions from your payment provider account
  * Automatic trial expiration: Trials automatically expire at the designated end date
  * Improved subscription synchronization: Better alignment of subscription state across web and mobile platforms

<!-- end of auto-generated comment: release notes by coderabbit.ai -->