### PR TITLE
[P4-4] Add paywall integration in mobile with annual-first presentation

### DIFF
--- a/mobile/lib/features/subscriptions/application/offerings_provider.dart
+++ b/mobile/lib/features/subscriptions/application/offerings_provider.dart
@@ -1,0 +1,67 @@
+import 'package:flutter/foundation.dart';
+import '../domain/offering.dart';
+import '../infrastructure/revenuecat_sdk_adapter.dart';
+
+/// Fetches and caches RevenueCat offerings.
+/// AC-12: Caches offerings and serves from cache on subsequent access.
+class OfferingsProvider extends ChangeNotifier {
+  OfferingsProvider({
+    required RevenueCatSdkAdapter revenueCatSdk,
+    Duration cacheTtl = const Duration(minutes: 15),
+  })  : _revenueCatSdk = revenueCatSdk,
+        _cacheTtl = cacheTtl;
+
+  final RevenueCatSdkAdapter _revenueCatSdk;
+  final Duration _cacheTtl;
+
+  Offering? _cachedOffering;
+  DateTime? _lastFetchedAt;
+  bool _isLoading = false;
+  String? _errorMessage;
+
+  /// The current cached offering, or null if not yet fetched.
+  Offering? get offering => _cachedOffering;
+
+  /// Whether offerings are currently being loaded.
+  bool get isLoading => _isLoading;
+
+  /// Error message from the last fetch attempt, if any.
+  String? get errorMessage => _errorMessage;
+
+  /// Whether the cache is still valid.
+  bool get _isCacheValid {
+    if (_lastFetchedAt == null || _cachedOffering == null) return false;
+    return DateTime.now().difference(_lastFetchedAt!) < _cacheTtl;
+  }
+
+  /// Fetches the current offering from RevenueCat.
+  /// Returns cached data if the cache is still valid.
+  Future<Offering?> fetchOffering({bool forceRefresh = false}) async {
+    if (_isCacheValid && !forceRefresh) {
+      return _cachedOffering;
+    }
+
+    _isLoading = true;
+    _errorMessage = null;
+    notifyListeners();
+
+    try {
+      final offering = await _revenueCatSdk.getCurrentOffering();
+      _cachedOffering = offering;
+      _lastFetchedAt = DateTime.now();
+    } catch (e) {
+      _errorMessage = e.toString();
+      debugPrint('OfferingsProvider: failed to fetch offerings: $e');
+    } finally {
+      _isLoading = false;
+      notifyListeners();
+    }
+
+    return _cachedOffering;
+  }
+
+  /// Invalidates the cache, forcing a fresh fetch on next access.
+  void invalidateCache() {
+    _lastFetchedAt = null;
+  }
+}

--- a/mobile/lib/features/subscriptions/application/purchase_controller.dart
+++ b/mobile/lib/features/subscriptions/application/purchase_controller.dart
@@ -1,0 +1,99 @@
+import 'package:flutter/foundation.dart';
+import '../domain/offering.dart';
+import '../domain/purchase_result.dart';
+import '../infrastructure/revenuecat_sdk_adapter.dart';
+import 'entitlement_provider.dart';
+
+/// State of the purchase flow.
+enum PurchaseFlowState {
+  idle,
+  purchasing,
+  success,
+  cancelled,
+  pending,
+  error,
+}
+
+/// Orchestrates the purchase flow:
+/// select plan -> RevenueCat purchase -> update entitlements.
+class PurchaseController extends ChangeNotifier {
+  PurchaseController({
+    required RevenueCatSdkAdapter revenueCatSdk,
+    required EntitlementProvider entitlementProvider,
+    required String householdId,
+  })  : _revenueCatSdk = revenueCatSdk,
+        _entitlementProvider = entitlementProvider,
+        _householdId = householdId;
+
+  final RevenueCatSdkAdapter _revenueCatSdk;
+  final EntitlementProvider _entitlementProvider;
+  final String _householdId;
+
+  PurchaseFlowState _state = PurchaseFlowState.idle;
+  PurchaseResult? _lastResult;
+  String? _errorMessage;
+
+  /// Current state of the purchase flow.
+  PurchaseFlowState get state => _state;
+
+  /// The result of the last purchase attempt.
+  PurchaseResult? get lastResult => _lastResult;
+
+  /// Error message from the last failed purchase.
+  String? get errorMessage => _errorMessage;
+
+  /// Whether a purchase is currently in progress.
+  bool get isPurchasing => _state == PurchaseFlowState.purchasing;
+
+  /// Initiates a purchase for the given package.
+  /// AC-4: Tapping "Subscribe" initiates RevenueCat purchase flow.
+  /// AC-5: Successful purchase updates entitlements.
+  /// AC-6: Failed purchase returns error.
+  /// AC-7: Cancellation returns to idle without error.
+  /// AC-8: Pending purchase shows pending message.
+  Future<PurchaseResult> purchase(Package package) async {
+    _state = PurchaseFlowState.purchasing;
+    _lastResult = null;
+    _errorMessage = null;
+    notifyListeners();
+
+    try {
+      final result = await _revenueCatSdk.purchasePackage(package);
+      _lastResult = result;
+
+      switch (result) {
+        case PurchaseSuccess():
+          _state = PurchaseFlowState.success;
+          // Invalidate and refresh entitlements after successful purchase.
+          _entitlementProvider.invalidateCache();
+          await _entitlementProvider.fetchEntitlements(_householdId);
+        case PurchaseCancelled():
+          _state = PurchaseFlowState.cancelled;
+        case PurchasePending():
+          _state = PurchaseFlowState.pending;
+        case PurchaseFailed(:final errorMessage):
+          _state = PurchaseFlowState.error;
+          _errorMessage = errorMessage;
+      }
+    } catch (e) {
+      _state = PurchaseFlowState.error;
+      _errorMessage = e.toString();
+      _lastResult = PurchaseFailed(
+        errorMessage: e.toString(),
+        isRetryable: true,
+      );
+    } finally {
+      notifyListeners();
+    }
+
+    return _lastResult!;
+  }
+
+  /// Resets the controller to idle state.
+  void reset() {
+    _state = PurchaseFlowState.idle;
+    _lastResult = null;
+    _errorMessage = null;
+    notifyListeners();
+  }
+}

--- a/mobile/lib/features/subscriptions/domain/offering.dart
+++ b/mobile/lib/features/subscriptions/domain/offering.dart
@@ -1,0 +1,151 @@
+/// A RevenueCat Offering — a collection of packages available for purchase.
+class Offering {
+  const Offering({
+    required this.identifier,
+    required this.packages,
+    this.metadata = const {},
+  });
+
+  /// Unique identifier for this offering (e.g. "default").
+  final String identifier;
+
+  /// The packages available within this offering.
+  final List<Package> packages;
+
+  /// Server-side metadata attached to this offering.
+  final Map<String, String> metadata;
+
+  /// Returns the annual package if one exists.
+  Package? get annual => packages.cast<Package?>().firstWhere(
+        (p) => p!.packageType == PackageType.annual,
+        orElse: () => null,
+      );
+
+  /// Returns the monthly package if one exists.
+  Package? get monthly => packages.cast<Package?>().firstWhere(
+        (p) => p!.packageType == PackageType.monthly,
+        orElse: () => null,
+      );
+}
+
+/// A purchasable package within an offering.
+class Package {
+  const Package({
+    required this.identifier,
+    required this.packageType,
+    required this.productId,
+    required this.priceString,
+    required this.priceAmountMicros,
+    required this.currencyCode,
+    required this.period,
+    this.introPrice,
+  });
+
+  /// Unique identifier for this package (e.g. "\$rc_annual").
+  final String identifier;
+
+  /// The type of package (annual, monthly, etc.).
+  final PackageType packageType;
+
+  /// The underlying product ID from the app store.
+  final String productId;
+
+  /// Localized price string (e.g. "\$49.99").
+  final String priceString;
+
+  /// Price in micros (e.g. 49990000 for \$49.99).
+  final int priceAmountMicros;
+
+  /// ISO 4217 currency code (e.g. "USD").
+  final String currencyCode;
+
+  /// Billing period for this package.
+  final BillingPeriod period;
+
+  /// Introductory price info, if available (e.g. free trial).
+  final IntroPrice? introPrice;
+
+  /// Calculates the per-month price in micros for annual packages.
+  int get monthlyEquivalentMicros {
+    if (packageType == PackageType.annual) {
+      return (priceAmountMicros / 12).round();
+    }
+    return priceAmountMicros;
+  }
+
+  /// Calculates the savings percentage compared to a monthly package.
+  /// Returns 0 if this is not an annual package or monthlyPrice is zero.
+  int savingsPercentVsMonthly(int monthlyPriceMicros) {
+    if (packageType != PackageType.annual || monthlyPriceMicros <= 0) {
+      return 0;
+    }
+    final yearlyAtMonthlyRate = monthlyPriceMicros * 12;
+    final savings = yearlyAtMonthlyRate - priceAmountMicros;
+    return ((savings / yearlyAtMonthlyRate) * 100).round();
+  }
+}
+
+/// Type of subscription package.
+enum PackageType {
+  annual,
+  monthly,
+  weekly,
+  lifetime,
+  custom;
+
+  static PackageType fromString(String value) {
+    return PackageType.values.firstWhere(
+      (t) => t.name.toLowerCase() == value.toLowerCase(),
+      orElse: () => PackageType.custom,
+    );
+  }
+}
+
+/// Billing period for a subscription.
+enum BillingPeriod {
+  monthly,
+  annual,
+  weekly,
+  lifetime;
+
+  String get displayLabel {
+    switch (this) {
+      case BillingPeriod.monthly:
+        return 'month';
+      case BillingPeriod.annual:
+        return 'year';
+      case BillingPeriod.weekly:
+        return 'week';
+      case BillingPeriod.lifetime:
+        return 'lifetime';
+    }
+  }
+}
+
+/// Introductory pricing information (e.g., free trial).
+class IntroPrice {
+  const IntroPrice({
+    required this.priceString,
+    required this.priceAmountMicros,
+    required this.periodDays,
+    required this.cycles,
+  });
+
+  /// Localized price string for the intro period ("\$0.00" for free trial).
+  final String priceString;
+
+  /// Price in micros for the intro period.
+  final int priceAmountMicros;
+
+  /// Duration of each intro period in days.
+  final int periodDays;
+
+  /// Number of intro billing cycles.
+  final int cycles;
+
+  /// Whether this intro is a free trial.
+  bool get isFreeTrial => priceAmountMicros == 0;
+
+  /// Total trial days.
+  int get totalTrialDays => periodDays * cycles;
+}

--- a/mobile/lib/features/subscriptions/domain/purchase_result.dart
+++ b/mobile/lib/features/subscriptions/domain/purchase_result.dart
@@ -1,0 +1,47 @@
+/// Result of a purchase attempt — a sealed type covering all outcomes.
+sealed class PurchaseResult {
+  const PurchaseResult();
+}
+
+/// Purchase completed successfully.
+class PurchaseSuccess extends PurchaseResult {
+  const PurchaseSuccess({
+    required this.productId,
+    required this.isActive,
+  });
+
+  /// The product ID that was purchased.
+  final String productId;
+
+  /// Whether the subscription is now active.
+  final bool isActive;
+}
+
+/// User cancelled the purchase (dismissed the store sheet).
+class PurchaseCancelled extends PurchaseResult {
+  const PurchaseCancelled();
+}
+
+/// Purchase is pending (deferred transaction, e.g. parental controls).
+class PurchasePending extends PurchaseResult {
+  const PurchasePending({
+    this.message = 'Your purchase is pending approval.',
+  });
+
+  /// Human-readable explanation of the pending state.
+  final String message;
+}
+
+/// Purchase failed with an error.
+class PurchaseFailed extends PurchaseResult {
+  const PurchaseFailed({
+    required this.errorMessage,
+    this.isRetryable = true,
+  });
+
+  /// Human-readable error description.
+  final String errorMessage;
+
+  /// Whether the user should be offered a retry option.
+  final bool isRetryable;
+}

--- a/mobile/lib/features/subscriptions/infrastructure/revenuecat_sdk_adapter.dart
+++ b/mobile/lib/features/subscriptions/infrastructure/revenuecat_sdk_adapter.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/foundation.dart';
+import '../domain/offering.dart';
+import '../domain/purchase_result.dart';
 
 /// Result of a RevenueCat restore purchases operation.
 class RestoreResult {
@@ -27,6 +29,12 @@ abstract class RevenueCatSdkAdapter {
 
   /// Checks if the user has an active subscription.
   Future<bool> hasActiveSubscription();
+
+  /// Fetches the current offerings from RevenueCat.
+  Future<Offering?> getCurrentOffering();
+
+  /// Initiates a purchase for the given package.
+  Future<PurchaseResult> purchasePackage(Package package);
 }
 
 /// In-memory implementation for testing.
@@ -37,6 +45,8 @@ class InMemoryRevenueCatSdkAdapter implements RevenueCatSdkAdapter {
     this.productId,
     this.expiresAt,
     this.shouldThrow = false,
+    this.offering,
+    this.purchaseResult,
   });
 
   final String appUserId;
@@ -45,6 +55,16 @@ class InMemoryRevenueCatSdkAdapter implements RevenueCatSdkAdapter {
   final DateTime? expiresAt;
   final bool shouldThrow;
   int restoreCallCount = 0;
+  int getOfferingsCallCount = 0;
+  int purchaseCallCount = 0;
+  Package? lastPurchasedPackage;
+
+  /// The offering to return from [getCurrentOffering].
+  final Offering? offering;
+
+  /// The result to return from [purchasePackage].
+  /// Defaults to [PurchaseSuccess] if not set.
+  final PurchaseResult? purchaseResult;
 
   @override
   Future<RestoreResult> restorePurchases() async {
@@ -68,5 +88,28 @@ class InMemoryRevenueCatSdkAdapter implements RevenueCatSdkAdapter {
   @override
   Future<bool> hasActiveSubscription() async {
     return isActive;
+  }
+
+  @override
+  Future<Offering?> getCurrentOffering() async {
+    getOfferingsCallCount++;
+    if (shouldThrow) {
+      throw Exception('RevenueCat SDK error');
+    }
+    return offering;
+  }
+
+  @override
+  Future<PurchaseResult> purchasePackage(Package package) async {
+    purchaseCallCount++;
+    lastPurchasedPackage = package;
+    if (shouldThrow) {
+      throw Exception('RevenueCat SDK error');
+    }
+    return purchaseResult ??
+        PurchaseSuccess(
+          productId: package.productId,
+          isActive: true,
+        );
   }
 }

--- a/mobile/lib/features/subscriptions/presentation/feature_gate.dart
+++ b/mobile/lib/features/subscriptions/presentation/feature_gate.dart
@@ -2,6 +2,11 @@ import 'package:flutter/widgets.dart';
 import '../application/entitlement_provider.dart';
 import '../domain/feature_key.dart';
 
+/// Callback type for navigating to the paywall with a source parameter.
+typedef OnUpgradeTap = void Function(String source);
+
+/// Gates premium features and optionally navigates to the paywall.
+/// AC-9: FeatureGate upgrade CTA navigates to paywall with source parameter.
 class FeatureGate extends StatelessWidget {
   const FeatureGate({
     super.key,
@@ -9,12 +14,18 @@ class FeatureGate extends StatelessWidget {
     required this.entitlementProvider,
     required this.entitled,
     required this.fallback,
+    this.onUpgradeTap,
   });
 
   final FeatureKey feature;
   final EntitlementProvider entitlementProvider;
   final Widget entitled;
   final Widget fallback;
+
+  /// Called when the user taps the upgrade CTA.
+  /// Provides a source string identifying this feature gate (e.g. "bankSync").
+  /// If null, the fallback widget is rendered as-is without tap handling.
+  final OnUpgradeTap? onUpgradeTap;
 
   @override
   Widget build(BuildContext context) {
@@ -23,6 +34,12 @@ class FeatureGate extends StatelessWidget {
       builder: (context, _) {
         if (entitlementProvider.hasFeature(feature)) {
           return entitled;
+        }
+        if (onUpgradeTap != null) {
+          return GestureDetector(
+            onTap: () => onUpgradeTap!(feature.name),
+            child: fallback,
+          );
         }
         return fallback;
       },

--- a/mobile/lib/features/subscriptions/presentation/paywall_controller.dart
+++ b/mobile/lib/features/subscriptions/presentation/paywall_controller.dart
@@ -1,0 +1,134 @@
+import 'package:flutter/foundation.dart';
+import '../application/offerings_provider.dart';
+import '../application/purchase_controller.dart';
+import '../domain/offering.dart';
+import '../domain/purchase_result.dart';
+
+/// State of the paywall screen.
+enum PaywallState {
+  loading,
+  loaded,
+  purchasing,
+  success,
+  error,
+  empty,
+}
+
+/// Manages paywall screen state.
+/// Coordinates between OfferingsProvider (data) and PurchaseController (actions).
+class PaywallController extends ChangeNotifier {
+  PaywallController({
+    required OfferingsProvider offeringsProvider,
+    required PurchaseController purchaseController,
+    this.source,
+    this.variant = 'A',
+  })  : _offeringsProvider = offeringsProvider,
+        _purchaseController = purchaseController;
+
+  final OfferingsProvider _offeringsProvider;
+  final PurchaseController _purchaseController;
+
+  /// Source that triggered the paywall (e.g. "feature_gate", "settings").
+  final String? source;
+
+  /// A/B test variant identifier. AC-13: Paywall supports variant parameter.
+  final String variant;
+
+  PaywallState _state = PaywallState.loading;
+  Package? _selectedPackage;
+  String? _errorMessage;
+
+  /// Current state of the paywall.
+  PaywallState get state => _state;
+
+  /// The current offering.
+  Offering? get offering => _offeringsProvider.offering;
+
+  /// The currently selected package.
+  Package? get selectedPackage => _selectedPackage;
+
+  /// Error message, if any.
+  String? get errorMessage => _errorMessage;
+
+  /// Whether a purchase is in progress.
+  bool get isPurchasing => _state == PaywallState.purchasing;
+
+  /// Available packages from the current offering.
+  List<Package> get packages => offering?.packages ?? const [];
+
+  /// The annual package, if available.
+  Package? get annualPackage => offering?.annual;
+
+  /// The monthly package, if available.
+  Package? get monthlyPackage => offering?.monthly;
+
+  /// Loads offerings and initializes the paywall.
+  /// Selects annual plan by default (annual-first presentation).
+  Future<void> loadOfferings() async {
+    _state = PaywallState.loading;
+    _errorMessage = null;
+    notifyListeners();
+
+    try {
+      await _offeringsProvider.fetchOffering();
+
+      if (offering == null || packages.isEmpty) {
+        _state = PaywallState.empty;
+        _errorMessage = 'No plans are currently available. Please try again later.';
+      } else {
+        _state = PaywallState.loaded;
+        // AC-1: Annual plan is primary (selected by default).
+        _selectedPackage = annualPackage ?? packages.first;
+      }
+    } catch (e) {
+      _state = PaywallState.error;
+      _errorMessage = e.toString();
+    }
+
+    notifyListeners();
+  }
+
+  /// Selects a package for purchase.
+  void selectPackage(Package package) {
+    _selectedPackage = package;
+    notifyListeners();
+  }
+
+  /// Initiates the purchase for the selected package.
+  Future<PurchaseResult?> purchaseSelectedPackage() async {
+    if (_selectedPackage == null) return null;
+
+    _state = PaywallState.purchasing;
+    _errorMessage = null;
+    notifyListeners();
+
+    final result = await _purchaseController.purchase(_selectedPackage!);
+
+    switch (result) {
+      case PurchaseSuccess():
+        _state = PaywallState.success;
+      case PurchaseCancelled():
+        // AC-7: Return to loaded state without error.
+        _state = PaywallState.loaded;
+      case PurchasePending():
+        _state = PaywallState.loaded;
+      case PurchaseFailed(:final errorMessage):
+        _state = PaywallState.error;
+        _errorMessage = errorMessage;
+    }
+
+    notifyListeners();
+    return result;
+  }
+
+  /// Resets to loaded state for retry.
+  void resetError() {
+    if (offering != null && packages.isNotEmpty) {
+      _state = PaywallState.loaded;
+    } else {
+      _state = PaywallState.empty;
+    }
+    _errorMessage = null;
+    notifyListeners();
+  }
+}

--- a/mobile/lib/features/subscriptions/presentation/paywall_screen.dart
+++ b/mobile/lib/features/subscriptions/presentation/paywall_screen.dart
@@ -1,0 +1,500 @@
+import 'package:flutter/material.dart';
+import '../../../app/theme/app_theme_tokens.dart';
+import '../domain/offering.dart';
+import '../domain/purchase_result.dart';
+import 'paywall_controller.dart';
+import 'plan_card.dart';
+import 'purchase_button.dart';
+import 'purchase_failure_dialog.dart';
+import 'purchase_success_screen.dart';
+
+/// Main paywall screen with annual-first pricing presentation.
+/// AC-1: Annual plan displayed as primary (highlighted, recommended).
+/// AC-2: Pricing loaded from RevenueCat Offerings.
+/// AC-10: Accessible from settings, feature gates, and direct navigation.
+/// AC-13: Supports variant parameter for A/B test readiness.
+/// AC-15: Follows Flutter UX theming standards.
+class PaywallScreen extends StatefulWidget {
+  const PaywallScreen({
+    super.key,
+    required this.controller,
+    this.source,
+    this.variant = 'A',
+    this.isTrialEligible = false,
+    this.trialDays = 0,
+  });
+
+  /// Route name for named navigation.
+  static const routeName = '/paywall';
+
+  /// Navigates to the paywall screen.
+  /// Returns true if a purchase was completed, false otherwise.
+  static Future<bool?> navigate(
+    BuildContext context, {
+    required PaywallController controller,
+    String? source,
+    String variant = 'A',
+    bool isTrialEligible = false,
+    int trialDays = 0,
+  }) {
+    return Navigator.of(context).push<bool>(
+      MaterialPageRoute(
+        builder: (_) => PaywallScreen(
+          controller: controller,
+          source: source,
+          variant: variant,
+          isTrialEligible: isTrialEligible,
+          trialDays: trialDays,
+        ),
+      ),
+    );
+  }
+
+  /// Paywall state controller.
+  final PaywallController controller;
+
+  /// Source that triggered the paywall (for analytics).
+  final String? source;
+
+  /// A/B test variant. AC-13.
+  final String variant;
+
+  /// Whether the user is eligible for a free trial. AC-11.
+  final bool isTrialEligible;
+
+  /// Number of trial days, if eligible.
+  final int trialDays;
+
+  @override
+  State<PaywallScreen> createState() => _PaywallScreenState();
+}
+
+class _PaywallScreenState extends State<PaywallScreen> {
+  @override
+  void initState() {
+    super.initState();
+    widget.controller.loadOfferings();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return ListenableBuilder(
+      listenable: widget.controller,
+      builder: (context, _) {
+        final state = widget.controller.state;
+
+        if (state == PaywallState.success) {
+          return PurchaseSuccessScreen(
+            onContinue: () => Navigator.of(context).pop(true),
+          );
+        }
+
+        return Scaffold(
+          appBar: AppBar(
+            title: const Text('Upgrade to Premium'),
+            leading: IconButton(
+              icon: const Icon(Icons.close),
+              onPressed: () => Navigator.of(context).pop(false),
+            ),
+          ),
+          body: _buildBody(context, state),
+        );
+      },
+    );
+  }
+
+  Widget _buildBody(BuildContext context, PaywallState state) {
+    final tokens = AppThemeTokens.of(context);
+
+    switch (state) {
+      case PaywallState.loading:
+        return const Center(child: CircularProgressIndicator());
+
+      case PaywallState.empty:
+        return _EmptyState(
+          tokens: tokens,
+          errorMessage: widget.controller.errorMessage ??
+              'No plans are currently available.',
+          onRetry: () => widget.controller.loadOfferings(),
+        );
+
+      case PaywallState.error:
+        return _EmptyState(
+          tokens: tokens,
+          errorMessage: widget.controller.errorMessage ??
+              'Something went wrong. Please try again.',
+          onRetry: () {
+            widget.controller.resetError();
+            widget.controller.loadOfferings();
+          },
+        );
+
+      case PaywallState.loaded:
+      case PaywallState.purchasing:
+      case PaywallState.success:
+        return _LoadedPaywall(
+          controller: widget.controller,
+          isTrialEligible: widget.isTrialEligible,
+          trialDays: widget.trialDays,
+          onPurchase: _handlePurchase,
+        );
+    }
+  }
+
+  Future<void> _handlePurchase() async {
+    final result = await widget.controller.purchaseSelectedPackage();
+    if (result == null || !mounted) return;
+
+    switch (result) {
+      case PurchaseFailed(:final errorMessage):
+        if (mounted) {
+          PurchaseFailureDialog.show(
+            context: context,
+            errorMessage: errorMessage,
+            onRetry: () {
+              Navigator.of(context).pop();
+              widget.controller.resetError();
+            },
+            onDismiss: () {
+              Navigator.of(context).pop();
+              widget.controller.resetError();
+            },
+          );
+        }
+      case PurchasePending(:final message):
+        if (mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(content: Text(message)),
+          );
+        }
+      case PurchaseSuccess():
+      case PurchaseCancelled():
+        // Handled by state transitions in the controller.
+        break;
+    }
+  }
+}
+
+class _LoadedPaywall extends StatelessWidget {
+  const _LoadedPaywall({
+    required this.controller,
+    required this.isTrialEligible,
+    required this.trialDays,
+    required this.onPurchase,
+  });
+
+  final PaywallController controller;
+  final bool isTrialEligible;
+  final int trialDays;
+  final VoidCallback onPurchase;
+
+  @override
+  Widget build(BuildContext context) {
+    final tokens = AppThemeTokens.of(context);
+    final scheme = Theme.of(context).colorScheme;
+
+    return SingleChildScrollView(
+      padding: EdgeInsets.all(tokens.space4),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          // AC-11: Trial information when eligible.
+          if (isTrialEligible && trialDays > 0)
+            _TrialBanner(trialDays: trialDays, tokens: tokens, scheme: scheme),
+
+          // Header
+          Text(
+            'Unlock all features',
+            style: Theme.of(context).textTheme.headlineSmall?.copyWith(
+                  fontWeight: FontWeight.w700,
+                ),
+          ),
+          SizedBox(height: tokens.space2),
+          Text(
+            'Get the most out of Money Tracker with Premium.',
+            style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+                  color: tokens.contentSecondary,
+                ),
+          ),
+          SizedBox(height: tokens.space5),
+
+          // Feature comparison
+          _FeatureList(tokens: tokens),
+          SizedBox(height: tokens.space5),
+
+          // Plan cards — annual first (AC-1)
+          Text(
+            'Choose your plan',
+            style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                  fontWeight: FontWeight.w600,
+                ),
+          ),
+          SizedBox(height: tokens.space3),
+
+          if (controller.annualPackage != null)
+            Padding(
+              padding: EdgeInsets.only(bottom: tokens.space3),
+              child: PlanCard(
+                package: controller.annualPackage!,
+                isSelected:
+                    controller.selectedPackage == controller.annualPackage,
+                onTap: () =>
+                    controller.selectPackage(controller.annualPackage!),
+                monthlyPackage: controller.monthlyPackage,
+                isRecommended: true,
+              ),
+            ),
+
+          if (controller.monthlyPackage != null)
+            Padding(
+              padding: EdgeInsets.only(bottom: tokens.space3),
+              child: PlanCard(
+                package: controller.monthlyPackage!,
+                isSelected:
+                    controller.selectedPackage == controller.monthlyPackage,
+                onTap: () =>
+                    controller.selectPackage(controller.monthlyPackage!),
+              ),
+            ),
+
+          SizedBox(height: tokens.space3),
+
+          // Purchase button
+          PurchaseButton(
+            onPressed: onPurchase,
+            isLoading: controller.isPurchasing,
+            label: isTrialEligible
+                ? 'Start free trial'
+                : 'Subscribe',
+            isDisabled: controller.selectedPackage == null,
+          ),
+
+          SizedBox(height: tokens.space4),
+
+          // Terms and privacy
+          _LegalLinks(tokens: tokens),
+        ],
+      ),
+    );
+  }
+}
+
+class _TrialBanner extends StatelessWidget {
+  const _TrialBanner({
+    required this.trialDays,
+    required this.tokens,
+    required this.scheme,
+  });
+
+  final int trialDays;
+  final AppThemeTokens tokens;
+  final ColorScheme scheme;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: EdgeInsets.only(bottom: tokens.space4),
+      child: DecoratedBox(
+        decoration: BoxDecoration(
+          color: Color.lerp(scheme.surface, scheme.primary, 0.08),
+          borderRadius: tokens.radiusMedium,
+          border: Border.all(
+            color: Color.lerp(scheme.surface, scheme.primary, 0.25)!,
+          ),
+        ),
+        child: Padding(
+          padding: EdgeInsets.all(tokens.space4),
+          child: Row(
+            children: [
+              Icon(Icons.card_giftcard, color: scheme.primary, size: 28),
+              SizedBox(width: tokens.space3),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      'Start your $trialDays-day free trial',
+                      style:
+                          Theme.of(context).textTheme.titleSmall?.copyWith(
+                                fontWeight: FontWeight.w600,
+                              ),
+                    ),
+                    SizedBox(height: tokens.space1),
+                    Text(
+                      'Try all premium features free. Cancel anytime.',
+                      style:
+                          Theme.of(context).textTheme.bodySmall?.copyWith(
+                                color: tokens.contentSecondary,
+                              ),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _FeatureList extends StatelessWidget {
+  const _FeatureList({required this.tokens});
+
+  final AppThemeTokens tokens;
+
+  static const _features = [
+    _Feature('Bank sync', true),
+    _Feature('Premium insights', true),
+    _Feature('Unlimited budgets', true),
+    _Feature('Unlimited bill reminders', true),
+    _Feature('Data export', true),
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        borderRadius: tokens.radiusMedium,
+        border: Border.all(color: tokens.borderSubtle),
+        color: tokens.surfaceMuted,
+      ),
+      child: Padding(
+        padding: EdgeInsets.all(tokens.space4),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              'Premium includes',
+              style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                    fontWeight: FontWeight.w600,
+                  ),
+            ),
+            SizedBox(height: tokens.space3),
+            ..._features.map(
+              (feature) => Padding(
+                padding: EdgeInsets.only(bottom: tokens.space2),
+                child: Row(
+                  children: [
+                    Icon(
+                      Icons.check_circle,
+                      size: 20,
+                      color: tokens.stateSuccess,
+                    ),
+                    SizedBox(width: tokens.space2),
+                    Text(
+                      feature.label,
+                      style: Theme.of(context).textTheme.bodyMedium,
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _Feature {
+  const _Feature(this.label, this.isPremium);
+
+  final String label;
+  final bool isPremium;
+}
+
+class _LegalLinks extends StatelessWidget {
+  const _LegalLinks({required this.tokens});
+
+  final AppThemeTokens tokens;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        Text(
+          'Recurring billing. Cancel anytime.',
+          textAlign: TextAlign.center,
+          style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                color: tokens.contentMuted,
+              ),
+        ),
+        SizedBox(height: tokens.space2),
+        Row(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            TextButton(
+              onPressed: () {
+                // Will be wired to actual terms URL in production.
+              },
+              child: Text(
+                'Terms of Service',
+                style: Theme.of(context).textTheme.bodySmall,
+              ),
+            ),
+            Text(
+              ' and ',
+              style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                    color: tokens.contentMuted,
+                  ),
+            ),
+            TextButton(
+              onPressed: () {
+                // Will be wired to actual privacy URL in production.
+              },
+              child: Text(
+                'Privacy Policy',
+                style: Theme.of(context).textTheme.bodySmall,
+              ),
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+}
+
+class _EmptyState extends StatelessWidget {
+  const _EmptyState({
+    required this.tokens,
+    required this.errorMessage,
+    required this.onRetry,
+  });
+
+  final AppThemeTokens tokens;
+  final String errorMessage;
+  final VoidCallback onRetry;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: EdgeInsets.all(tokens.space5),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(
+              Icons.cloud_off,
+              size: 48,
+              color: tokens.contentMuted,
+            ),
+            SizedBox(height: tokens.space4),
+            Text(
+              errorMessage,
+              textAlign: TextAlign.center,
+              style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+                    color: tokens.contentSecondary,
+                  ),
+            ),
+            SizedBox(height: tokens.space4),
+            OutlinedButton(
+              onPressed: onRetry,
+              child: const Text('Try again'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/mobile/lib/features/subscriptions/presentation/plan_card.dart
+++ b/mobile/lib/features/subscriptions/presentation/plan_card.dart
@@ -1,0 +1,232 @@
+import 'package:flutter/material.dart';
+import '../../../app/theme/app_theme_tokens.dart';
+import '../domain/offering.dart';
+
+/// Displays a subscription plan option (annual or monthly).
+/// AC-1: Annual plan shown as primary with highlighted styling.
+/// AC-3: Annual plan shows per-month equivalent and savings percentage.
+class PlanCard extends StatelessWidget {
+  const PlanCard({
+    super.key,
+    required this.package,
+    required this.isSelected,
+    required this.onTap,
+    this.monthlyPackage,
+    this.isRecommended = false,
+  });
+
+  /// The package this card represents.
+  final Package package;
+
+  /// Whether this card is currently selected.
+  final bool isSelected;
+
+  /// Called when the user taps this card.
+  final VoidCallback onTap;
+
+  /// The monthly package, used to calculate savings for annual plans.
+  final Package? monthlyPackage;
+
+  /// Whether to show the "Recommended" badge.
+  final bool isRecommended;
+
+  @override
+  Widget build(BuildContext context) {
+    final tokens = AppThemeTokens.of(context);
+    final scheme = Theme.of(context).colorScheme;
+
+    final savingsPercent = monthlyPackage != null
+        ? package.savingsPercentVsMonthly(
+            monthlyPackage!.priceAmountMicros,
+          )
+        : 0;
+
+    return GestureDetector(
+      onTap: onTap,
+      child: AnimatedContainer(
+        duration: const Duration(milliseconds: 200),
+        curve: Curves.easeInOut,
+        decoration: BoxDecoration(
+          borderRadius: tokens.radiusMedium,
+          border: Border.all(
+            color: isSelected ? scheme.primary : tokens.borderSubtle,
+            width: isSelected ? 2 : 1,
+          ),
+          color: isSelected
+              ? Color.lerp(scheme.primary, tokens.surfaceElevated, 0.92)
+              : tokens.surfaceElevated,
+        ),
+        padding: EdgeInsets.all(tokens.space4),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Expanded(
+                  child: Text(
+                    _planTitle,
+                    style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                          fontWeight: FontWeight.w600,
+                        ),
+                  ),
+                ),
+                if (isRecommended && savingsPercent > 0)
+                  _SavingsBadge(
+                    savingsPercent: savingsPercent,
+                    tokens: tokens,
+                    scheme: scheme,
+                  ),
+                SizedBox(width: tokens.space2),
+                _SelectionIndicator(
+                  isSelected: isSelected,
+                  scheme: scheme,
+                ),
+              ],
+            ),
+            SizedBox(height: tokens.space2),
+            Text(
+              package.priceString,
+              style: Theme.of(context).textTheme.headlineSmall?.copyWith(
+                    fontWeight: FontWeight.w700,
+                  ),
+            ),
+            SizedBox(height: tokens.space1),
+            Text(
+              _periodLabel,
+              style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                    color: tokens.contentSecondary,
+                  ),
+            ),
+            if (package.packageType == PackageType.annual) ...[
+              SizedBox(height: tokens.space1),
+              Text(
+                _perMonthLabel,
+                style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                      color: tokens.contentMuted,
+                    ),
+              ),
+            ],
+            if (package.introPrice != null && package.introPrice!.isFreeTrial) ...[
+              SizedBox(height: tokens.space2),
+              _TrialBadge(
+                introPrice: package.introPrice!,
+                tokens: tokens,
+                scheme: scheme,
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+
+  String get _planTitle {
+    switch (package.packageType) {
+      case PackageType.annual:
+        return 'Annual';
+      case PackageType.monthly:
+        return 'Monthly';
+      case PackageType.weekly:
+        return 'Weekly';
+      case PackageType.lifetime:
+        return 'Lifetime';
+      case PackageType.custom:
+        return package.identifier;
+    }
+  }
+
+  String get _periodLabel {
+    return 'per ${package.period.displayLabel}';
+  }
+
+  String get _perMonthLabel {
+    if (package.packageType != PackageType.annual) return '';
+    final monthlyMicros = package.monthlyEquivalentMicros;
+    // Format to a readable string — approximate since we use micros.
+    final monthlyDollars = monthlyMicros / 1000000;
+    return 'That\'s \$${monthlyDollars.toStringAsFixed(2)}/month';
+  }
+}
+
+class _SavingsBadge extends StatelessWidget {
+  const _SavingsBadge({
+    required this.savingsPercent,
+    required this.tokens,
+    required this.scheme,
+  });
+
+  final int savingsPercent;
+  final AppThemeTokens tokens;
+  final ColorScheme scheme;
+
+  @override
+  Widget build(BuildContext context) {
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: Color.lerp(scheme.surface, tokens.stateSuccess, 0.15),
+        borderRadius: BorderRadius.circular(999),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+        child: Text(
+          'Save $savingsPercent%',
+          style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                color: tokens.stateSuccess,
+                fontWeight: FontWeight.w700,
+              ),
+        ),
+      ),
+    );
+  }
+}
+
+class _SelectionIndicator extends StatelessWidget {
+  const _SelectionIndicator({
+    required this.isSelected,
+    required this.scheme,
+  });
+
+  final bool isSelected;
+  final ColorScheme scheme;
+
+  @override
+  Widget build(BuildContext context) {
+    return Icon(
+      isSelected ? Icons.radio_button_checked : Icons.radio_button_off,
+      color: isSelected ? scheme.primary : scheme.outline,
+      size: 22,
+    );
+  }
+}
+
+class _TrialBadge extends StatelessWidget {
+  const _TrialBadge({
+    required this.introPrice,
+    required this.tokens,
+    required this.scheme,
+  });
+
+  final IntroPrice introPrice;
+  final AppThemeTokens tokens;
+  final ColorScheme scheme;
+
+  @override
+  Widget build(BuildContext context) {
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: Color.lerp(scheme.surface, scheme.primary, 0.1),
+        borderRadius: BorderRadius.circular(999),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+        child: Text(
+          '${introPrice.totalTrialDays}-day free trial',
+          style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                color: scheme.primary,
+                fontWeight: FontWeight.w600,
+              ),
+        ),
+      ),
+    );
+  }
+}

--- a/mobile/lib/features/subscriptions/presentation/purchase_button.dart
+++ b/mobile/lib/features/subscriptions/presentation/purchase_button.dart
@@ -1,0 +1,60 @@
+import 'package:flutter/material.dart';
+import '../../../app/theme/app_theme_tokens.dart';
+
+/// Purchase CTA button with loading state.
+/// AC-4: Shows loading spinner during purchase.
+class PurchaseButton extends StatelessWidget {
+  const PurchaseButton({
+    super.key,
+    required this.onPressed,
+    required this.isLoading,
+    this.label = 'Subscribe',
+    this.isDisabled = false,
+  });
+
+  /// Called when the button is tapped.
+  final VoidCallback? onPressed;
+
+  /// Whether the purchase is currently in progress.
+  final bool isLoading;
+
+  /// Button label text.
+  final String label;
+
+  /// Whether the button is disabled (e.g. no plan selected).
+  final bool isDisabled;
+
+  @override
+  Widget build(BuildContext context) {
+    final tokens = AppThemeTokens.of(context);
+
+    return SizedBox(
+      width: double.infinity,
+      height: 52,
+      child: FilledButton(
+        onPressed: isLoading || isDisabled ? null : onPressed,
+        style: FilledButton.styleFrom(
+          shape: RoundedRectangleBorder(
+            borderRadius: tokens.radiusMedium,
+          ),
+        ),
+        child: isLoading
+            ? SizedBox(
+                width: 22,
+                height: 22,
+                child: CircularProgressIndicator(
+                  strokeWidth: 2.5,
+                  color: Theme.of(context).colorScheme.onPrimary,
+                ),
+              )
+            : Text(
+                label,
+                style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                      color: Theme.of(context).colorScheme.onPrimary,
+                      fontWeight: FontWeight.w600,
+                    ),
+              ),
+      ),
+    );
+  }
+}

--- a/mobile/lib/features/subscriptions/presentation/purchase_failure_dialog.dart
+++ b/mobile/lib/features/subscriptions/presentation/purchase_failure_dialog.dart
@@ -1,0 +1,87 @@
+import 'package:flutter/material.dart';
+import '../../../app/theme/app_theme_tokens.dart';
+
+/// Error feedback dialog for failed purchases.
+/// AC-6: Shows error dialog with retry option.
+class PurchaseFailureDialog extends StatelessWidget {
+  const PurchaseFailureDialog({
+    super.key,
+    required this.errorMessage,
+    required this.onRetry,
+    required this.onDismiss,
+  });
+
+  /// Human-readable error message.
+  final String errorMessage;
+
+  /// Called when the user taps "Try again".
+  final VoidCallback onRetry;
+
+  /// Called when the user dismisses the dialog.
+  final VoidCallback onDismiss;
+
+  /// Shows the dialog as a modal.
+  static Future<void> show({
+    required BuildContext context,
+    required String errorMessage,
+    required VoidCallback onRetry,
+    required VoidCallback onDismiss,
+  }) {
+    return showDialog(
+      context: context,
+      barrierDismissible: false,
+      builder: (_) => PurchaseFailureDialog(
+        errorMessage: errorMessage,
+        onRetry: onRetry,
+        onDismiss: onDismiss,
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final tokens = AppThemeTokens.of(context);
+
+    return AlertDialog(
+      shape: RoundedRectangleBorder(
+        borderRadius: tokens.radiusMedium,
+      ),
+      icon: Icon(
+        Icons.error_outline,
+        color: tokens.stateDanger,
+        size: 40,
+      ),
+      title: const Text('Purchase failed'),
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Text(
+            errorMessage,
+            textAlign: TextAlign.center,
+            style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                  color: tokens.contentSecondary,
+                ),
+          ),
+          SizedBox(height: tokens.space3),
+          Text(
+            'If the problem persists, please contact support.',
+            textAlign: TextAlign.center,
+            style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                  color: tokens.contentMuted,
+                ),
+          ),
+        ],
+      ),
+      actions: [
+        TextButton(
+          onPressed: onDismiss,
+          child: const Text('Cancel'),
+        ),
+        FilledButton(
+          onPressed: onRetry,
+          child: const Text('Try again'),
+        ),
+      ],
+    );
+  }
+}

--- a/mobile/lib/features/subscriptions/presentation/purchase_success_screen.dart
+++ b/mobile/lib/features/subscriptions/presentation/purchase_success_screen.dart
@@ -1,0 +1,163 @@
+import 'package:flutter/material.dart';
+import '../../../app/theme/app_theme_tokens.dart';
+import '../domain/feature_key.dart';
+
+/// Post-purchase confirmation screen.
+/// AC-5: Shows purchase success screen after successful purchase.
+class PurchaseSuccessScreen extends StatelessWidget {
+  const PurchaseSuccessScreen({
+    super.key,
+    required this.onContinue,
+  });
+
+  /// Called when the user taps the continue button.
+  final VoidCallback onContinue;
+
+  static const _unlockedFeatures = [
+    _FeatureItem(
+      icon: Icons.sync,
+      label: 'Bank sync',
+      description: 'Automatic transaction imports',
+    ),
+    _FeatureItem(
+      icon: Icons.insights,
+      label: 'Premium insights',
+      description: 'Advanced spending analytics',
+    ),
+    _FeatureItem(
+      icon: Icons.all_inclusive,
+      label: 'Unlimited budgets',
+      description: 'Create as many budgets as you need',
+    ),
+    _FeatureItem(
+      icon: Icons.notifications_active,
+      label: 'Unlimited bill reminders',
+      description: 'Never miss a payment',
+    ),
+    _FeatureItem(
+      icon: Icons.download,
+      label: 'Data export',
+      description: 'Export your financial data anytime',
+    ),
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    final tokens = AppThemeTokens.of(context);
+    final scheme = Theme.of(context).colorScheme;
+
+    return Scaffold(
+      body: SafeArea(
+        child: Padding(
+          padding: EdgeInsets.all(tokens.space5),
+          child: Column(
+            children: [
+              const Spacer(flex: 1),
+              Icon(
+                Icons.check_circle_outline,
+                size: 80,
+                color: tokens.stateSuccess,
+              ),
+              SizedBox(height: tokens.space4),
+              Text(
+                'Welcome to Premium!',
+                style: Theme.of(context).textTheme.headlineMedium?.copyWith(
+                      fontWeight: FontWeight.w700,
+                    ),
+                textAlign: TextAlign.center,
+              ),
+              SizedBox(height: tokens.space2),
+              Text(
+                'You now have access to all premium features.',
+                style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+                      color: tokens.contentSecondary,
+                    ),
+                textAlign: TextAlign.center,
+              ),
+              SizedBox(height: tokens.space5),
+              ..._unlockedFeatures.map(
+                (feature) => Padding(
+                  padding: EdgeInsets.only(bottom: tokens.space3),
+                  child: _FeatureRow(feature: feature, tokens: tokens),
+                ),
+              ),
+              const Spacer(flex: 2),
+              SizedBox(
+                width: double.infinity,
+                height: 52,
+                child: FilledButton(
+                  onPressed: onContinue,
+                  style: FilledButton.styleFrom(
+                    shape: RoundedRectangleBorder(
+                      borderRadius: tokens.radiusMedium,
+                    ),
+                  ),
+                  child: Text(
+                    'Continue',
+                    style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                          color: scheme.onPrimary,
+                          fontWeight: FontWeight.w600,
+                        ),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _FeatureItem {
+  const _FeatureItem({
+    required this.icon,
+    required this.label,
+    required this.description,
+  });
+
+  final IconData icon;
+  final String label;
+  final String description;
+}
+
+class _FeatureRow extends StatelessWidget {
+  const _FeatureRow({
+    required this.feature,
+    required this.tokens,
+  });
+
+  final _FeatureItem feature;
+  final AppThemeTokens tokens;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        Icon(
+          feature.icon,
+          color: tokens.stateSuccess,
+          size: 24,
+        ),
+        SizedBox(width: tokens.space3),
+        Expanded(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                feature.label,
+                style: Theme.of(context).textTheme.titleSmall,
+              ),
+              Text(
+                feature.description,
+                style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                      color: tokens.contentSecondary,
+                    ),
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/mobile/test/unit/offerings_provider_test.dart
+++ b/mobile/test/unit/offerings_provider_test.dart
@@ -1,0 +1,256 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:money_tracker/features/subscriptions/application/offerings_provider.dart';
+import 'package:money_tracker/features/subscriptions/domain/offering.dart';
+import 'package:money_tracker/features/subscriptions/domain/purchase_result.dart';
+import 'package:money_tracker/features/subscriptions/infrastructure/revenuecat_sdk_adapter.dart';
+
+Offering _buildDefaultOffering() {
+  return const Offering(
+    identifier: 'default',
+    packages: [
+      Package(
+        identifier: '\$rc_annual',
+        packageType: PackageType.annual,
+        productId: 'premium_annual',
+        priceString: '\$49.99',
+        priceAmountMicros: 49990000,
+        currencyCode: 'USD',
+        period: BillingPeriod.annual,
+      ),
+      Package(
+        identifier: '\$rc_monthly',
+        packageType: PackageType.monthly,
+        productId: 'premium_monthly',
+        priceString: '\$5.99',
+        priceAmountMicros: 5990000,
+        currencyCode: 'USD',
+        period: BillingPeriod.monthly,
+      ),
+    ],
+  );
+}
+
+void main() {
+  late InMemoryRevenueCatSdkAdapter sdkAdapter;
+  late OfferingsProvider provider;
+
+  group('OfferingsProvider', () {
+    setUp(() {
+      sdkAdapter = InMemoryRevenueCatSdkAdapter(
+        offering: _buildDefaultOffering(),
+      );
+      provider = OfferingsProvider(
+        revenueCatSdk: sdkAdapter,
+        cacheTtl: const Duration(minutes: 15),
+      );
+    });
+
+    test('starts with null offering and not loading', () {
+      expect(provider.offering, isNull);
+      expect(provider.isLoading, false);
+      expect(provider.errorMessage, isNull);
+    });
+
+    // P4-4-UNIT-01: OfferingsProvider parses RevenueCat offering response.
+    test('fetchOffering returns offering with correct packages', () async {
+      final result = await provider.fetchOffering();
+
+      expect(result, isNotNull);
+      expect(result!.identifier, 'default');
+      expect(result.packages.length, 2);
+
+      final annual = result.annual;
+      expect(annual, isNotNull);
+      expect(annual!.productId, 'premium_annual');
+      expect(annual.priceAmountMicros, 49990000);
+      expect(annual.packageType, PackageType.annual);
+
+      final monthly = result.monthly;
+      expect(monthly, isNotNull);
+      expect(monthly!.productId, 'premium_monthly');
+      expect(monthly.priceAmountMicros, 5990000);
+    });
+
+    // P4-4-UNIT-09: OfferingsProvider cache hit returns cached without SDK call.
+    test('cache hit returns cached offerings without SDK call', () async {
+      await provider.fetchOffering();
+      expect(sdkAdapter.getOfferingsCallCount, 1);
+
+      // Second call should use cache.
+      final result = await provider.fetchOffering();
+      expect(sdkAdapter.getOfferingsCallCount, 1);
+      expect(result, isNotNull);
+      expect(result!.packages.length, 2);
+    });
+
+    test('forceRefresh bypasses cache', () async {
+      await provider.fetchOffering();
+      expect(sdkAdapter.getOfferingsCallCount, 1);
+
+      await provider.fetchOffering(forceRefresh: true);
+      expect(sdkAdapter.getOfferingsCallCount, 2);
+    });
+
+    test('invalidateCache forces fresh fetch on next access', () async {
+      await provider.fetchOffering();
+      expect(sdkAdapter.getOfferingsCallCount, 1);
+
+      provider.invalidateCache();
+
+      await provider.fetchOffering();
+      expect(sdkAdapter.getOfferingsCallCount, 2);
+    });
+
+    test('notifies listeners on fetch', () async {
+      int notifyCount = 0;
+      provider.addListener(() => notifyCount++);
+
+      await provider.fetchOffering();
+
+      // At least 2: loading start and loading end.
+      expect(notifyCount, greaterThanOrEqualTo(2));
+    });
+
+    test('isLoading is false after fetch completes', () async {
+      await provider.fetchOffering();
+      expect(provider.isLoading, false);
+    });
+
+    test('SDK error sets error message', () async {
+      final failingSdk = InMemoryRevenueCatSdkAdapter(shouldThrow: true);
+      final failingProvider = OfferingsProvider(revenueCatSdk: failingSdk);
+
+      await failingProvider.fetchOffering();
+
+      expect(failingProvider.errorMessage, isNotNull);
+      expect(failingProvider.offering, isNull);
+    });
+
+    test('null offering from SDK is handled gracefully', () async {
+      final emptySdk = InMemoryRevenueCatSdkAdapter();
+      final emptyProvider = OfferingsProvider(revenueCatSdk: emptySdk);
+
+      final result = await emptyProvider.fetchOffering();
+
+      expect(result, isNull);
+      expect(emptyProvider.errorMessage, isNull);
+    });
+  });
+
+  group('Offering domain', () {
+    test('annual getter returns annual package', () {
+      final offering = _buildDefaultOffering();
+      expect(offering.annual, isNotNull);
+      expect(offering.annual!.packageType, PackageType.annual);
+    });
+
+    test('monthly getter returns monthly package', () {
+      final offering = _buildDefaultOffering();
+      expect(offering.monthly, isNotNull);
+      expect(offering.monthly!.packageType, PackageType.monthly);
+    });
+
+    test('annual getter returns null when no annual package', () {
+      const offering = Offering(
+        identifier: 'default',
+        packages: [
+          Package(
+            identifier: '\$rc_monthly',
+            packageType: PackageType.monthly,
+            productId: 'premium_monthly',
+            priceString: '\$5.99',
+            priceAmountMicros: 5990000,
+            currencyCode: 'USD',
+            period: BillingPeriod.monthly,
+          ),
+        ],
+      );
+      expect(offering.annual, isNull);
+    });
+
+    // P4-4-UNIT-03: PlanCard calculates per-month equivalent for annual.
+    test('monthlyEquivalentMicros divides annual by 12', () {
+      const annual = Package(
+        identifier: '\$rc_annual',
+        packageType: PackageType.annual,
+        productId: 'premium_annual',
+        priceString: '\$49.99',
+        priceAmountMicros: 49990000,
+        currencyCode: 'USD',
+        period: BillingPeriod.annual,
+      );
+
+      // 49990000 / 12 = 4165833 (rounded)
+      expect(annual.monthlyEquivalentMicros, 4165833);
+    });
+
+    // P4-4-UNIT-02: PlanCard calculates annual savings percentage.
+    test('savingsPercentVsMonthly calculates correct percentage', () {
+      const annual = Package(
+        identifier: '\$rc_annual',
+        packageType: PackageType.annual,
+        productId: 'premium_annual',
+        priceString: '\$49.99',
+        priceAmountMicros: 49990000,
+        currencyCode: 'USD',
+        period: BillingPeriod.annual,
+      );
+
+      // Monthly at $5.99 = 5990000 micros * 12 = 71880000 yearly
+      // Savings = (71880000 - 49990000) / 71880000 * 100 = 30%
+      final savings = annual.savingsPercentVsMonthly(5990000);
+      expect(savings, 30);
+    });
+
+    test('savingsPercentVsMonthly returns 0 for monthly package', () {
+      const monthly = Package(
+        identifier: '\$rc_monthly',
+        packageType: PackageType.monthly,
+        productId: 'premium_monthly',
+        priceString: '\$5.99',
+        priceAmountMicros: 5990000,
+        currencyCode: 'USD',
+        period: BillingPeriod.monthly,
+      );
+
+      expect(monthly.savingsPercentVsMonthly(5990000), 0);
+    });
+
+    test('savingsPercentVsMonthly returns 0 when monthly price is zero', () {
+      const annual = Package(
+        identifier: '\$rc_annual',
+        packageType: PackageType.annual,
+        productId: 'premium_annual',
+        priceString: '\$49.99',
+        priceAmountMicros: 49990000,
+        currencyCode: 'USD',
+        period: BillingPeriod.annual,
+      );
+
+      expect(annual.savingsPercentVsMonthly(0), 0);
+    });
+  });
+
+  group('IntroPrice', () {
+    test('isFreeTrial is true when price is zero', () {
+      const intro = IntroPrice(
+        priceString: '\$0.00',
+        priceAmountMicros: 0,
+        periodDays: 14,
+        cycles: 1,
+      );
+      expect(intro.isFreeTrial, true);
+      expect(intro.totalTrialDays, 14);
+    });
+
+    test('isFreeTrial is false when price is non-zero', () {
+      const intro = IntroPrice(
+        priceString: '\$0.99',
+        priceAmountMicros: 990000,
+        periodDays: 7,
+        cycles: 1,
+      );
+      expect(intro.isFreeTrial, false);
+    });
+  });
+}

--- a/mobile/test/unit/purchase_controller_test.dart
+++ b/mobile/test/unit/purchase_controller_test.dart
@@ -1,0 +1,277 @@
+import 'dart:convert';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:money_tracker/features/subscriptions/application/entitlement_provider.dart';
+import 'package:money_tracker/features/subscriptions/application/purchase_controller.dart';
+import 'package:money_tracker/features/subscriptions/domain/offering.dart';
+import 'package:money_tracker/features/subscriptions/domain/purchase_result.dart';
+import 'package:money_tracker/features/subscriptions/infrastructure/revenuecat_sdk_adapter.dart';
+import 'package:money_tracker/features/subscriptions/infrastructure/subscription_gateway.dart';
+
+class StubHttpClient implements HttpClientAdapter {
+  StubHttpClient({
+    required this.statusCode,
+    required this.responseBody,
+  });
+
+  final int statusCode;
+  final String responseBody;
+
+  @override
+  Future<HttpResponse> get(Uri uri, {Map<String, String>? headers}) async {
+    return HttpResponse(statusCode: statusCode, body: responseBody);
+  }
+
+  @override
+  Future<HttpResponse> post(Uri uri,
+      {String? body, Map<String, String>? headers}) async {
+    return HttpResponse(statusCode: statusCode, body: responseBody);
+  }
+}
+
+const _testAnnualPackage = Package(
+  identifier: '\$rc_annual',
+  packageType: PackageType.annual,
+  productId: 'premium_annual',
+  priceString: '\$49.99',
+  priceAmountMicros: 49990000,
+  currencyCode: 'USD',
+  period: BillingPeriod.annual,
+);
+
+const _testMonthlyPackage = Package(
+  identifier: '\$rc_monthly',
+  packageType: PackageType.monthly,
+  productId: 'premium_monthly',
+  priceString: '\$5.99',
+  priceAmountMicros: 5990000,
+  currencyCode: 'USD',
+  period: BillingPeriod.monthly,
+);
+
+void main() {
+  late InMemoryRevenueCatSdkAdapter sdkAdapter;
+  late EntitlementProvider entitlementProvider;
+  late PurchaseController controller;
+
+  final premiumResponse = jsonEncode({
+    'tier': 'Premium',
+    'featureKeys': [
+      'BankSync',
+      'PremiumInsights',
+      'UnlimitedBudgets',
+      'UnlimitedBillReminders',
+      'ExportData',
+    ],
+    'trialExpiresAtUtc': null,
+    'currentPeriodEndUtc': '2026-04-01T00:00:00Z',
+  });
+
+  setUp(() {
+    sdkAdapter = InMemoryRevenueCatSdkAdapter(
+      offering: Offering(
+        identifier: 'default',
+        packages: [_testAnnualPackage, _testMonthlyPackage],
+      ),
+    );
+
+    final httpClient = StubHttpClient(
+      statusCode: 200,
+      responseBody: premiumResponse,
+    );
+
+    final gateway = SubscriptionGateway(
+      apiBaseUrl: Uri.parse('https://api.example.com'),
+      tokenProvider: () => 'test-token',
+      httpClient: httpClient,
+    );
+
+    entitlementProvider = EntitlementProvider(
+      gateway: gateway,
+      cacheTtl: const Duration(minutes: 5),
+    );
+
+    controller = PurchaseController(
+      revenueCatSdk: sdkAdapter,
+      entitlementProvider: entitlementProvider,
+      householdId: 'household-1',
+    );
+  });
+
+  group('PurchaseController', () {
+    test('starts in idle state', () {
+      expect(controller.state, PurchaseFlowState.idle);
+      expect(controller.lastResult, isNull);
+      expect(controller.errorMessage, isNull);
+      expect(controller.isPurchasing, false);
+    });
+
+    // P4-4-UNIT-04: PurchaseController initiates purchase for selected package.
+    test('initiates purchase for given package', () async {
+      await controller.purchase(_testAnnualPackage);
+
+      expect(sdkAdapter.purchaseCallCount, 1);
+      expect(sdkAdapter.lastPurchasedPackage, _testAnnualPackage);
+    });
+
+    // P4-4-UNIT-05: PurchaseController handles successful purchase.
+    test('successful purchase transitions to success state', () async {
+      final result = await controller.purchase(_testAnnualPackage);
+
+      expect(result, isA<PurchaseSuccess>());
+      expect(controller.state, PurchaseFlowState.success);
+      expect(controller.lastResult, isA<PurchaseSuccess>());
+    });
+
+    test('successful purchase refreshes entitlements', () async {
+      await controller.purchase(_testAnnualPackage);
+
+      // Entitlements should have been refreshed (cache invalidated + re-fetched).
+      expect(entitlementProvider.entitlements.tier.name, 'premium');
+    });
+
+    // P4-4-UNIT-06: PurchaseController handles failed purchase.
+    test('failed purchase transitions to error state', () async {
+      sdkAdapter = InMemoryRevenueCatSdkAdapter(
+        purchaseResult: const PurchaseFailed(
+          errorMessage: 'Store unavailable',
+          isRetryable: true,
+        ),
+      );
+
+      controller = PurchaseController(
+        revenueCatSdk: sdkAdapter,
+        entitlementProvider: entitlementProvider,
+        householdId: 'household-1',
+      );
+
+      final result = await controller.purchase(_testMonthlyPackage);
+
+      expect(result, isA<PurchaseFailed>());
+      expect(controller.state, PurchaseFlowState.error);
+      expect(controller.errorMessage, 'Store unavailable');
+    });
+
+    // P4-4-UNIT-07: PurchaseController handles user cancellation.
+    test('cancelled purchase returns to idle without error', () async {
+      sdkAdapter = InMemoryRevenueCatSdkAdapter(
+        purchaseResult: const PurchaseCancelled(),
+      );
+
+      controller = PurchaseController(
+        revenueCatSdk: sdkAdapter,
+        entitlementProvider: entitlementProvider,
+        householdId: 'household-1',
+      );
+
+      final result = await controller.purchase(_testMonthlyPackage);
+
+      expect(result, isA<PurchaseCancelled>());
+      expect(controller.state, PurchaseFlowState.cancelled);
+      expect(controller.errorMessage, isNull);
+    });
+
+    // P4-4-UNIT-08: PurchaseController handles deferred/pending purchase.
+    test('pending purchase transitions to pending state', () async {
+      sdkAdapter = InMemoryRevenueCatSdkAdapter(
+        purchaseResult: const PurchasePending(
+          message: 'Awaiting parental approval.',
+        ),
+      );
+
+      controller = PurchaseController(
+        revenueCatSdk: sdkAdapter,
+        entitlementProvider: entitlementProvider,
+        householdId: 'household-1',
+      );
+
+      final result = await controller.purchase(_testMonthlyPackage);
+
+      expect(result, isA<PurchasePending>());
+      expect(controller.state, PurchaseFlowState.pending);
+    });
+
+    // P4-4-UNIT-14: Purchase flow handles edge cases.
+    test('SDK exception transitions to error state', () async {
+      sdkAdapter = InMemoryRevenueCatSdkAdapter(shouldThrow: true);
+
+      controller = PurchaseController(
+        revenueCatSdk: sdkAdapter,
+        entitlementProvider: entitlementProvider,
+        householdId: 'household-1',
+      );
+
+      final result = await controller.purchase(_testAnnualPackage);
+
+      expect(result, isA<PurchaseFailed>());
+      expect(controller.state, PurchaseFlowState.error);
+      expect(controller.errorMessage, isNotNull);
+    });
+
+    test('notifies listeners on state transitions', () async {
+      int notifyCount = 0;
+      controller.addListener(() => notifyCount++);
+
+      await controller.purchase(_testAnnualPackage);
+
+      // At least 2: purchasing start and success/error end.
+      expect(notifyCount, greaterThanOrEqualTo(2));
+    });
+
+    test('isPurchasing is true during purchase', () async {
+      bool wasPurchasing = false;
+      controller.addListener(() {
+        if (controller.isPurchasing) {
+          wasPurchasing = true;
+        }
+      });
+
+      await controller.purchase(_testAnnualPackage);
+
+      expect(wasPurchasing, true);
+      expect(controller.isPurchasing, false);
+    });
+
+    test('reset returns to idle state', () async {
+      await controller.purchase(_testAnnualPackage);
+      expect(controller.state, PurchaseFlowState.success);
+
+      controller.reset();
+
+      expect(controller.state, PurchaseFlowState.idle);
+      expect(controller.lastResult, isNull);
+      expect(controller.errorMessage, isNull);
+    });
+  });
+
+  group('PurchaseResult sealed class', () {
+    test('PurchaseSuccess contains productId and isActive', () {
+      const result = PurchaseSuccess(productId: 'test', isActive: true);
+      expect(result.productId, 'test');
+      expect(result.isActive, true);
+    });
+
+    test('PurchaseCancelled is a valid result', () {
+      const result = PurchaseCancelled();
+      expect(result, isA<PurchaseResult>());
+    });
+
+    test('PurchasePending has default message', () {
+      const result = PurchasePending();
+      expect(result.message, isNotEmpty);
+    });
+
+    test('PurchaseFailed contains errorMessage and isRetryable', () {
+      const result = PurchaseFailed(
+        errorMessage: 'Network error',
+        isRetryable: true,
+      );
+      expect(result.errorMessage, 'Network error');
+      expect(result.isRetryable, true);
+    });
+
+    test('PurchaseFailed isRetryable defaults to true', () {
+      const result = PurchaseFailed(errorMessage: 'Error');
+      expect(result.isRetryable, true);
+    });
+  });
+}

--- a/mobile/test/widget/paywall_screen_test.dart
+++ b/mobile/test/widget/paywall_screen_test.dart
@@ -1,0 +1,300 @@
+import 'dart:convert';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:money_tracker/app/theme/money_tracker_theme.dart';
+import 'package:money_tracker/features/subscriptions/application/entitlement_provider.dart';
+import 'package:money_tracker/features/subscriptions/application/offerings_provider.dart';
+import 'package:money_tracker/features/subscriptions/application/purchase_controller.dart';
+import 'package:money_tracker/features/subscriptions/domain/offering.dart';
+import 'package:money_tracker/features/subscriptions/domain/purchase_result.dart';
+import 'package:money_tracker/features/subscriptions/infrastructure/revenuecat_sdk_adapter.dart';
+import 'package:money_tracker/features/subscriptions/infrastructure/subscription_gateway.dart';
+import 'package:money_tracker/features/subscriptions/presentation/paywall_controller.dart';
+import 'package:money_tracker/features/subscriptions/presentation/paywall_screen.dart';
+import 'package:money_tracker/features/subscriptions/presentation/plan_card.dart';
+import 'package:money_tracker/features/subscriptions/presentation/purchase_button.dart';
+
+class StubHttpClient implements HttpClientAdapter {
+  StubHttpClient({
+    required this.statusCode,
+    required this.responseBody,
+  });
+
+  final int statusCode;
+  final String responseBody;
+
+  @override
+  Future<HttpResponse> get(Uri uri, {Map<String, String>? headers}) async {
+    return HttpResponse(statusCode: statusCode, body: responseBody);
+  }
+
+  @override
+  Future<HttpResponse> post(Uri uri,
+      {String? body, Map<String, String>? headers}) async {
+    return HttpResponse(statusCode: statusCode, body: responseBody);
+  }
+}
+
+const _testAnnualPackage = Package(
+  identifier: '\$rc_annual',
+  packageType: PackageType.annual,
+  productId: 'premium_annual',
+  priceString: '\$49.99',
+  priceAmountMicros: 49990000,
+  currencyCode: 'USD',
+  period: BillingPeriod.annual,
+);
+
+const _testMonthlyPackage = Package(
+  identifier: '\$rc_monthly',
+  packageType: PackageType.monthly,
+  productId: 'premium_monthly',
+  priceString: '\$5.99',
+  priceAmountMicros: 5990000,
+  currencyCode: 'USD',
+  period: BillingPeriod.monthly,
+);
+
+Offering _buildDefaultOffering() {
+  return const Offering(
+    identifier: 'default',
+    packages: [_testAnnualPackage, _testMonthlyPackage],
+  );
+}
+
+Widget _buildTestApp({
+  required PaywallController controller,
+  bool isTrialEligible = false,
+  int trialDays = 0,
+  String variant = 'A',
+}) {
+  return MaterialApp(
+    theme: MoneyTrackerTheme.light(),
+    home: PaywallScreen(
+      controller: controller,
+      isTrialEligible: isTrialEligible,
+      trialDays: trialDays,
+      variant: variant,
+    ),
+  );
+}
+
+PaywallController _createController({
+  InMemoryRevenueCatSdkAdapter? sdkAdapter,
+  String? source,
+  String variant = 'A',
+}) {
+  final sdk = sdkAdapter ??
+      InMemoryRevenueCatSdkAdapter(
+        offering: _buildDefaultOffering(),
+      );
+
+  final premiumResponse = jsonEncode({
+    'tier': 'Premium',
+    'featureKeys': ['BankSync', 'PremiumInsights'],
+    'trialExpiresAtUtc': null,
+    'currentPeriodEndUtc': '2026-04-01T00:00:00Z',
+  });
+
+  final httpClient = StubHttpClient(
+    statusCode: 200,
+    responseBody: premiumResponse,
+  );
+
+  final gateway = SubscriptionGateway(
+    apiBaseUrl: Uri.parse('https://api.example.com'),
+    tokenProvider: () => 'test-token',
+    httpClient: httpClient,
+  );
+
+  final entitlementProvider = EntitlementProvider(
+    gateway: gateway,
+    cacheTtl: const Duration(minutes: 5),
+  );
+
+  final offeringsProvider = OfferingsProvider(revenueCatSdk: sdk);
+  final purchaseController = PurchaseController(
+    revenueCatSdk: sdk,
+    entitlementProvider: entitlementProvider,
+    householdId: 'household-1',
+  );
+
+  return PaywallController(
+    offeringsProvider: offeringsProvider,
+    purchaseController: purchaseController,
+    source: source,
+    variant: variant,
+  );
+}
+
+void main() {
+  group('PaywallScreen', () {
+    testWidgets('shows loading indicator initially', (tester) async {
+      final controller = _createController();
+
+      await tester.pumpWidget(_buildTestApp(controller: controller));
+
+      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+    });
+
+    // P4-4-COMP-01: PaywallScreen renders with annual plan highlighted.
+    testWidgets('renders with annual plan highlighted after loading',
+        (tester) async {
+      final controller = _createController();
+
+      await tester.pumpWidget(_buildTestApp(controller: controller));
+      await tester.pumpAndSettle();
+
+      // Both plans should be visible.
+      expect(find.text('Annual'), findsOneWidget);
+      expect(find.text('Monthly'), findsOneWidget);
+
+      // Pricing should be visible.
+      expect(find.text('\$49.99'), findsOneWidget);
+      expect(find.text('\$5.99'), findsOneWidget);
+
+      // Annual should be selected (2 PlanCard widgets present).
+      expect(find.byType(PlanCard), findsNWidgets(2));
+    });
+
+    testWidgets('shows feature comparison list', (tester) async {
+      final controller = _createController();
+
+      await tester.pumpWidget(_buildTestApp(controller: controller));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Premium includes'), findsOneWidget);
+      expect(find.text('Bank sync'), findsOneWidget);
+      expect(find.text('Premium insights'), findsOneWidget);
+      expect(find.text('Unlimited budgets'), findsOneWidget);
+    });
+
+    testWidgets('shows subscribe button', (tester) async {
+      final controller = _createController();
+
+      await tester.pumpWidget(_buildTestApp(controller: controller));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(PurchaseButton), findsOneWidget);
+      expect(find.text('Subscribe'), findsOneWidget);
+    });
+
+    testWidgets('shows terms and privacy links', (tester) async {
+      final controller = _createController();
+
+      await tester.pumpWidget(_buildTestApp(controller: controller));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Terms of Service'), findsOneWidget);
+      expect(find.text('Privacy Policy'), findsOneWidget);
+    });
+
+    testWidgets('shows close button in app bar', (tester) async {
+      final controller = _createController();
+
+      await tester.pumpWidget(_buildTestApp(controller: controller));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Upgrade to Premium'), findsOneWidget);
+      expect(find.byIcon(Icons.close), findsOneWidget);
+    });
+
+    // P4-4-UNIT-11: PaywallScreen shows trial info when eligible.
+    testWidgets('shows trial banner when eligible', (tester) async {
+      final controller = _createController();
+
+      await tester.pumpWidget(_buildTestApp(
+        controller: controller,
+        isTrialEligible: true,
+        trialDays: 14,
+      ));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Start your 14-day free trial'), findsOneWidget);
+      expect(find.text('Start free trial'), findsOneWidget);
+    });
+
+    testWidgets('hides trial banner when not eligible', (tester) async {
+      final controller = _createController();
+
+      await tester.pumpWidget(_buildTestApp(
+        controller: controller,
+        isTrialEligible: false,
+      ));
+      await tester.pumpAndSettle();
+
+      expect(find.textContaining('free trial'), findsNothing);
+      expect(find.text('Subscribe'), findsOneWidget);
+    });
+
+    // P4-4-COMP-06: Paywall with no network.
+    testWidgets('shows error state when offerings fail to load',
+        (tester) async {
+      final failingSdk = InMemoryRevenueCatSdkAdapter(shouldThrow: true);
+      final controller = _createController(sdkAdapter: failingSdk);
+
+      await tester.pumpWidget(_buildTestApp(controller: controller));
+      await tester.pumpAndSettle();
+
+      // Should show empty/error state with retry.
+      expect(find.text('Try again'), findsOneWidget);
+    });
+
+    testWidgets('shows empty state when no packages available',
+        (tester) async {
+      final emptySdk = InMemoryRevenueCatSdkAdapter();
+      final controller = _createController(sdkAdapter: emptySdk);
+
+      await tester.pumpWidget(_buildTestApp(controller: controller));
+      await tester.pumpAndSettle();
+
+      expect(find.textContaining('No plans'), findsOneWidget);
+      expect(find.text('Try again'), findsOneWidget);
+    });
+
+    // P4-4-UNIT-10: PaywallScreen accepts variant parameter.
+    testWidgets('accepts variant parameter', (tester) async {
+      final controller = _createController(variant: 'B');
+
+      await tester.pumpWidget(
+        _buildTestApp(controller: controller, variant: 'B'),
+      );
+      await tester.pumpAndSettle();
+
+      // Variant should be set on the controller.
+      expect(controller.variant, 'B');
+    });
+
+    testWidgets('savings badge is displayed for annual plan', (tester) async {
+      final controller = _createController();
+
+      await tester.pumpWidget(_buildTestApp(controller: controller));
+      await tester.pumpAndSettle();
+
+      // Annual savings vs monthly: ~30%.
+      expect(find.text('Save 30%'), findsOneWidget);
+    });
+
+    testWidgets('can select monthly plan', (tester) async {
+      final controller = _createController();
+
+      await tester.pumpWidget(_buildTestApp(controller: controller));
+      await tester.pumpAndSettle();
+
+      // Scroll down to make the monthly plan card visible.
+      await tester.scrollUntilVisible(
+        find.text('Monthly'),
+        200,
+        scrollable: find.byType(Scrollable),
+      );
+      await tester.pumpAndSettle();
+
+      // Tap the monthly plan card.
+      await tester.tap(find.text('Monthly'));
+      await tester.pump();
+
+      expect(controller.selectedPackage?.packageType, PackageType.monthly);
+      expect(controller.selectedPackage?.productId, 'premium_monthly');
+    });
+  });
+}

--- a/mobile/test/widget/plan_card_test.dart
+++ b/mobile/test/widget/plan_card_test.dart
@@ -1,0 +1,177 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:money_tracker/app/theme/money_tracker_theme.dart';
+import 'package:money_tracker/features/subscriptions/domain/offering.dart';
+import 'package:money_tracker/features/subscriptions/presentation/plan_card.dart';
+
+const _testAnnualPackage = Package(
+  identifier: '\$rc_annual',
+  packageType: PackageType.annual,
+  productId: 'premium_annual',
+  priceString: '\$49.99',
+  priceAmountMicros: 49990000,
+  currencyCode: 'USD',
+  period: BillingPeriod.annual,
+);
+
+const _testMonthlyPackage = Package(
+  identifier: '\$rc_monthly',
+  packageType: PackageType.monthly,
+  productId: 'premium_monthly',
+  priceString: '\$5.99',
+  priceAmountMicros: 5990000,
+  currencyCode: 'USD',
+  period: BillingPeriod.monthly,
+);
+
+const _testAnnualWithTrial = Package(
+  identifier: '\$rc_annual',
+  packageType: PackageType.annual,
+  productId: 'premium_annual',
+  priceString: '\$49.99',
+  priceAmountMicros: 49990000,
+  currencyCode: 'USD',
+  period: BillingPeriod.annual,
+  introPrice: IntroPrice(
+    priceString: '\$0.00',
+    priceAmountMicros: 0,
+    periodDays: 14,
+    cycles: 1,
+  ),
+);
+
+Widget _buildTestWidget({
+  required Package package,
+  bool isSelected = false,
+  VoidCallback? onTap,
+  Package? monthlyPackage,
+  bool isRecommended = false,
+}) {
+  return MaterialApp(
+    theme: MoneyTrackerTheme.light(),
+    home: Scaffold(
+      body: PlanCard(
+        package: package,
+        isSelected: isSelected,
+        onTap: onTap ?? () {},
+        monthlyPackage: monthlyPackage,
+        isRecommended: isRecommended,
+      ),
+    ),
+  );
+}
+
+void main() {
+  group('PlanCard', () {
+    testWidgets('renders annual plan with correct title and price',
+        (tester) async {
+      await tester.pumpWidget(_buildTestWidget(
+        package: _testAnnualPackage,
+      ));
+
+      expect(find.text('Annual'), findsOneWidget);
+      expect(find.text('\$49.99'), findsOneWidget);
+      expect(find.text('per year'), findsOneWidget);
+    });
+
+    testWidgets('renders monthly plan with correct title and price',
+        (tester) async {
+      await tester.pumpWidget(_buildTestWidget(
+        package: _testMonthlyPackage,
+      ));
+
+      expect(find.text('Monthly'), findsOneWidget);
+      expect(find.text('\$5.99'), findsOneWidget);
+      expect(find.text('per month'), findsOneWidget);
+    });
+
+    testWidgets('shows per-month equivalent for annual plan', (tester) async {
+      await tester.pumpWidget(_buildTestWidget(
+        package: _testAnnualPackage,
+      ));
+
+      // 49990000 / 12 / 1000000 = $4.17 (rounded)
+      expect(find.textContaining('/month'), findsOneWidget);
+    });
+
+    testWidgets('does not show per-month equivalent for monthly plan',
+        (tester) async {
+      await tester.pumpWidget(_buildTestWidget(
+        package: _testMonthlyPackage,
+      ));
+
+      expect(find.textContaining('/month'), findsNothing);
+    });
+
+    testWidgets('shows savings badge when recommended with monthly package',
+        (tester) async {
+      await tester.pumpWidget(_buildTestWidget(
+        package: _testAnnualPackage,
+        monthlyPackage: _testMonthlyPackage,
+        isRecommended: true,
+      ));
+
+      expect(find.text('Save 30%'), findsOneWidget);
+    });
+
+    testWidgets('does not show savings badge when not recommended',
+        (tester) async {
+      await tester.pumpWidget(_buildTestWidget(
+        package: _testAnnualPackage,
+        monthlyPackage: _testMonthlyPackage,
+        isRecommended: false,
+      ));
+
+      expect(find.textContaining('Save'), findsNothing);
+    });
+
+    testWidgets('shows selected indicator when selected', (tester) async {
+      await tester.pumpWidget(_buildTestWidget(
+        package: _testAnnualPackage,
+        isSelected: true,
+      ));
+
+      expect(find.byIcon(Icons.radio_button_checked), findsOneWidget);
+    });
+
+    testWidgets('shows unselected indicator when not selected',
+        (tester) async {
+      await tester.pumpWidget(_buildTestWidget(
+        package: _testAnnualPackage,
+        isSelected: false,
+      ));
+
+      expect(find.byIcon(Icons.radio_button_off), findsOneWidget);
+    });
+
+    testWidgets('calls onTap when tapped', (tester) async {
+      bool tapped = false;
+
+      await tester.pumpWidget(_buildTestWidget(
+        package: _testAnnualPackage,
+        onTap: () => tapped = true,
+      ));
+
+      await tester.tap(find.byType(PlanCard));
+      expect(tapped, true);
+    });
+
+    testWidgets('shows trial badge when intro price is free trial',
+        (tester) async {
+      await tester.pumpWidget(_buildTestWidget(
+        package: _testAnnualWithTrial,
+      ));
+
+      expect(find.text('14-day free trial'), findsOneWidget);
+    });
+
+    testWidgets('does not show trial badge when no intro price',
+        (tester) async {
+      await tester.pumpWidget(_buildTestWidget(
+        package: _testAnnualPackage,
+      ));
+
+      expect(find.textContaining('free trial'), findsNothing);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Adds paywall screen with annual-first pricing presentation (annual plan highlighted as primary)
- Implements purchase flow via RevenueCat SDK adapter (select plan -> purchase -> update entitlements)
- Adds domain types: Offering, Package, PurchaseResult (sealed: Success, Cancelled, Pending, Failed)
- Adds OfferingsProvider with cache (15-min TTL) and PurchaseController for purchase orchestration
- Adds presentation layer: PaywallScreen, PlanCard, PurchaseButton, PurchaseSuccessScreen, PurchaseFailureDialog
- Extends FeatureGate with onUpgradeTap callback for paywall navigation with source parameter
- Supports A/B test readiness via variant parameter on PaywallScreen and PaywallController
- Handles all purchase edge cases: success, cancellation, pending/deferred, failure with retry

## Changes
- **Domain**: `offering.dart` (Offering, Package, PackageType, BillingPeriod, IntroPrice), `purchase_result.dart` (sealed PurchaseResult)
- **Infrastructure**: Extended `revenuecat_sdk_adapter.dart` with `getCurrentOffering()` and `purchasePackage()` methods
- **Application**: `offerings_provider.dart` (cache with TTL), `purchase_controller.dart` (purchase flow state machine)
- **Presentation**: `paywall_screen.dart`, `paywall_controller.dart`, `plan_card.dart`, `purchase_button.dart`, `purchase_success_screen.dart`, `purchase_failure_dialog.dart`
- **Feature Gate**: Extended with `onUpgradeTap` callback for deep-link paywall navigation (AC-9)

## Test Evidence
- 109 tests passing (all existing + 51 new tests)
- Unit tests: OfferingsProvider (cache behavior, SDK error handling), PurchaseController (all purchase states), domain calculations (savings%, monthly equivalent)
- Widget tests: PaywallScreen (loading, loaded, error, empty, trial, variant, plan selection), PlanCard (rendering, selection, savings badge, trial badge)

## Acceptance Criteria Coverage
- AC-1: Annual plan displayed as primary with highlighted styling
- AC-2: Pricing loaded from RevenueCat Offerings
- AC-3: Annual plan shows per-month equivalent and savings percentage
- AC-4: Subscribe initiates RevenueCat purchase flow
- AC-5: Successful purchase shows success screen and updates entitlements
- AC-6: Failed purchase shows error dialog with retry
- AC-7: Cancellation returns to paywall without error
- AC-8: Pending purchase shows pending message
- AC-9: FeatureGate upgrade CTA navigates to paywall with source parameter
- AC-10: Paywall accessible via push navigation from settings, feature gates, and direct
- AC-11: Trial information shown when user is eligible
- AC-12: OfferingsProvider caches offerings with TTL
- AC-13: Variant parameter for A/B test readiness
- AC-14: Purchase flow handles edge cases (SDK errors, no network)
- AC-15: Follows Flutter UX theming standards (AppThemeTokens throughout)

## Risk Notes
- Mobile-only changes, no backend modifications
- Uses InMemory RevenueCat SDK adapter (real SDK integration follows standard pattern)
- No new package dependencies added (`purchases_flutter` not required for adapter pattern)

Closes #82