### PR TITLE
[P5-2] Add onboarding flow instrumentation and activation funnel tracking

### DIFF
--- a/backend/MoneyTracker.slnx
+++ b/backend/MoneyTracker.slnx
@@ -10,6 +10,7 @@
     <Project Path="src/Modules/Transactions/MoneyTracker.Modules.Transactions.csproj" />
     <Project Path="src/Modules/BankConnections/MoneyTracker.Modules.BankConnections.csproj" />
     <Project Path="src/Modules/Subscriptions/MoneyTracker.Modules.Subscriptions.csproj" />
+    <Project Path="src/Modules/Analytics/MoneyTracker.Modules.Analytics.csproj" />
   </Folder>
   <Folder Name="/tests/">
     <Project Path="tests/MoneyTracker.Api.Tests/MoneyTracker.Api.Tests.csproj" />
@@ -19,5 +20,6 @@
     <Project Path="tests/MoneyTracker.Modules.Transactions.Tests/MoneyTracker.Modules.Transactions.Tests.csproj" />
     <Project Path="tests/MoneyTracker.Modules.BankConnections.Tests/MoneyTracker.Modules.BankConnections.Tests.csproj" />
     <Project Path="tests/MoneyTracker.Modules.Subscriptions.Tests/MoneyTracker.Modules.Subscriptions.Tests.csproj" />
+    <Project Path="tests/MoneyTracker.Modules.Analytics.Tests/MoneyTracker.Modules.Analytics.Tests.csproj" />
   </Folder>
 </Solution>

--- a/backend/openapi/openapi.v1.json
+++ b/backend/openapi/openapi.v1.json
@@ -281,6 +281,155 @@
         ],
         "type": "object"
       },
+      "RecordEventsRequest": {
+        "properties": {
+          "events": {
+            "items": {
+              "$ref": "#/components/schemas/RecordEventItemRequest"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "events"
+        ],
+        "type": "object"
+      },
+      "RecordEventItemRequest": {
+        "properties": {
+          "milestone": {
+            "type": "string"
+          },
+          "householdId": {
+            "format": "uuid",
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "metadata": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": [
+              "null",
+              "object"
+            ]
+          },
+          "occurredAtUtc": {
+            "format": "date-time",
+            "type": "string"
+          }
+        },
+        "required": [
+          "milestone",
+          "occurredAtUtc"
+        ],
+        "type": "object"
+      },
+      "RecordEventsResponse": {
+        "properties": {
+          "acceptedCount": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "duplicateCount": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "acceptedCount",
+          "duplicateCount"
+        ],
+        "type": "object"
+      },
+      "ActivationFunnelResponse": {
+        "properties": {
+          "periodDays": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "platform": {
+            "type": "string"
+          },
+          "region": {
+            "type": "string"
+          },
+          "totalUsers": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "stages": {
+            "items": {
+              "$ref": "#/components/schemas/FunnelStageResponse"
+            },
+            "type": "array"
+          },
+          "cohorts": {
+            "items": {
+              "$ref": "#/components/schemas/CohortSummaryResponse"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "periodDays",
+          "platform",
+          "region",
+          "totalUsers",
+          "stages",
+          "cohorts"
+        ],
+        "type": "object"
+      },
+      "FunnelStageResponse": {
+        "properties": {
+          "milestone": {
+            "type": "string"
+          },
+          "userCount": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "conversionRate": {
+            "format": "double",
+            "type": "number"
+          },
+          "dropOffRate": {
+            "format": "double",
+            "type": "number"
+          }
+        },
+        "required": [
+          "milestone",
+          "userCount",
+          "conversionRate",
+          "dropOffRate"
+        ],
+        "type": "object"
+      },
+      "CohortSummaryResponse": {
+        "properties": {
+          "cohortKey": {
+            "type": "string"
+          },
+          "signupCount": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "paidConversionRate": {
+            "format": "double",
+            "type": "number"
+          }
+        },
+        "required": [
+          "cohortKey",
+          "signupCount",
+          "paidConversionRate"
+        ],
+        "type": "object"
+      },
       "ProblemDetails": {
         "properties": {
           "detail": {
@@ -348,6 +497,127 @@
         },
         "tags": [
           "MoneyTracker.Api"
+        ]
+      }
+    },
+    "/analytics/events": {
+      "post": {
+        "description": "Accepts a batch of activation milestone events. Deduplicates by (userId, milestone).",
+        "operationId": "RecordEvents",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RecordEventsRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "202": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RecordEventsResponse"
+                }
+              }
+            },
+            "description": "Accepted"
+          },
+          "400": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "401": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          }
+        },
+        "summary": "Record activation milestone events.",
+        "tags": [
+          "AnalyticsEndpoints"
+        ]
+      }
+    },
+    "/admin/activation-funnel": {
+      "get": {
+        "description": "Returns funnel stages with user counts, conversion rates, drop-off rates, and cohort summaries. Admin-gated via IAdminAccessService.",
+        "operationId": "GetActivationFunnel",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "periodDays",
+            "schema": {
+              "default": 30,
+              "format": "int32",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "platform",
+            "schema": {
+              "default": "all",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "region",
+            "schema": {
+              "default": "all",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivationFunnelResponse"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            },
+            "description": "Forbidden"
+          }
+        },
+        "summary": "Get the activation funnel report.",
+        "tags": [
+          "AnalyticsEndpoints"
         ]
       }
     },
@@ -658,6 +928,9 @@
     },
     {
       "name": "BillReminderEndpoints"
+    },
+    {
+      "name": "AnalyticsEndpoints"
     }
   ]
 }

--- a/backend/src/Modules/Analytics/Application/GetActivationFunnel/GetActivationFunnelHandler.cs
+++ b/backend/src/Modules/Analytics/Application/GetActivationFunnel/GetActivationFunnelHandler.cs
@@ -1,0 +1,114 @@
+using MoneyTracker.Modules.Analytics.Domain;
+
+namespace MoneyTracker.Modules.Analytics.Application.GetActivationFunnel;
+
+public sealed class GetActivationFunnelHandler(
+    IActivationEventRepository repository,
+    TimeProvider timeProvider)
+{
+    public async Task<GetActivationFunnelResult> HandleAsync(
+        GetActivationFunnelQuery query,
+        CancellationToken cancellationToken)
+    {
+        var sinceUtc = timeProvider.GetUtcNow().AddDays(-query.PeriodDays);
+
+        var platform = string.Equals(query.Platform, "all", StringComparison.OrdinalIgnoreCase)
+            ? null
+            : query.Platform;
+
+        var region = string.Equals(query.Region, "all", StringComparison.OrdinalIgnoreCase)
+            ? null
+            : query.Region;
+
+        var events = await repository.GetByPeriodAsync(
+            sinceUtc, platform, region, cancellationToken);
+
+        // Build user-milestone lookup: distinct users per milestone
+        var usersByMilestone = new Dictionary<ActivationMilestone, HashSet<Guid>>();
+        foreach (var milestone in ActivationMilestoneExtensions.OrderedStages)
+        {
+            usersByMilestone[milestone] = [];
+        }
+
+        foreach (var evt in events)
+        {
+            if (usersByMilestone.TryGetValue(evt.Milestone, out var userSet))
+            {
+                userSet.Add(evt.UserId);
+            }
+        }
+
+        // Compute total users (users who reached at least the first milestone)
+        var firstStage = ActivationMilestoneExtensions.OrderedStages[0];
+        var totalUsers = usersByMilestone[firstStage].Count;
+
+        // Build funnel stages
+        var stages = new List<FunnelStage>();
+        for (var i = 0; i < ActivationMilestoneExtensions.OrderedStages.Count; i++)
+        {
+            var milestone = ActivationMilestoneExtensions.OrderedStages[i];
+            var userCount = usersByMilestone[milestone].Count;
+
+            var conversionRate = totalUsers > 0
+                ? (double)userCount / totalUsers
+                : 0.0;
+
+            var dropOffRate = 0.0;
+            if (i > 0)
+            {
+                var previousMilestone = ActivationMilestoneExtensions.OrderedStages[i - 1];
+                var previousCount = usersByMilestone[previousMilestone].Count;
+                dropOffRate = previousCount > 0
+                    ? 1.0 - ((double)userCount / previousCount)
+                    : 0.0;
+            }
+
+            stages.Add(new FunnelStage(
+                milestone.ToSnakeCase(),
+                userCount,
+                Math.Round(conversionRate, 4),
+                Math.Round(dropOffRate, 4)));
+        }
+
+        // Build cohort summaries grouped by ISO week of signup_completed event
+        var signupEvents = events
+            .Where(e => e.Milestone == ActivationMilestone.SignupCompleted)
+            .ToArray();
+
+        var paidUsers = events
+            .Where(e => e.Milestone == ActivationMilestone.PaidConversion)
+            .Select(e => e.UserId)
+            .ToHashSet();
+
+        var cohortGroups = signupEvents
+            .GroupBy(e => CohortKey.FromDate(e.OccurredAtUtc).Value)
+            .OrderBy(g => g.Key);
+
+        var cohorts = new List<CohortSummary>();
+        foreach (var group in cohortGroups)
+        {
+            var signupCount = group.Select(e => e.UserId).Distinct().Count();
+            var paidCount = group
+                .Select(e => e.UserId)
+                .Distinct()
+                .Count(userId => paidUsers.Contains(userId));
+
+            var paidConversionRate = signupCount > 0
+                ? (double)paidCount / signupCount
+                : 0.0;
+
+            cohorts.Add(new CohortSummary(
+                group.Key,
+                signupCount,
+                Math.Round(paidConversionRate, 4)));
+        }
+
+        return GetActivationFunnelResult.Success(
+            query.PeriodDays,
+            query.Platform,
+            query.Region,
+            totalUsers,
+            stages,
+            cohorts);
+    }
+}

--- a/backend/src/Modules/Analytics/Application/GetActivationFunnel/GetActivationFunnelQuery.cs
+++ b/backend/src/Modules/Analytics/Application/GetActivationFunnel/GetActivationFunnelQuery.cs
@@ -1,0 +1,6 @@
+namespace MoneyTracker.Modules.Analytics.Application.GetActivationFunnel;
+
+public sealed record GetActivationFunnelQuery(
+    int PeriodDays = 30,
+    string Platform = "all",
+    string Region = "all");

--- a/backend/src/Modules/Analytics/Application/GetActivationFunnel/GetActivationFunnelResult.cs
+++ b/backend/src/Modules/Analytics/Application/GetActivationFunnel/GetActivationFunnelResult.cs
@@ -1,0 +1,42 @@
+using MoneyTracker.Modules.Analytics.Domain;
+
+namespace MoneyTracker.Modules.Analytics.Application.GetActivationFunnel;
+
+public sealed class GetActivationFunnelResult
+{
+    public bool IsSuccess { get; private init; }
+    public int PeriodDays { get; private init; }
+    public string Platform { get; private init; } = "all";
+    public string Region { get; private init; } = "all";
+    public int TotalUsers { get; private init; }
+    public IReadOnlyCollection<FunnelStage> Stages { get; private init; } = [];
+    public IReadOnlyCollection<CohortSummary> Cohorts { get; private init; } = [];
+    public string? ErrorCode { get; private init; }
+    public string? ErrorMessage { get; private init; }
+
+    public static GetActivationFunnelResult Success(
+        int periodDays,
+        string platform,
+        string region,
+        int totalUsers,
+        IReadOnlyCollection<FunnelStage> stages,
+        IReadOnlyCollection<CohortSummary> cohorts) =>
+        new()
+        {
+            IsSuccess = true,
+            PeriodDays = periodDays,
+            Platform = platform,
+            Region = region,
+            TotalUsers = totalUsers,
+            Stages = stages,
+            Cohorts = cohorts
+        };
+
+    public static GetActivationFunnelResult Failure(string errorCode, string errorMessage) =>
+        new()
+        {
+            IsSuccess = false,
+            ErrorCode = errorCode,
+            ErrorMessage = errorMessage
+        };
+}

--- a/backend/src/Modules/Analytics/Application/RecordEvent/RecordEventCommand.cs
+++ b/backend/src/Modules/Analytics/Application/RecordEvent/RecordEventCommand.cs
@@ -1,0 +1,6 @@
+namespace MoneyTracker.Modules.Analytics.Application.RecordEvent;
+
+public sealed record RecordEventCommand(
+    Guid UserId,
+    string Platform,
+    IReadOnlyCollection<RecordEventItem> Events);

--- a/backend/src/Modules/Analytics/Application/RecordEvent/RecordEventHandler.cs
+++ b/backend/src/Modules/Analytics/Application/RecordEvent/RecordEventHandler.cs
@@ -1,0 +1,60 @@
+using MoneyTracker.Modules.Analytics.Domain;
+
+namespace MoneyTracker.Modules.Analytics.Application.RecordEvent;
+
+public sealed class RecordEventHandler(
+    IActivationEventRepository repository,
+    TimeProvider timeProvider)
+{
+    public async Task<RecordEventResult> HandleAsync(
+        RecordEventCommand command,
+        CancellationToken cancellationToken)
+    {
+        if (command.Events.Count == 0)
+        {
+            return RecordEventResult.Failure(
+                AnalyticsErrors.ValidationError,
+                "At least one event is required.");
+        }
+
+        var acceptedCount = 0;
+        var duplicateCount = 0;
+        var recordedAtUtc = timeProvider.GetUtcNow();
+
+        foreach (var item in command.Events)
+        {
+            if (!ActivationMilestoneExtensions.TryParse(item.Milestone, out var milestone))
+            {
+                return RecordEventResult.Failure(
+                    AnalyticsErrors.InvalidMilestone,
+                    $"Invalid milestone: '{item.Milestone}'.");
+            }
+
+            var exists = await repository.ExistsAsync(
+                command.UserId,
+                milestone,
+                cancellationToken);
+
+            if (exists)
+            {
+                duplicateCount += 1;
+                continue;
+            }
+
+            var activationEvent = ActivationEvent.Create(
+                command.UserId,
+                milestone,
+                item.HouseholdId,
+                command.Platform,
+                region: null,
+                item.Metadata,
+                item.OccurredAtUtc,
+                recordedAtUtc);
+
+            await repository.AddAsync(activationEvent, cancellationToken);
+            acceptedCount += 1;
+        }
+
+        return RecordEventResult.Success(acceptedCount, duplicateCount);
+    }
+}

--- a/backend/src/Modules/Analytics/Application/RecordEvent/RecordEventItem.cs
+++ b/backend/src/Modules/Analytics/Application/RecordEvent/RecordEventItem.cs
@@ -1,0 +1,7 @@
+namespace MoneyTracker.Modules.Analytics.Application.RecordEvent;
+
+public sealed record RecordEventItem(
+    string Milestone,
+    Guid? HouseholdId,
+    Dictionary<string, string>? Metadata,
+    DateTimeOffset OccurredAtUtc);

--- a/backend/src/Modules/Analytics/Application/RecordEvent/RecordEventResult.cs
+++ b/backend/src/Modules/Analytics/Application/RecordEvent/RecordEventResult.cs
@@ -1,0 +1,26 @@
+namespace MoneyTracker.Modules.Analytics.Application.RecordEvent;
+
+public sealed class RecordEventResult
+{
+    public bool IsSuccess { get; private init; }
+    public int AcceptedCount { get; private init; }
+    public int DuplicateCount { get; private init; }
+    public string? ErrorCode { get; private init; }
+    public string? ErrorMessage { get; private init; }
+
+    public static RecordEventResult Success(int acceptedCount, int duplicateCount) =>
+        new()
+        {
+            IsSuccess = true,
+            AcceptedCount = acceptedCount,
+            DuplicateCount = duplicateCount
+        };
+
+    public static RecordEventResult Failure(string errorCode, string errorMessage) =>
+        new()
+        {
+            IsSuccess = false,
+            ErrorCode = errorCode,
+            ErrorMessage = errorMessage
+        };
+}

--- a/backend/src/Modules/Analytics/Domain/ActivationEvent.cs
+++ b/backend/src/Modules/Analytics/Domain/ActivationEvent.cs
@@ -1,0 +1,72 @@
+namespace MoneyTracker.Modules.Analytics.Domain;
+
+public sealed class ActivationEvent
+{
+    public Guid Id { get; }
+    public Guid UserId { get; }
+    public ActivationMilestone Milestone { get; }
+    public Guid? HouseholdId { get; }
+    public string Platform { get; }
+    public string? Region { get; }
+    public Dictionary<string, string>? Metadata { get; }
+    public DateTimeOffset OccurredAtUtc { get; }
+    public DateTimeOffset RecordedAtUtc { get; }
+
+    private ActivationEvent(
+        Guid id,
+        Guid userId,
+        ActivationMilestone milestone,
+        Guid? householdId,
+        string platform,
+        string? region,
+        Dictionary<string, string>? metadata,
+        DateTimeOffset occurredAtUtc,
+        DateTimeOffset recordedAtUtc)
+    {
+        Id = id;
+        UserId = userId;
+        Milestone = milestone;
+        HouseholdId = householdId;
+        Platform = platform;
+        Region = region;
+        Metadata = metadata;
+        OccurredAtUtc = occurredAtUtc;
+        RecordedAtUtc = recordedAtUtc;
+    }
+
+    public static ActivationEvent Create(
+        Guid userId,
+        ActivationMilestone milestone,
+        Guid? householdId,
+        string platform,
+        string? region,
+        Dictionary<string, string>? metadata,
+        DateTimeOffset occurredAtUtc,
+        DateTimeOffset recordedAtUtc)
+    {
+        if (userId == Guid.Empty)
+        {
+            throw new AnalyticsDomainException(
+                AnalyticsErrors.ValidationError,
+                "User ID is required.");
+        }
+
+        if (string.IsNullOrWhiteSpace(platform))
+        {
+            throw new AnalyticsDomainException(
+                AnalyticsErrors.ValidationError,
+                "Platform is required.");
+        }
+
+        return new ActivationEvent(
+            Guid.NewGuid(),
+            userId,
+            milestone,
+            householdId,
+            platform,
+            region,
+            metadata,
+            occurredAtUtc,
+            recordedAtUtc);
+    }
+}

--- a/backend/src/Modules/Analytics/Domain/ActivationMilestone.cs
+++ b/backend/src/Modules/Analytics/Domain/ActivationMilestone.cs
@@ -1,0 +1,66 @@
+namespace MoneyTracker.Modules.Analytics.Domain;
+
+public enum ActivationMilestone
+{
+    SignupCompleted,
+    HouseholdCreated,
+    PartnerInvited,
+    PartnerJoined,
+    FirstBudgetCreated,
+    FirstTransactionCreated,
+    BankLinkStarted,
+    BankLinkCompleted,
+    FirstSyncCompleted,
+    PaywallViewed,
+    TrialStarted,
+    PaidConversion
+}
+
+public static class ActivationMilestoneExtensions
+{
+    private static readonly Dictionary<string, ActivationMilestone> NameLookup =
+        new(StringComparer.OrdinalIgnoreCase)
+        {
+            ["signup_completed"] = ActivationMilestone.SignupCompleted,
+            ["household_created"] = ActivationMilestone.HouseholdCreated,
+            ["partner_invited"] = ActivationMilestone.PartnerInvited,
+            ["partner_joined"] = ActivationMilestone.PartnerJoined,
+            ["first_budget_created"] = ActivationMilestone.FirstBudgetCreated,
+            ["first_transaction_created"] = ActivationMilestone.FirstTransactionCreated,
+            ["bank_link_started"] = ActivationMilestone.BankLinkStarted,
+            ["bank_link_completed"] = ActivationMilestone.BankLinkCompleted,
+            ["first_sync_completed"] = ActivationMilestone.FirstSyncCompleted,
+            ["paywall_viewed"] = ActivationMilestone.PaywallViewed,
+            ["trial_started"] = ActivationMilestone.TrialStarted,
+            ["paid_conversion"] = ActivationMilestone.PaidConversion,
+        };
+
+    private static readonly Dictionary<ActivationMilestone, string> ValueLookup =
+        NameLookup.ToDictionary(kvp => kvp.Value, kvp => kvp.Key);
+
+    public static bool TryParse(string name, out ActivationMilestone milestone)
+    {
+        return NameLookup.TryGetValue(name, out milestone);
+    }
+
+    public static string ToSnakeCase(this ActivationMilestone milestone)
+    {
+        return ValueLookup[milestone];
+    }
+
+    public static IReadOnlyList<ActivationMilestone> OrderedStages { get; } =
+    [
+        ActivationMilestone.SignupCompleted,
+        ActivationMilestone.HouseholdCreated,
+        ActivationMilestone.PartnerInvited,
+        ActivationMilestone.PartnerJoined,
+        ActivationMilestone.FirstBudgetCreated,
+        ActivationMilestone.FirstTransactionCreated,
+        ActivationMilestone.BankLinkStarted,
+        ActivationMilestone.BankLinkCompleted,
+        ActivationMilestone.FirstSyncCompleted,
+        ActivationMilestone.PaywallViewed,
+        ActivationMilestone.TrialStarted,
+        ActivationMilestone.PaidConversion,
+    ];
+}

--- a/backend/src/Modules/Analytics/Domain/AnalyticsDomainException.cs
+++ b/backend/src/Modules/Analytics/Domain/AnalyticsDomainException.cs
@@ -1,0 +1,12 @@
+namespace MoneyTracker.Modules.Analytics.Domain;
+
+public sealed class AnalyticsDomainException : Exception
+{
+    public string Code { get; }
+
+    public AnalyticsDomainException(string code, string message)
+        : base(message)
+    {
+        Code = code;
+    }
+}

--- a/backend/src/Modules/Analytics/Domain/AnalyticsErrors.cs
+++ b/backend/src/Modules/Analytics/Domain/AnalyticsErrors.cs
@@ -1,0 +1,8 @@
+namespace MoneyTracker.Modules.Analytics.Domain;
+
+public static class AnalyticsErrors
+{
+    public const string ValidationError = "ANALYTICS_VALIDATION_ERROR";
+    public const string InvalidMilestone = "ANALYTICS_INVALID_MILESTONE";
+    public const string AccessDenied = "ANALYTICS_ACCESS_DENIED";
+}

--- a/backend/src/Modules/Analytics/Domain/CohortKey.cs
+++ b/backend/src/Modules/Analytics/Domain/CohortKey.cs
@@ -1,0 +1,24 @@
+using System.Globalization;
+
+namespace MoneyTracker.Modules.Analytics.Domain;
+
+public sealed record CohortKey(string Value)
+{
+    public static CohortKey FromDate(DateTimeOffset date)
+    {
+        var calendar = CultureInfo.InvariantCulture.Calendar;
+        var week = calendar.GetWeekOfYear(
+            date.UtcDateTime,
+            CalendarWeekRule.FirstFourDayWeek,
+            DayOfWeek.Monday);
+        var year = date.Year;
+
+        // Handle edge case where the last days of the year belong to week 1 of the next year
+        if (week == 1 && date.Month == 12)
+        {
+            year += 1;
+        }
+
+        return new CohortKey($"{year}-W{week:D2}");
+    }
+}

--- a/backend/src/Modules/Analytics/Domain/CohortSummary.cs
+++ b/backend/src/Modules/Analytics/Domain/CohortSummary.cs
@@ -1,0 +1,6 @@
+namespace MoneyTracker.Modules.Analytics.Domain;
+
+public sealed record CohortSummary(
+    string CohortKey,
+    int SignupCount,
+    double PaidConversionRate);

--- a/backend/src/Modules/Analytics/Domain/FunnelStage.cs
+++ b/backend/src/Modules/Analytics/Domain/FunnelStage.cs
@@ -1,0 +1,7 @@
+namespace MoneyTracker.Modules.Analytics.Domain;
+
+public sealed record FunnelStage(
+    string Milestone,
+    int UserCount,
+    double ConversionRate,
+    double DropOffRate);

--- a/backend/src/Modules/Analytics/Domain/IActivationEventRepository.cs
+++ b/backend/src/Modules/Analytics/Domain/IActivationEventRepository.cs
@@ -1,0 +1,16 @@
+namespace MoneyTracker.Modules.Analytics.Domain;
+
+public interface IActivationEventRepository
+{
+    Task AddAsync(ActivationEvent activationEvent, CancellationToken cancellationToken);
+
+    Task<bool> ExistsAsync(Guid userId, ActivationMilestone milestone, CancellationToken cancellationToken);
+
+    Task<IReadOnlyCollection<ActivationEvent>> GetAllAsync(CancellationToken cancellationToken);
+
+    Task<IReadOnlyCollection<ActivationEvent>> GetByPeriodAsync(
+        DateTimeOffset sinceUtc,
+        string? platform,
+        string? region,
+        CancellationToken cancellationToken);
+}

--- a/backend/src/Modules/Analytics/Infrastructure/AnalyticsEventPublisher.cs
+++ b/backend/src/Modules/Analytics/Infrastructure/AnalyticsEventPublisher.cs
@@ -1,0 +1,50 @@
+using Microsoft.Extensions.Logging;
+using MoneyTracker.Modules.Analytics.Domain;
+using MoneyTracker.Modules.SharedKernel.Analytics;
+
+namespace MoneyTracker.Modules.Analytics.Infrastructure;
+
+public sealed class AnalyticsEventPublisher(
+    IActivationEventRepository repository,
+    TimeProvider timeProvider,
+    ILogger<AnalyticsEventPublisher> logger) : IAnalyticsEventPublisher
+{
+    public async Task PublishAsync(
+        Guid userId,
+        string milestone,
+        Guid? householdId,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            if (!ActivationMilestoneExtensions.TryParse(milestone, out var parsedMilestone))
+            {
+                logger.LogWarning("Invalid activation milestone: {Milestone}", milestone);
+                return;
+            }
+
+            var exists = await repository.ExistsAsync(userId, parsedMilestone, cancellationToken);
+            if (exists)
+            {
+                return;
+            }
+
+            var nowUtc = timeProvider.GetUtcNow();
+            var activationEvent = ActivationEvent.Create(
+                userId,
+                parsedMilestone,
+                householdId,
+                "backend",
+                region: null,
+                metadata: null,
+                occurredAtUtc: nowUtc,
+                recordedAtUtc: nowUtc);
+
+            await repository.AddAsync(activationEvent, cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Failed to publish activation event: {Milestone} for user {UserId}", milestone, userId);
+        }
+    }
+}

--- a/backend/src/Modules/Analytics/Infrastructure/InMemoryActivationEventRepository.cs
+++ b/backend/src/Modules/Analytics/Infrastructure/InMemoryActivationEventRepository.cs
@@ -1,0 +1,86 @@
+using MoneyTracker.Modules.Analytics.Domain;
+
+namespace MoneyTracker.Modules.Analytics.Infrastructure;
+
+public sealed class InMemoryActivationEventRepository : IActivationEventRepository
+{
+    private readonly object _sync = new();
+    private readonly List<ActivationEvent> _events = [];
+    private readonly HashSet<(Guid UserId, ActivationMilestone Milestone)> _uniqueKeys = [];
+
+    public Task AddAsync(ActivationEvent activationEvent, CancellationToken cancellationToken)
+    {
+        if (cancellationToken.IsCancellationRequested)
+        {
+            return Task.FromCanceled(cancellationToken);
+        }
+
+        lock (_sync)
+        {
+            var key = (activationEvent.UserId, activationEvent.Milestone);
+            if (_uniqueKeys.Add(key))
+            {
+                _events.Add(activationEvent);
+            }
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public Task<bool> ExistsAsync(Guid userId, ActivationMilestone milestone, CancellationToken cancellationToken)
+    {
+        if (cancellationToken.IsCancellationRequested)
+        {
+            return Task.FromCanceled<bool>(cancellationToken);
+        }
+
+        lock (_sync)
+        {
+            return Task.FromResult(_uniqueKeys.Contains((userId, milestone)));
+        }
+    }
+
+    public Task<IReadOnlyCollection<ActivationEvent>> GetAllAsync(CancellationToken cancellationToken)
+    {
+        if (cancellationToken.IsCancellationRequested)
+        {
+            return Task.FromCanceled<IReadOnlyCollection<ActivationEvent>>(cancellationToken);
+        }
+
+        lock (_sync)
+        {
+            return Task.FromResult<IReadOnlyCollection<ActivationEvent>>(_events.ToArray());
+        }
+    }
+
+    public Task<IReadOnlyCollection<ActivationEvent>> GetByPeriodAsync(
+        DateTimeOffset sinceUtc,
+        string? platform,
+        string? region,
+        CancellationToken cancellationToken)
+    {
+        if (cancellationToken.IsCancellationRequested)
+        {
+            return Task.FromCanceled<IReadOnlyCollection<ActivationEvent>>(cancellationToken);
+        }
+
+        lock (_sync)
+        {
+            var query = _events.Where(e => e.OccurredAtUtc >= sinceUtc);
+
+            if (platform is not null)
+            {
+                query = query.Where(e =>
+                    string.Equals(e.Platform, platform, StringComparison.OrdinalIgnoreCase));
+            }
+
+            if (region is not null)
+            {
+                query = query.Where(e =>
+                    string.Equals(e.Region, region, StringComparison.OrdinalIgnoreCase));
+            }
+
+            return Task.FromResult<IReadOnlyCollection<ActivationEvent>>(query.ToArray());
+        }
+    }
+}

--- a/backend/src/Modules/Analytics/MoneyTracker.Modules.Analytics.csproj
+++ b/backend/src/Modules/Analytics/MoneyTracker.Modules.Analytics.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    <ProjectReference Include="..\Auth\MoneyTracker.Modules.Auth.csproj" />
+    <ProjectReference Include="..\SharedKernel\MoneyTracker.Modules.SharedKernel.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/backend/src/Modules/Analytics/Presentation/AnalyticsEndpoints.cs
+++ b/backend/src/Modules/Analytics/Presentation/AnalyticsEndpoints.cs
@@ -1,0 +1,217 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using MoneyTracker.Modules.Analytics.Application.GetActivationFunnel;
+using MoneyTracker.Modules.Analytics.Application.RecordEvent;
+using MoneyTracker.Modules.Analytics.Domain;
+using MoneyTracker.Modules.Analytics.Infrastructure;
+using MoneyTracker.Modules.SharedKernel.Analytics;
+using MoneyTracker.Modules.SharedKernel.Presentation;
+
+namespace MoneyTracker.Modules.Analytics.Presentation;
+
+public static class AnalyticsEndpoints
+{
+    public static IServiceCollection AddAnalyticsModule(this IServiceCollection services)
+    {
+        services.AddSingleton<IActivationEventRepository, InMemoryActivationEventRepository>();
+        services.AddSingleton<IAnalyticsEventPublisher, AnalyticsEventPublisher>();
+        services.AddScoped<RecordEventHandler>();
+        services.AddScoped<GetActivationFunnelHandler>();
+
+        return services;
+    }
+
+    public static IEndpointRouteBuilder MapAnalyticsEndpoints(this IEndpointRouteBuilder app)
+    {
+        var recordEventsEndpoint = (RouteHandlerBuilder)app.MapPost("/analytics/events", RecordEvents);
+        recordEventsEndpoint
+            .WithName("RecordAnalyticsEvents")
+            .WithSummary("Record activation events.")
+            .WithDescription("Accepts a batch of activation milestone events for funnel tracking.")
+            .Accepts<RecordEventsRequest>("application/json")
+            .Produces<RecordEventsResponse>(StatusCodes.Status202Accepted)
+            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status401Unauthorized);
+
+        var funnelEndpoint = (RouteHandlerBuilder)app.MapGet("/admin/activation-funnel", GetActivationFunnel);
+        funnelEndpoint
+            .WithName("GetActivationFunnel")
+            .WithSummary("Get activation funnel metrics.")
+            .WithDescription("Returns ordered funnel stages with conversion and drop-off rates. Admin access required.")
+            .Produces<ActivationFunnelResponse>(StatusCodes.Status200OK)
+            .ProducesProblem(StatusCodes.Status401Unauthorized)
+            .ProducesProblem(StatusCodes.Status403Forbidden);
+
+        return app;
+    }
+
+    private static async Task RecordEvents(HttpContext httpContext)
+    {
+        var authResult = await EndpointHelpers.ResolveAuthenticatedUser(httpContext);
+        if (!authResult.Success)
+        {
+            await authResult.Problem!.ExecuteAsync(httpContext);
+            return;
+        }
+
+        var (isValidRequest, request, parseProblem) =
+            await EndpointHelpers.ReadJsonRequestAsync<RecordEventsRequest>(httpContext, AnalyticsErrors.ValidationError);
+        if (!isValidRequest || request is null)
+        {
+            if (parseProblem is not null)
+            {
+                await parseProblem.ExecuteAsync(httpContext);
+            }
+            else
+            {
+                await EndpointHelpers.WriteProblemAsync(
+                    httpContext,
+                    StatusCodes.Status400BadRequest,
+                    "Validation failed.",
+                    "The request payload is required.",
+                    AnalyticsErrors.ValidationError,
+                    AnalyticsErrors.ValidationError);
+            }
+            return;
+        }
+
+        var platform = httpContext.Request.Headers["X-Platform"].FirstOrDefault() ?? "unknown";
+
+        var handler = httpContext.RequestServices.GetRequiredService<RecordEventHandler>();
+        var result = await handler.HandleAsync(
+            new RecordEventCommand(
+                authResult.AuthenticatedUser!.UserId,
+                platform,
+                request.Events
+                    .Select(e => new RecordEventItem(
+                        e.Milestone,
+                        e.HouseholdId,
+                        e.Metadata,
+                        e.OccurredAtUtc))
+                    .ToArray()),
+            httpContext.RequestAborted);
+
+        if (!result.IsSuccess)
+        {
+            var statusCode = result.ErrorCode switch
+            {
+                AnalyticsErrors.InvalidMilestone => StatusCodes.Status400BadRequest,
+                _ => StatusCodes.Status400BadRequest
+            };
+
+            await EndpointHelpers.WriteProblemAsync(
+                httpContext,
+                statusCode,
+                "Validation failed.",
+                result.ErrorMessage ?? "Request rejected.",
+                result.ErrorCode,
+                AnalyticsErrors.ValidationError);
+            return;
+        }
+
+        var response = new RecordEventsResponse(result.AcceptedCount, result.DuplicateCount);
+        httpContext.Response.StatusCode = StatusCodes.Status202Accepted;
+        await httpContext.Response.WriteAsJsonAsync(response, httpContext.RequestAborted);
+    }
+
+    private static async Task GetActivationFunnel(HttpContext httpContext)
+    {
+        var authResult = await EndpointHelpers.ResolveAuthenticatedUser(httpContext);
+        if (!authResult.Success)
+        {
+            await authResult.Problem!.ExecuteAsync(httpContext);
+            return;
+        }
+
+        // Admin role gate
+        var adminService = httpContext.RequestServices.GetRequiredService<IAdminAccessService>();
+        var isAdmin = await adminService.IsAdminAsync(
+            authResult.AuthenticatedUser!.UserId,
+            httpContext.RequestAborted);
+        if (!isAdmin)
+        {
+            await EndpointHelpers.WriteProblemAsync(
+                httpContext,
+                StatusCodes.Status403Forbidden,
+                "Access denied.",
+                "Admin access is required to view activation funnel.",
+                AnalyticsErrors.AccessDenied,
+                AnalyticsErrors.AccessDenied);
+            return;
+        }
+
+        var periodDaysRaw = httpContext.Request.Query["periodDays"].FirstOrDefault();
+        var periodDays = 30;
+        if (periodDaysRaw is not null && int.TryParse(periodDaysRaw, out var parsed) && parsed > 0)
+        {
+            periodDays = parsed;
+        }
+
+        var platform = httpContext.Request.Query["platform"].FirstOrDefault() ?? "all";
+        var region = httpContext.Request.Query["region"].FirstOrDefault() ?? "all";
+
+        var handler = httpContext.RequestServices.GetRequiredService<GetActivationFunnelHandler>();
+        var result = await handler.HandleAsync(
+            new GetActivationFunnelQuery(periodDays, platform, region),
+            httpContext.RequestAborted);
+
+        if (!result.IsSuccess)
+        {
+            await EndpointHelpers.WriteProblemAsync(
+                httpContext,
+                StatusCodes.Status400BadRequest,
+                "Request failed.",
+                result.ErrorMessage ?? "Request rejected.",
+                result.ErrorCode,
+                AnalyticsErrors.ValidationError);
+            return;
+        }
+
+        var response = new ActivationFunnelResponse(
+            result.PeriodDays,
+            result.Platform,
+            result.Region,
+            result.TotalUsers,
+            result.Stages
+                .Select(s => new FunnelStageResponse(s.Milestone, s.UserCount, s.ConversionRate, s.DropOffRate))
+                .ToArray(),
+            result.Cohorts
+                .Select(c => new CohortSummaryResponse(c.CohortKey, c.SignupCount, c.PaidConversionRate))
+                .ToArray());
+
+        await TypedResults.Ok(response).ExecuteAsync(httpContext);
+    }
+}
+
+// Request DTOs
+public sealed record RecordEventsRequest(RecordEventItemRequest[] Events);
+
+public sealed record RecordEventItemRequest(
+    string Milestone,
+    Guid? HouseholdId,
+    Dictionary<string, string>? Metadata,
+    DateTimeOffset OccurredAtUtc);
+
+// Response DTOs
+public sealed record RecordEventsResponse(int AcceptedCount, int DuplicateCount);
+
+public sealed record ActivationFunnelResponse(
+    int PeriodDays,
+    string Platform,
+    string Region,
+    int TotalUsers,
+    FunnelStageResponse[] Stages,
+    CohortSummaryResponse[] Cohorts);
+
+public sealed record FunnelStageResponse(
+    string Milestone,
+    int UserCount,
+    double ConversionRate,
+    double DropOffRate);
+
+public sealed record CohortSummaryResponse(
+    string CohortKey,
+    int SignupCount,
+    double PaidConversionRate);

--- a/backend/src/Modules/Auth/Presentation/AuthEndpoint.cs
+++ b/backend/src/Modules/Auth/Presentation/AuthEndpoint.cs
@@ -92,8 +92,11 @@ public static class AuthEndpoint
                 return;
             }
 
+            // Fire-and-forget: emit signup_completed activation event via IAnalyticsEventPublisher
+            await EmitAnalyticsEventAsync(httpContext, result.Tokens!.UserId, "signup_completed", householdId: null);
+
             var response = new VerifyCodeResponse(
-                result.Tokens!.UserId,
+                result.Tokens.UserId,
                 result.Tokens.Email,
                 result.Tokens.AccessToken,
                 result.Tokens.AccessTokenExpiresAtUtc,
@@ -260,6 +263,37 @@ public static class AuthEndpoint
     {
         var mediaType = contentType.Split(';')[0].Trim();
         return mediaType.Equals("application/json", StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Resolves IAnalyticsEventPublisher from DI at runtime to avoid circular project reference
+    /// (SharedKernel references Auth, so Auth cannot reference SharedKernel).
+    /// Fire-and-forget: failures are silently swallowed.
+    /// </summary>
+    private static async Task EmitAnalyticsEventAsync(
+        HttpContext httpContext, Guid userId, string milestone, Guid? householdId)
+    {
+        try
+        {
+            // Resolve by assembly-qualified type name to avoid compile-time dependency
+            var publisherType = Type.GetType(
+                "MoneyTracker.Modules.SharedKernel.Analytics.IAnalyticsEventPublisher, MoneyTracker.Modules.SharedKernel");
+            if (publisherType is null) return;
+
+            var publisher = httpContext.RequestServices.GetService(publisherType);
+            if (publisher is null) return;
+
+            var publishMethod = publisherType.GetMethod("PublishAsync");
+            if (publishMethod is null) return;
+
+            var task = (Task?)publishMethod.Invoke(publisher,
+                [userId, milestone, householdId, httpContext.RequestAborted]);
+            if (task is not null) await task;
+        }
+        catch
+        {
+            // Analytics emission must not fail the auth flow.
+        }
     }
 }
 

--- a/backend/src/Modules/BankConnections/Application/CreateLinkSession/CreateLinkSessionHandler.cs
+++ b/backend/src/Modules/BankConnections/Application/CreateLinkSession/CreateLinkSessionHandler.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics;
 using Microsoft.Extensions.Logging;
 using MoneyTracker.Modules.BankConnections.Domain;
+using MoneyTracker.Modules.SharedKernel.Analytics;
 using MoneyTracker.Modules.SharedKernel.Households;
 
 namespace MoneyTracker.Modules.BankConnections.Application.CreateLinkSession;
@@ -10,6 +11,7 @@ public sealed class CreateLinkSessionHandler(
     IBankProviderAdapter providerAdapter,
     IHouseholdAccessService householdAccessService,
     ILinkEventRepository linkEventRepository,
+    IAnalyticsEventPublisher analyticsPublisher,
     TimeProvider timeProvider,
     ILogger<CreateLinkSessionHandler> logger)
 {
@@ -105,6 +107,9 @@ public sealed class CreateLinkSessionHandler(
             stopwatch.ElapsedMilliseconds,
             errorCategory: null,
             cancellationToken);
+
+        await analyticsPublisher.PublishAsync(
+            command.RequestingUserId, "bank_link_started", command.HouseholdId, cancellationToken);
 
         return CreateLinkSessionResult.Success(consentResult.ConsentUrl!, connection.Id.Value);
     }

--- a/backend/src/Modules/BankConnections/Application/ProcessCallback/ProcessCallbackHandler.cs
+++ b/backend/src/Modules/BankConnections/Application/ProcessCallback/ProcessCallbackHandler.cs
@@ -1,10 +1,12 @@
 using MoneyTracker.Modules.BankConnections.Domain;
+using MoneyTracker.Modules.SharedKernel.Analytics;
 
 namespace MoneyTracker.Modules.BankConnections.Application.ProcessCallback;
 
 public sealed class ProcessCallbackHandler(
     IBankConnectionRepository repository,
     IBankProviderAdapter providerAdapter,
+    IAnalyticsEventPublisher analyticsPublisher,
     TimeProvider timeProvider)
 {
     public async Task<ProcessCallbackResult> HandleAsync(
@@ -83,6 +85,10 @@ public sealed class ProcessCallbackHandler(
         }
 
         await repository.UpdateAsync(connection, cancellationToken);
+
+        await analyticsPublisher.PublishAsync(
+            connection.CreatedByUserId, "bank_link_completed", connection.HouseholdId, cancellationToken);
+
         return ProcessCallbackResult.Success(connection);
     }
 }

--- a/backend/src/Modules/BankConnections/Application/SyncTransactions/SyncTransactionsHandler.cs
+++ b/backend/src/Modules/BankConnections/Application/SyncTransactions/SyncTransactionsHandler.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics;
 using Microsoft.Extensions.Logging;
 using MoneyTracker.Modules.BankConnections.Domain;
+using MoneyTracker.Modules.SharedKernel.Analytics;
 using MoneyTracker.Modules.SharedKernel.Transactions;
 
 namespace MoneyTracker.Modules.BankConnections.Application.SyncTransactions;
@@ -10,6 +11,7 @@ public sealed class SyncTransactionsHandler(
     IBankProviderAdapter providerAdapter,
     ITransactionSyncRepository transactionSyncRepository,
     ISyncEventRepository syncEventRepository,
+    IAnalyticsEventPublisher analyticsPublisher,
     TimeProvider timeProvider,
     ILogger<SyncTransactionsHandler> logger)
 {
@@ -71,6 +73,9 @@ public sealed class SyncTransactionsHandler(
                     synced + skipped,
                     errorCategory: null,
                     cancellationToken);
+
+                await analyticsPublisher.PublishAsync(
+                    connection.CreatedByUserId, "first_sync_completed", connection.HouseholdId, cancellationToken);
             }
             catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
             {

--- a/backend/src/Modules/Budgets/Application/CreateBudgetCategory/CreateBudgetCategoryHandler.cs
+++ b/backend/src/Modules/Budgets/Application/CreateBudgetCategory/CreateBudgetCategoryHandler.cs
@@ -1,4 +1,5 @@
 using MoneyTracker.Modules.Budgets.Domain;
+using MoneyTracker.Modules.SharedKernel.Analytics;
 using MoneyTracker.Modules.SharedKernel.Households;
 
 namespace MoneyTracker.Modules.Budgets.Application.CreateBudgetCategory;
@@ -6,7 +7,8 @@ namespace MoneyTracker.Modules.Budgets.Application.CreateBudgetCategory;
 public sealed class CreateBudgetCategoryHandler(
     IBudgetRepository repository,
     IHouseholdAccessService householdAccessService,
-    TimeProvider timeProvider)
+    TimeProvider timeProvider,
+    IAnalyticsEventPublisher analyticsPublisher)
 {
     public async Task<CreateBudgetCategoryResult> HandleAsync(
         CreateBudgetCategoryCommand command,
@@ -45,6 +47,9 @@ public sealed class CreateBudgetCategoryHandler(
         {
             return CreateBudgetCategoryResult.Conflict();
         }
+
+        await analyticsPublisher.PublishAsync(
+            command.RequestingUserId, "first_budget_created", command.HouseholdId, cancellationToken);
 
         return CreateBudgetCategoryResult.Success(category);
     }

--- a/backend/src/Modules/Households/Application/AcceptHouseholdInvitation/AcceptHouseholdInvitationHandler.cs
+++ b/backend/src/Modules/Households/Application/AcceptHouseholdInvitation/AcceptHouseholdInvitationHandler.cs
@@ -1,8 +1,12 @@
 using MoneyTracker.Modules.Households.Domain;
+using MoneyTracker.Modules.SharedKernel.Analytics;
 
 namespace MoneyTracker.Modules.Households.Application.AcceptHouseholdInvitation;
 
-public sealed class AcceptHouseholdInvitationHandler(IHouseholdRepository repository, TimeProvider timeProvider)
+public sealed class AcceptHouseholdInvitationHandler(
+    IHouseholdRepository repository,
+    TimeProvider timeProvider,
+    IAnalyticsEventPublisher analyticsPublisher)
 {
     public async Task<AcceptHouseholdInvitationResult> HandleAsync(
         AcceptHouseholdInvitationCommand command,
@@ -68,6 +72,9 @@ public sealed class AcceptHouseholdInvitationHandler(IHouseholdRepository reposi
                 HouseholdErrors.HouseholdInvitationUsed,
                 "Invitation already used.");
         }
+
+        await analyticsPublisher.PublishAsync(
+            command.AcceptingUserId, "partner_joined", invitation.HouseholdId.Value, cancellationToken);
 
         return AcceptHouseholdInvitationResult.Success();
     }

--- a/backend/src/Modules/Households/Application/CreateHousehold/CreateHouseholdHandler.cs
+++ b/backend/src/Modules/Households/Application/CreateHousehold/CreateHouseholdHandler.cs
@@ -1,8 +1,12 @@
 using MoneyTracker.Modules.Households.Domain;
+using MoneyTracker.Modules.SharedKernel.Analytics;
 
 namespace MoneyTracker.Modules.Households.Application.CreateHousehold;
 
-public sealed class CreateHouseholdHandler(IHouseholdRepository repository, TimeProvider timeProvider)
+public sealed class CreateHouseholdHandler(
+    IHouseholdRepository repository,
+    TimeProvider timeProvider,
+    IAnalyticsEventPublisher analyticsPublisher)
 {
     public async Task<CreateHouseholdResult> HandleAsync(CreateHouseholdCommand command, CancellationToken cancellationToken)
     {
@@ -22,6 +26,9 @@ public sealed class CreateHouseholdHandler(IHouseholdRepository repository, Time
         {
             return CreateHouseholdResult.Conflict();
         }
+
+        await analyticsPublisher.PublishAsync(
+            command.OwnerUserId, "household_created", household.Id.Value, cancellationToken);
 
         return CreateHouseholdResult.Success(household);
     }

--- a/backend/src/Modules/Households/Application/InviteHouseholdMember/InviteHouseholdMemberHandler.cs
+++ b/backend/src/Modules/Households/Application/InviteHouseholdMember/InviteHouseholdMemberHandler.cs
@@ -1,8 +1,12 @@
 using MoneyTracker.Modules.Households.Domain;
+using MoneyTracker.Modules.SharedKernel.Analytics;
 
 namespace MoneyTracker.Modules.Households.Application.InviteHouseholdMember;
 
-public sealed class InviteHouseholdMemberHandler(IHouseholdRepository repository, TimeProvider timeProvider)
+public sealed class InviteHouseholdMemberHandler(
+    IHouseholdRepository repository,
+    TimeProvider timeProvider,
+    IAnalyticsEventPublisher analyticsPublisher)
 {
     public async Task<InviteHouseholdMemberResult> HandleAsync(
         InviteHouseholdMemberCommand command,
@@ -39,6 +43,9 @@ public sealed class InviteHouseholdMemberHandler(IHouseholdRepository repository
         {
             return InviteHouseholdMemberResult.Failure(HouseholdErrors.ValidationError, "Invitation could not be created.");
         }
+
+        await analyticsPublisher.PublishAsync(
+            command.InviterUserId, "partner_invited", command.HouseholdId.Value, cancellationToken);
 
         return InviteHouseholdMemberResult.Success(invitationToken, expiresAtUtc);
     }

--- a/backend/src/Modules/SharedKernel/Analytics/IAnalyticsEventPublisher.cs
+++ b/backend/src/Modules/SharedKernel/Analytics/IAnalyticsEventPublisher.cs
@@ -1,0 +1,6 @@
+namespace MoneyTracker.Modules.SharedKernel.Analytics;
+
+public interface IAnalyticsEventPublisher
+{
+    Task PublishAsync(Guid userId, string milestone, Guid? householdId, CancellationToken cancellationToken);
+}

--- a/backend/src/Modules/SharedKernel/Analytics/NoopAnalyticsEventPublisher.cs
+++ b/backend/src/Modules/SharedKernel/Analytics/NoopAnalyticsEventPublisher.cs
@@ -1,0 +1,9 @@
+namespace MoneyTracker.Modules.SharedKernel.Analytics;
+
+public sealed class NoopAnalyticsEventPublisher : IAnalyticsEventPublisher
+{
+    public Task PublishAsync(Guid userId, string milestone, Guid? householdId, CancellationToken cancellationToken)
+    {
+        return Task.CompletedTask;
+    }
+}

--- a/backend/src/Modules/Transactions/Application/CreateTransaction/CreateTransactionHandler.cs
+++ b/backend/src/Modules/Transactions/Application/CreateTransaction/CreateTransactionHandler.cs
@@ -1,4 +1,5 @@
 using MoneyTracker.Modules.Budgets.Domain;
+using MoneyTracker.Modules.SharedKernel.Analytics;
 using MoneyTracker.Modules.SharedKernel.Households;
 using MoneyTracker.Modules.Transactions.Domain;
 
@@ -8,7 +9,8 @@ public sealed class CreateTransactionHandler(
     ITransactionRepository transactionRepository,
     IBudgetRepository budgetRepository,
     IHouseholdAccessService householdAccessService,
-    TimeProvider timeProvider)
+    TimeProvider timeProvider,
+    IAnalyticsEventPublisher analyticsPublisher)
 {
     public async Task<CreateTransactionResult> HandleAsync(
         CreateTransactionCommand command,
@@ -58,6 +60,10 @@ public sealed class CreateTransactionHandler(
         }
 
         await transactionRepository.AddAsync(transaction, cancellationToken);
+
+        await analyticsPublisher.PublishAsync(
+            command.RequestingUserId, "first_transaction_created", command.HouseholdId, cancellationToken);
+
         return CreateTransactionResult.Success(transaction);
     }
 }

--- a/backend/src/MoneyTracker.Api/MoneyTracker.Api.csproj
+++ b/backend/src/MoneyTracker.Api/MoneyTracker.Api.csproj
@@ -15,6 +15,7 @@
     <ProjectReference Include="..\Modules\Transactions\MoneyTracker.Modules.Transactions.csproj" />
     <ProjectReference Include="..\Modules\BankConnections\MoneyTracker.Modules.BankConnections.csproj" />
     <ProjectReference Include="..\Modules\Subscriptions\MoneyTracker.Modules.Subscriptions.csproj" />
+    <ProjectReference Include="..\Modules\Analytics\MoneyTracker.Modules.Analytics.csproj" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.0" />
   </ItemGroup>
 

--- a/backend/src/MoneyTracker.Api/Program.cs
+++ b/backend/src/MoneyTracker.Api/Program.cs
@@ -9,6 +9,7 @@ using MoneyTracker.Modules.Notifications.Presentation;
 using MoneyTracker.Modules.Transactions.Presentation;
 using MoneyTracker.Modules.BankConnections.Presentation;
 using MoneyTracker.Modules.Subscriptions.Presentation;
+using MoneyTracker.Modules.Analytics.Presentation;
 using MoneyTracker.Api.Observability;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -25,6 +26,7 @@ builder.Services.AddBillRemindersModule();
 builder.Services.AddNotificationsModule();
 builder.Services.AddBankConnectionsModule();
 builder.Services.AddSubscriptionsModule();
+builder.Services.AddAnalyticsModule();
 builder.Services.AddOpenApi();
 
 var app = builder.Build();
@@ -48,6 +50,7 @@ app.MapBillReminderEndpoints();
 app.MapNotificationEndpoints();
 app.MapBankConnectionEndpoints();
 app.MapSubscriptionEndpoints();
+app.MapAnalyticsEndpoints();
 
 if (app.Environment.IsEnvironment("Testing"))
 {

--- a/backend/tests/MoneyTracker.Modules.Analytics.Tests/ActivationEventTests.cs
+++ b/backend/tests/MoneyTracker.Modules.Analytics.Tests/ActivationEventTests.cs
@@ -1,0 +1,111 @@
+using MoneyTracker.Modules.Analytics.Domain;
+
+namespace MoneyTracker.Modules.Analytics.Tests;
+
+public sealed class ActivationEventTests
+{
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void Create_WithValidFields_ReturnsEvent()
+    {
+        // P5-2-UNIT-07: ActivationEvent.Create() validates required fields
+        var userId = Guid.NewGuid();
+        var occurredAtUtc = DateTimeOffset.Parse("2026-03-01T12:00:00Z");
+        var recordedAtUtc = DateTimeOffset.Parse("2026-03-01T12:00:01Z");
+
+        var evt = ActivationEvent.Create(
+            userId,
+            ActivationMilestone.SignupCompleted,
+            householdId: null,
+            "ios",
+            "AU",
+            metadata: null,
+            occurredAtUtc,
+            recordedAtUtc);
+
+        Assert.Equal(userId, evt.UserId);
+        Assert.Equal(ActivationMilestone.SignupCompleted, evt.Milestone);
+        Assert.Equal("ios", evt.Platform);
+        Assert.Equal("AU", evt.Region);
+        Assert.Equal(occurredAtUtc, evt.OccurredAtUtc);
+        Assert.Equal(recordedAtUtc, evt.RecordedAtUtc);
+        Assert.NotEqual(Guid.Empty, evt.Id);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void Create_WithEmptyUserId_ThrowsAnalyticsDomainException()
+    {
+        // P5-2-UNIT-07: Throws AnalyticsDomainException on empty userId
+        var exception = Assert.Throws<AnalyticsDomainException>(() =>
+            ActivationEvent.Create(
+                Guid.Empty,
+                ActivationMilestone.SignupCompleted,
+                householdId: null,
+                "ios",
+                "AU",
+                metadata: null,
+                DateTimeOffset.UtcNow,
+                DateTimeOffset.UtcNow));
+
+        Assert.Equal(AnalyticsErrors.ValidationError, exception.Code);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void Create_WithEmptyPlatform_ThrowsAnalyticsDomainException()
+    {
+        // P5-2-UNIT-07: Throws AnalyticsDomainException on null platform
+        var exception = Assert.Throws<AnalyticsDomainException>(() =>
+            ActivationEvent.Create(
+                Guid.NewGuid(),
+                ActivationMilestone.SignupCompleted,
+                householdId: null,
+                "  ",
+                "AU",
+                metadata: null,
+                DateTimeOffset.UtcNow,
+                DateTimeOffset.UtcNow));
+
+        Assert.Equal(AnalyticsErrors.ValidationError, exception.Code);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void ActivationMilestone_TryParse_ValidNames()
+    {
+        Assert.True(ActivationMilestoneExtensions.TryParse("signup_completed", out var m1));
+        Assert.Equal(ActivationMilestone.SignupCompleted, m1);
+
+        Assert.True(ActivationMilestoneExtensions.TryParse("household_created", out var m2));
+        Assert.Equal(ActivationMilestone.HouseholdCreated, m2);
+
+        Assert.True(ActivationMilestoneExtensions.TryParse("paid_conversion", out var m3));
+        Assert.Equal(ActivationMilestone.PaidConversion, m3);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void ActivationMilestone_TryParse_InvalidName_ReturnsFalse()
+    {
+        Assert.False(ActivationMilestoneExtensions.TryParse("invalid_milestone", out _));
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void ActivationMilestone_ToSnakeCase_ReturnsCorrectNames()
+    {
+        Assert.Equal("signup_completed", ActivationMilestone.SignupCompleted.ToSnakeCase());
+        Assert.Equal("household_created", ActivationMilestone.HouseholdCreated.ToSnakeCase());
+        Assert.Equal("paid_conversion", ActivationMilestone.PaidConversion.ToSnakeCase());
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void OrderedStages_Contains12Milestones()
+    {
+        Assert.Equal(12, ActivationMilestoneExtensions.OrderedStages.Count);
+        Assert.Equal(ActivationMilestone.SignupCompleted, ActivationMilestoneExtensions.OrderedStages[0]);
+        Assert.Equal(ActivationMilestone.PaidConversion, ActivationMilestoneExtensions.OrderedStages[^1]);
+    }
+}

--- a/backend/tests/MoneyTracker.Modules.Analytics.Tests/GetActivationFunnelHandlerTests.cs
+++ b/backend/tests/MoneyTracker.Modules.Analytics.Tests/GetActivationFunnelHandlerTests.cs
@@ -1,0 +1,219 @@
+using MoneyTracker.Modules.Analytics.Application.GetActivationFunnel;
+using MoneyTracker.Modules.Analytics.Domain;
+using MoneyTracker.Modules.Analytics.Infrastructure;
+
+namespace MoneyTracker.Modules.Analytics.Tests;
+
+public sealed class GetActivationFunnelHandlerTests
+{
+    private static readonly DateTimeOffset NowUtc = DateTimeOffset.Parse("2026-03-10T12:00:00Z");
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task HandleAsync_ComputesStageCounts()
+    {
+        // P5-2-UNIT-04: GetActivationFunnelHandler computes stage counts correctly
+        var repository = new InMemoryActivationEventRepository();
+        var user1 = Guid.NewGuid();
+        var user2 = Guid.NewGuid();
+
+        await SeedEvent(repository, user1, ActivationMilestone.SignupCompleted, NowUtc.AddDays(-5));
+        await SeedEvent(repository, user2, ActivationMilestone.SignupCompleted, NowUtc.AddDays(-4));
+        await SeedEvent(repository, user1, ActivationMilestone.HouseholdCreated, NowUtc.AddDays(-4));
+
+        var handler = new GetActivationFunnelHandler(repository, new StubTimeProvider(NowUtc));
+        var result = await handler.HandleAsync(
+            new GetActivationFunnelQuery(PeriodDays: 30),
+            CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(2, result.TotalUsers);
+
+        var signupStage = result.Stages.First(s => s.Milestone == "signup_completed");
+        Assert.Equal(2, signupStage.UserCount);
+        Assert.Equal(1.0, signupStage.ConversionRate);
+
+        var householdStage = result.Stages.First(s => s.Milestone == "household_created");
+        Assert.Equal(1, householdStage.UserCount);
+        Assert.Equal(0.5, householdStage.ConversionRate);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task HandleAsync_ComputesDropOffRates()
+    {
+        // P5-2-UNIT-05: Drop-off rates computed correctly between consecutive stages
+        var repository = new InMemoryActivationEventRepository();
+
+        // 10 users do signup, 8 do household_created, 4 do partner_invited
+        for (var i = 0; i < 10; i++)
+        {
+            var uid = Guid.NewGuid();
+            await SeedEvent(repository, uid, ActivationMilestone.SignupCompleted, NowUtc.AddDays(-5));
+            if (i < 8)
+                await SeedEvent(repository, uid, ActivationMilestone.HouseholdCreated, NowUtc.AddDays(-4));
+            if (i < 4)
+                await SeedEvent(repository, uid, ActivationMilestone.PartnerInvited, NowUtc.AddDays(-3));
+        }
+
+        var handler = new GetActivationFunnelHandler(repository, new StubTimeProvider(NowUtc));
+        var result = await handler.HandleAsync(
+            new GetActivationFunnelQuery(PeriodDays: 30),
+            CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+
+        var signupStage = result.Stages.First(s => s.Milestone == "signup_completed");
+        Assert.Equal(0.0, signupStage.DropOffRate); // first stage has no drop-off
+
+        var householdStage = result.Stages.First(s => s.Milestone == "household_created");
+        Assert.Equal(0.2, householdStage.DropOffRate); // 1 - (8/10) = 0.2
+
+        var partnerStage = result.Stages.First(s => s.Milestone == "partner_invited");
+        Assert.Equal(0.5, partnerStage.DropOffRate); // 1 - (4/8) = 0.5
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task HandleAsync_CohortGroupingByIsoWeek()
+    {
+        // P5-2-UNIT-06: Cohort grouping by ISO signup week
+        var repository = new InMemoryActivationEventRepository();
+
+        var user1 = Guid.NewGuid();
+        var user2 = Guid.NewGuid();
+        var user3 = Guid.NewGuid();
+
+        // Week 10 signups (Mar 2-8, 2026)
+        await SeedEvent(repository, user1, ActivationMilestone.SignupCompleted,
+            DateTimeOffset.Parse("2026-03-02T10:00:00Z"));
+        await SeedEvent(repository, user2, ActivationMilestone.SignupCompleted,
+            DateTimeOffset.Parse("2026-03-04T10:00:00Z"));
+
+        // Week 9 signup (Feb 23-Mar 1, 2026)
+        await SeedEvent(repository, user3, ActivationMilestone.SignupCompleted,
+            DateTimeOffset.Parse("2026-02-25T10:00:00Z"));
+
+        // user1 has paid_conversion
+        await SeedEvent(repository, user1, ActivationMilestone.PaidConversion,
+            DateTimeOffset.Parse("2026-03-09T10:00:00Z"));
+
+        var handler = new GetActivationFunnelHandler(repository, new StubTimeProvider(NowUtc));
+        var result = await handler.HandleAsync(
+            new GetActivationFunnelQuery(PeriodDays: 30),
+            CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(2, result.Cohorts.Count);
+
+        // Verify week 10 cohort: 2 signups, 1 paid = 0.5 rate
+        var week10 = result.Cohorts.FirstOrDefault(c => c.SignupCount == 2);
+        Assert.NotNull(week10);
+        Assert.Equal(0.5, week10.PaidConversionRate);
+
+        // Verify week 9 cohort: 1 signup, 0 paid = 0.0 rate
+        var week9 = result.Cohorts.FirstOrDefault(c => c.SignupCount == 1);
+        Assert.NotNull(week9);
+        Assert.Equal(0.0, week9.PaidConversionRate);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task HandleAsync_FiltersByPlatform()
+    {
+        // P5-2-UNIT-08: Funnel query filters by platform
+        var repository = new InMemoryActivationEventRepository();
+
+        var user1 = Guid.NewGuid();
+        var user2 = Guid.NewGuid();
+
+        await SeedEvent(repository, user1, ActivationMilestone.SignupCompleted, NowUtc.AddDays(-5), "ios");
+        await SeedEvent(repository, user2, ActivationMilestone.SignupCompleted, NowUtc.AddDays(-4), "android");
+
+        var handler = new GetActivationFunnelHandler(repository, new StubTimeProvider(NowUtc));
+        var result = await handler.HandleAsync(
+            new GetActivationFunnelQuery(PeriodDays: 30, Platform: "ios"),
+            CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(1, result.TotalUsers);
+
+        var signupStage = result.Stages.First(s => s.Milestone == "signup_completed");
+        Assert.Equal(1, signupStage.UserCount);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task HandleAsync_FiltersByRegion()
+    {
+        // P5-2-UNIT-09: Funnel query filters by region
+        var repository = new InMemoryActivationEventRepository();
+
+        var user1 = Guid.NewGuid();
+        var user2 = Guid.NewGuid();
+
+        await SeedEvent(repository, user1, ActivationMilestone.SignupCompleted, NowUtc.AddDays(-5), "ios", "AU");
+        await SeedEvent(repository, user2, ActivationMilestone.SignupCompleted, NowUtc.AddDays(-4), "ios", "NZ");
+
+        var handler = new GetActivationFunnelHandler(repository, new StubTimeProvider(NowUtc));
+        var result = await handler.HandleAsync(
+            new GetActivationFunnelQuery(PeriodDays: 30, Region: "AU"),
+            CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(1, result.TotalUsers);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task HandleAsync_ZeroPreviousCount_DropOffRateIsZero()
+    {
+        // P5-2-UNIT-10: Drop-off rate handles zero previous stage count
+        var repository = new InMemoryActivationEventRepository();
+
+        var handler = new GetActivationFunnelHandler(repository, new StubTimeProvider(NowUtc));
+        var result = await handler.HandleAsync(
+            new GetActivationFunnelQuery(PeriodDays: 30),
+            CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(0, result.TotalUsers);
+
+        // All stages should have 0 counts and 0 drop-off rates
+        foreach (var stage in result.Stages)
+        {
+            Assert.Equal(0, stage.UserCount);
+            Assert.Equal(0.0, stage.DropOffRate);
+        }
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task HandleAsync_Returns12Stages()
+    {
+        var repository = new InMemoryActivationEventRepository();
+        var handler = new GetActivationFunnelHandler(repository, new StubTimeProvider(NowUtc));
+        var result = await handler.HandleAsync(
+            new GetActivationFunnelQuery(PeriodDays: 30),
+            CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(12, result.Stages.Count);
+        Assert.Equal("signup_completed", result.Stages.First().Milestone);
+        Assert.Equal("paid_conversion", result.Stages.Last().Milestone);
+    }
+
+    private static async Task SeedEvent(
+        InMemoryActivationEventRepository repository,
+        Guid userId,
+        ActivationMilestone milestone,
+        DateTimeOffset occurredAtUtc,
+        string platform = "backend",
+        string? region = null)
+    {
+        var evt = ActivationEvent.Create(
+            userId, milestone, householdId: null, platform, region,
+            metadata: null, occurredAtUtc, occurredAtUtc);
+        await repository.AddAsync(evt, CancellationToken.None);
+    }
+}

--- a/backend/tests/MoneyTracker.Modules.Analytics.Tests/MoneyTracker.Modules.Analytics.Tests.csproj
+++ b/backend/tests/MoneyTracker.Modules.Analytics.Tests/MoneyTracker.Modules.Analytics.Tests.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Modules\Analytics\MoneyTracker.Modules.Analytics.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>

--- a/backend/tests/MoneyTracker.Modules.Analytics.Tests/RecordEventHandlerTests.cs
+++ b/backend/tests/MoneyTracker.Modules.Analytics.Tests/RecordEventHandlerTests.cs
@@ -1,0 +1,142 @@
+using MoneyTracker.Modules.Analytics.Application.RecordEvent;
+using MoneyTracker.Modules.Analytics.Domain;
+using MoneyTracker.Modules.Analytics.Infrastructure;
+
+namespace MoneyTracker.Modules.Analytics.Tests;
+
+public sealed class RecordEventHandlerTests
+{
+    private static readonly DateTimeOffset NowUtc = DateTimeOffset.Parse("2026-03-01T12:00:00Z");
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task HandleAsync_PersistsValidBatch()
+    {
+        // P5-2-UNIT-01: RecordEventHandler persists valid batch of events
+        var repository = new InMemoryActivationEventRepository();
+        var handler = new RecordEventHandler(repository, new StubTimeProvider(NowUtc));
+        var userId = Guid.NewGuid();
+
+        var result = await handler.HandleAsync(
+            new RecordEventCommand(userId, "ios",
+            [
+                new RecordEventItem("signup_completed", null, null, NowUtc),
+                new RecordEventItem("household_created", Guid.NewGuid(), null, NowUtc),
+            ]),
+            CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(2, result.AcceptedCount);
+        Assert.Equal(0, result.DuplicateCount);
+
+        var all = await repository.GetAllAsync(CancellationToken.None);
+        Assert.Equal(2, all.Count);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task HandleAsync_RejectsInvalidMilestone()
+    {
+        // P5-2-UNIT-02: RecordEventHandler rejects invalid milestone name
+        var repository = new InMemoryActivationEventRepository();
+        var handler = new RecordEventHandler(repository, new StubTimeProvider(NowUtc));
+        var userId = Guid.NewGuid();
+
+        var result = await handler.HandleAsync(
+            new RecordEventCommand(userId, "ios",
+            [
+                new RecordEventItem("not_a_real_milestone", null, null, NowUtc),
+            ]),
+            CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(AnalyticsErrors.InvalidMilestone, result.ErrorCode);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task HandleAsync_DeduplicatesByUserIdAndMilestone()
+    {
+        // P5-2-UNIT-03: RecordEventHandler deduplicates by (userId, milestone)
+        var repository = new InMemoryActivationEventRepository();
+        var handler = new RecordEventHandler(repository, new StubTimeProvider(NowUtc));
+        var userId = Guid.NewGuid();
+
+        // First submission
+        var result1 = await handler.HandleAsync(
+            new RecordEventCommand(userId, "ios",
+            [
+                new RecordEventItem("signup_completed", null, null, NowUtc),
+            ]),
+            CancellationToken.None);
+
+        Assert.True(result1.IsSuccess);
+        Assert.Equal(1, result1.AcceptedCount);
+        Assert.Equal(0, result1.DuplicateCount);
+
+        // Second submission of same milestone for same user
+        var result2 = await handler.HandleAsync(
+            new RecordEventCommand(userId, "ios",
+            [
+                new RecordEventItem("signup_completed", null, null, NowUtc),
+            ]),
+            CancellationToken.None);
+
+        Assert.True(result2.IsSuccess);
+        Assert.Equal(0, result2.AcceptedCount);
+        Assert.Equal(1, result2.DuplicateCount);
+
+        var all = await repository.GetAllAsync(CancellationToken.None);
+        Assert.Single(all);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task HandleAsync_EmptyBatch_ReturnsValidationError()
+    {
+        var repository = new InMemoryActivationEventRepository();
+        var handler = new RecordEventHandler(repository, new StubTimeProvider(NowUtc));
+
+        var result = await handler.HandleAsync(
+            new RecordEventCommand(Guid.NewGuid(), "ios", []),
+            CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(AnalyticsErrors.ValidationError, result.ErrorCode);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task HandleAsync_MixedValidAndDuplicateEvents_CorrectCounts()
+    {
+        var repository = new InMemoryActivationEventRepository();
+        var handler = new RecordEventHandler(repository, new StubTimeProvider(NowUtc));
+        var userId = Guid.NewGuid();
+
+        // First insert signup_completed
+        await handler.HandleAsync(
+            new RecordEventCommand(userId, "ios",
+            [
+                new RecordEventItem("signup_completed", null, null, NowUtc),
+            ]),
+            CancellationToken.None);
+
+        // Now send both a duplicate and a new event
+        var result = await handler.HandleAsync(
+            new RecordEventCommand(userId, "ios",
+            [
+                new RecordEventItem("signup_completed", null, null, NowUtc),
+                new RecordEventItem("household_created", Guid.NewGuid(), null, NowUtc),
+            ]),
+            CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(1, result.AcceptedCount);
+        Assert.Equal(1, result.DuplicateCount);
+    }
+}
+
+internal sealed class StubTimeProvider(DateTimeOffset utcNow) : TimeProvider
+{
+    public override DateTimeOffset GetUtcNow() => utcNow;
+}

--- a/backend/tests/MoneyTracker.Modules.BankConnections.Tests/Application/CheckConsentExpiryHandlerTests.cs
+++ b/backend/tests/MoneyTracker.Modules.BankConnections.Tests/Application/CheckConsentExpiryHandlerTests.cs
@@ -4,6 +4,7 @@ using MoneyTracker.Modules.BankConnections.Application.ProcessCallback;
 using MoneyTracker.Modules.BankConnections.Application.SyncTransactions;
 using MoneyTracker.Modules.BankConnections.Domain;
 using MoneyTracker.Modules.BankConnections.Infrastructure;
+using MoneyTracker.Modules.SharedKernel.Analytics;
 using MoneyTracker.Modules.SharedKernel.Transactions;
 
 namespace MoneyTracker.Modules.BankConnections.Tests.Application;
@@ -129,6 +130,7 @@ public sealed class CheckConsentExpiryHandlerTests
         var handler = new SyncTransactionsHandler(
             connectionRepo, providerAdapter, transactionRepo,
             new NoOpSyncEventRepository(),
+            new NoopAnalyticsEventPublisher(),
             new StubTimeProvider(NowUtc),
             NullLogger<SyncTransactionsHandler>.Instance);
 
@@ -163,6 +165,7 @@ public sealed class CheckConsentExpiryHandlerTests
         var callbackHandler = new ProcessCallbackHandler(
             connectionRepo,
             providerAdapter,
+            new NoopAnalyticsEventPublisher(),
             new StubTimeProvider(NowUtc));
 
         var result = await callbackHandler.HandleAsync(

--- a/backend/tests/MoneyTracker.Modules.BankConnections.Tests/Application/CreateLinkSessionHandlerTests.cs
+++ b/backend/tests/MoneyTracker.Modules.BankConnections.Tests/Application/CreateLinkSessionHandlerTests.cs
@@ -2,6 +2,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 using MoneyTracker.Modules.BankConnections.Application.CreateLinkSession;
 using MoneyTracker.Modules.BankConnections.Domain;
 using MoneyTracker.Modules.BankConnections.Infrastructure;
+using MoneyTracker.Modules.SharedKernel.Analytics;
 using MoneyTracker.Modules.SharedKernel.Households;
 
 namespace MoneyTracker.Modules.BankConnections.Tests.Application;
@@ -18,6 +19,7 @@ public sealed class CreateLinkSessionHandlerTests
             new StubBankProviderAdapter(),
             new NotFoundHouseholdAccessService(),
             new StubLinkEventRepository(),
+            new NoopAnalyticsEventPublisher(),
             new FakeTimeProvider(DateTimeOffset.Parse("2026-03-01T00:00:00Z")),
             NullLogger<CreateLinkSessionHandler>.Instance);
 
@@ -38,6 +40,7 @@ public sealed class CreateLinkSessionHandlerTests
             new StubBankProviderAdapter(),
             new DeniedHouseholdAccessService(),
             new StubLinkEventRepository(),
+            new NoopAnalyticsEventPublisher(),
             new FakeTimeProvider(DateTimeOffset.Parse("2026-03-01T00:00:00Z")),
             NullLogger<CreateLinkSessionHandler>.Instance);
 
@@ -58,6 +61,7 @@ public sealed class CreateLinkSessionHandlerTests
             new StubBankProviderAdapter(),
             new AllowedHouseholdAccessService(),
             new StubLinkEventRepository(),
+            new NoopAnalyticsEventPublisher(),
             new FakeTimeProvider(DateTimeOffset.Parse("2026-03-01T00:00:00Z")),
             NullLogger<CreateLinkSessionHandler>.Instance);
 
@@ -80,6 +84,7 @@ public sealed class CreateLinkSessionHandlerTests
             new FailingBankProviderAdapter(),
             new AllowedHouseholdAccessService(),
             new StubLinkEventRepository(),
+            new NoopAnalyticsEventPublisher(),
             new FakeTimeProvider(DateTimeOffset.Parse("2026-03-01T00:00:00Z")),
             NullLogger<CreateLinkSessionHandler>.Instance);
 

--- a/backend/tests/MoneyTracker.Modules.BankConnections.Tests/Application/NonFunctionalTests.cs
+++ b/backend/tests/MoneyTracker.Modules.BankConnections.Tests/Application/NonFunctionalTests.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 using MoneyTracker.Modules.BankConnections.Application.SyncTransactions;
 using MoneyTracker.Modules.BankConnections.Domain;
 using MoneyTracker.Modules.BankConnections.Infrastructure;
+using MoneyTracker.Modules.SharedKernel.Analytics;
 
 namespace MoneyTracker.Modules.BankConnections.Tests.Application;
 
@@ -28,6 +29,7 @@ public sealed class NonFunctionalTests
         var handler = new SyncTransactionsHandler(
             connectionRepo, providerAdapter, transactionRepo,
             new StubSyncEventRepository(),
+            new NoopAnalyticsEventPublisher(),
             new StubTimeProvider(NowUtc),
             NullLogger<SyncTransactionsHandler>.Instance);
 

--- a/backend/tests/MoneyTracker.Modules.BankConnections.Tests/Application/SyncTransactionsHandlerTests.cs
+++ b/backend/tests/MoneyTracker.Modules.BankConnections.Tests/Application/SyncTransactionsHandlerTests.cs
@@ -1,6 +1,7 @@
 using Microsoft.Extensions.Logging.Abstractions;
 using MoneyTracker.Modules.BankConnections.Application.SyncTransactions;
 using MoneyTracker.Modules.BankConnections.Domain;
+using MoneyTracker.Modules.SharedKernel.Analytics;
 using MoneyTracker.Modules.SharedKernel.Transactions;
 using MoneyTracker.Modules.Transactions.Domain;
 
@@ -38,6 +39,7 @@ public sealed class SyncTransactionsHandlerTests
         var handler = new SyncTransactionsHandler(
             connectionRepo, providerAdapter, transactionRepo,
             new StubSyncEventRepository(),
+            new NoopAnalyticsEventPublisher(),
             new StubTimeProvider(NowUtc),
             NullLogger<SyncTransactionsHandler>.Instance);
 
@@ -70,6 +72,7 @@ public sealed class SyncTransactionsHandlerTests
         var handler = new SyncTransactionsHandler(
             connectionRepo, providerAdapter, transactionRepo,
             new StubSyncEventRepository(),
+            new NoopAnalyticsEventPublisher(),
             new StubTimeProvider(NowUtc),
             NullLogger<SyncTransactionsHandler>.Instance);
 
@@ -101,6 +104,7 @@ public sealed class SyncTransactionsHandlerTests
         var handler = new SyncTransactionsHandler(
             connectionRepo, providerAdapter, transactionRepo,
             new StubSyncEventRepository(),
+            new NoopAnalyticsEventPublisher(),
             new StubTimeProvider(NowUtc),
             NullLogger<SyncTransactionsHandler>.Instance);
 
@@ -130,6 +134,7 @@ public sealed class SyncTransactionsHandlerTests
         var handler = new SyncTransactionsHandler(
             connectionRepo, providerAdapter, transactionRepo,
             new StubSyncEventRepository(),
+            new NoopAnalyticsEventPublisher(),
             new StubTimeProvider(NowUtc),
             NullLogger<SyncTransactionsHandler>.Instance);
 

--- a/backend/tests/MoneyTracker.Modules.BankConnections.Tests/Integration/BasiqBankProviderAdapterTests.cs
+++ b/backend/tests/MoneyTracker.Modules.BankConnections.Tests/Integration/BasiqBankProviderAdapterTests.cs
@@ -7,6 +7,7 @@ using MoneyTracker.Modules.BankConnections.Application.ProcessCallback;
 using MoneyTracker.Modules.BankConnections.Domain;
 using MoneyTracker.Modules.BankConnections.Infrastructure;
 using MoneyTracker.Modules.BankConnections.Tests.Application;
+using MoneyTracker.Modules.SharedKernel.Analytics;
 
 namespace MoneyTracker.Modules.BankConnections.Tests.Integration;
 
@@ -103,6 +104,7 @@ public sealed class BasiqBankProviderAdapterTests
             stubAdapter,
             new AllowedHouseholdAccessService(),
             new StubLinkEventRepository(),
+            new NoopAnalyticsEventPublisher(),
             timeProvider,
             NullLogger<CreateLinkSessionHandler>.Instance);
 
@@ -119,6 +121,7 @@ public sealed class BasiqBankProviderAdapterTests
         var callbackHandler = new ProcessCallbackHandler(
             repository,
             stubAdapter,
+            new NoopAnalyticsEventPublisher(),
             timeProvider);
 
         var callbackResult = await callbackHandler.HandleAsync(

--- a/backend/tests/MoneyTracker.Modules.BankConnections.Tests/Integration/ConsentExpiryIntegrationTests.cs
+++ b/backend/tests/MoneyTracker.Modules.BankConnections.Tests/Integration/ConsentExpiryIntegrationTests.cs
@@ -5,6 +5,7 @@ using MoneyTracker.Modules.BankConnections.Application.SyncTransactions;
 using MoneyTracker.Modules.BankConnections.Domain;
 using MoneyTracker.Modules.BankConnections.Infrastructure;
 using MoneyTracker.Modules.BankConnections.Tests.Application;
+using MoneyTracker.Modules.SharedKernel.Analytics;
 using MoneyTracker.Modules.SharedKernel.Transactions;
 
 namespace MoneyTracker.Modules.BankConnections.Tests.Integration;
@@ -107,6 +108,7 @@ public sealed class ConsentExpiryIntegrationTests
         var callbackHandler = new ProcessCallbackHandler(
             connectionRepo,
             providerAdapter,
+            new NoopAnalyticsEventPublisher(),
             new StubTimeProvider(NowUtc));
 
         var callbackResult = await callbackHandler.HandleAsync(
@@ -153,6 +155,7 @@ public sealed class ConsentExpiryIntegrationTests
         var handler = new SyncTransactionsHandler(
             connectionRepo, providerAdapter, transactionRepo,
             new NoOpSyncEventRepository(),
+            new NoopAnalyticsEventPublisher(),
             new StubTimeProvider(NowUtc),
             NullLogger<SyncTransactionsHandler>.Instance);
 

--- a/backend/tests/MoneyTracker.Modules.BankConnections.Tests/Integration/SyncOrchestratorTests.cs
+++ b/backend/tests/MoneyTracker.Modules.BankConnections.Tests/Integration/SyncOrchestratorTests.cs
@@ -2,6 +2,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 using MoneyTracker.Modules.BankConnections.Application.SyncTransactions;
 using MoneyTracker.Modules.BankConnections.Domain;
 using MoneyTracker.Modules.BankConnections.Tests.Application;
+using MoneyTracker.Modules.SharedKernel.Analytics;
 using MoneyTracker.Modules.SharedKernel.Transactions;
 
 namespace MoneyTracker.Modules.BankConnections.Tests.Integration;
@@ -47,6 +48,7 @@ public sealed class SyncOrchestratorTests
         var handler = new SyncTransactionsHandler(
             connectionRepo, providerAdapter, transactionRepo,
             new StubSyncEventRepository(),
+            new NoopAnalyticsEventPublisher(),
             new StubTimeProvider(NowUtc),
             NullLogger<SyncTransactionsHandler>.Instance);
 
@@ -86,6 +88,7 @@ public sealed class SyncOrchestratorTests
         var handler = new SyncTransactionsHandler(
             connectionRepo, providerAdapter, transactionRepo,
             new StubSyncEventRepository(),
+            new NoopAnalyticsEventPublisher(),
             new StubTimeProvider(NowUtc),
             NullLogger<SyncTransactionsHandler>.Instance);
 
@@ -134,6 +137,7 @@ public sealed class SyncOrchestratorTests
         var handler = new SyncTransactionsHandler(
             connectionRepo, providerAdapter, transactionRepo,
             new StubSyncEventRepository(),
+            new NoopAnalyticsEventPublisher(),
             new StubTimeProvider(NowUtc),
             NullLogger<SyncTransactionsHandler>.Instance);
 

--- a/backend/tests/MoneyTracker.Modules.Budgets.Tests/Application/CreateBudgetCategoryHandlerTests.cs
+++ b/backend/tests/MoneyTracker.Modules.Budgets.Tests/Application/CreateBudgetCategoryHandlerTests.cs
@@ -1,6 +1,7 @@
 using MoneyTracker.Modules.Budgets.Application.CreateBudgetCategory;
 using MoneyTracker.Modules.Budgets.Domain;
 using MoneyTracker.Modules.Budgets.Infrastructure;
+using MoneyTracker.Modules.SharedKernel.Analytics;
 using MoneyTracker.Modules.SharedKernel.Households;
 
 namespace MoneyTracker.Modules.Budgets.Tests.Application;
@@ -17,7 +18,8 @@ public sealed class CreateBudgetCategoryHandlerTests
         var handler = new CreateBudgetCategoryHandler(
             repository,
             new AllowedHouseholdAccessService(),
-            TimeProvider.System);
+            TimeProvider.System,
+            new NoopAnalyticsEventPublisher());
 
         var first = await handler.HandleAsync(
             new CreateBudgetCategoryCommand(householdId, "Dining", userId),

--- a/backend/tests/MoneyTracker.Modules.Households.Tests/Application/CreateHouseholdHandlerTests.cs
+++ b/backend/tests/MoneyTracker.Modules.Households.Tests/Application/CreateHouseholdHandlerTests.cs
@@ -1,5 +1,6 @@
 using MoneyTracker.Modules.Households.Application.CreateHousehold;
 using MoneyTracker.Modules.Households.Domain;
+using MoneyTracker.Modules.SharedKernel.Analytics;
 
 namespace MoneyTracker.Modules.Households.Tests.Application;
 
@@ -13,7 +14,7 @@ public sealed class CreateHouseholdHandlerTests
     {
         var repository = new FakeHouseholdRepository(addSucceeds: true);
         var expectedCreatedAtUtc = DateTimeOffset.Parse("2026-02-03T04:05:06Z");
-        var handler = new CreateHouseholdHandler(repository, new FakeTimeProvider(expectedCreatedAtUtc));
+        var handler = new CreateHouseholdHandler(repository, new FakeTimeProvider(expectedCreatedAtUtc), new NoopAnalyticsEventPublisher());
 
         var result = await handler.HandleAsync(new CreateHouseholdCommand("Primary Home", OwnerUserId), CancellationToken.None);
 
@@ -33,7 +34,7 @@ public sealed class CreateHouseholdHandlerTests
     public async Task HandleAsync_ReturnsConflict_WhenNameAlreadyExistsCaseInsensitive()
     {
         var repository = new FakeHouseholdRepository(addSucceeds: true, existingName: " Shared ");
-        var handler = new CreateHouseholdHandler(repository, TimeProvider.System);
+        var handler = new CreateHouseholdHandler(repository, TimeProvider.System, new NoopAnalyticsEventPublisher());
 
         var result = await handler.HandleAsync(new CreateHouseholdCommand("sHaReD", OwnerUserId), CancellationToken.None);
 
@@ -47,7 +48,7 @@ public sealed class CreateHouseholdHandlerTests
     public async Task HandleAsync_ReturnsValidationError_WhenNameInvalid()
     {
         var repository = new FakeHouseholdRepository(addSucceeds: true);
-        var handler = new CreateHouseholdHandler(repository, TimeProvider.System);
+        var handler = new CreateHouseholdHandler(repository, TimeProvider.System, new NoopAnalyticsEventPublisher());
 
         var result = await handler.HandleAsync(new CreateHouseholdCommand("   ", OwnerUserId), CancellationToken.None);
 

--- a/backend/tests/MoneyTracker.Modules.Transactions.Tests/Application/CreateTransactionHandlerTests.cs
+++ b/backend/tests/MoneyTracker.Modules.Transactions.Tests/Application/CreateTransactionHandlerTests.cs
@@ -1,4 +1,5 @@
 using MoneyTracker.Modules.Budgets.Infrastructure;
+using MoneyTracker.Modules.SharedKernel.Analytics;
 using MoneyTracker.Modules.SharedKernel.Households;
 using MoneyTracker.Modules.Transactions.Application.CreateTransaction;
 using MoneyTracker.Modules.Transactions.Domain;
@@ -19,7 +20,8 @@ public sealed class CreateTransactionHandlerTests
             new InMemoryTransactionRepository(),
             new InMemoryBudgetRepository(),
             new AllowedHouseholdAccessService(),
-            new FakeTimeProvider(nowUtc));
+            new FakeTimeProvider(nowUtc),
+            new NoopAnalyticsEventPublisher());
 
         var result = await handler.HandleAsync(
             new CreateTransactionCommand(

--- a/mobile/lib/shared_kernel/analytics/activation_tracker.dart
+++ b/mobile/lib/shared_kernel/analytics/activation_tracker.dart
@@ -1,0 +1,84 @@
+import 'analytics_service.dart';
+
+/// Callback for loading the set of already-recorded milestones from storage.
+typedef RecordedMilestonesLoader = Future<Set<String>> Function();
+
+/// Callback for saving the set of recorded milestones to storage.
+typedef RecordedMilestonesSaver = Future<void> Function(Set<String> milestones);
+
+/// Wraps [AnalyticsService] with per-user deduplication so each activation
+/// milestone is tracked at most once per user session (or across sessions
+/// when backed by persistent storage).
+class ActivationTracker {
+  ActivationTracker({
+    required AnalyticsService analyticsService,
+    RecordedMilestonesLoader? loader,
+    RecordedMilestonesSaver? saver,
+  })  : _analyticsService = analyticsService,
+        _loader = loader,
+        _saver = saver;
+
+  final AnalyticsService _analyticsService;
+  final RecordedMilestonesLoader? _loader;
+  final RecordedMilestonesSaver? _saver;
+  final Set<String> _recorded = {};
+  bool _restored = false;
+
+  /// The set of milestones that have already been recorded.
+  Set<String> get recorded => Set.unmodifiable(_recorded);
+
+  /// Restores previously recorded milestones from persistent storage.
+  Future<void> restore() async {
+    if (_loader == null) return;
+    try {
+      final loaded = await _loader!();
+      _recorded.addAll(loaded);
+      _restored = true;
+    } catch (_) {
+      // Restore failure is tolerated; deduplication may re-emit.
+    }
+  }
+
+  /// Tracks a milestone if it has not already been recorded for this user.
+  ///
+  /// Returns `true` if the milestone was newly tracked, `false` if it was
+  /// a duplicate.
+  Future<bool> trackIfNew(
+    String milestone, {
+    String? householdId,
+    Map<String, String>? metadata,
+  }) async {
+    if (!_restored && _loader != null) {
+      await restore();
+    }
+
+    if (_recorded.contains(milestone)) {
+      return false;
+    }
+
+    await _analyticsService.track(
+      milestone,
+      householdId: householdId,
+      metadata: metadata,
+    );
+    _recorded.add(milestone);
+    await _save();
+    return true;
+  }
+
+  /// Resets the deduplication state (e.g. on user logout).
+  Future<void> reset() async {
+    _recorded.clear();
+    _restored = false;
+    await _save();
+  }
+
+  Future<void> _save() async {
+    if (_saver == null) return;
+    try {
+      await _saver!(Set.from(_recorded));
+    } catch (_) {
+      // Save failure is tolerated.
+    }
+  }
+}

--- a/mobile/lib/shared_kernel/analytics/analytics_event.dart
+++ b/mobile/lib/shared_kernel/analytics/analytics_event.dart
@@ -1,0 +1,57 @@
+/// A structured analytics event representing a user activation milestone.
+class AnalyticsEvent {
+  AnalyticsEvent({
+    required this.milestone,
+    this.householdId,
+    this.metadata,
+    required this.occurredAtUtc,
+  });
+
+  /// The milestone identifier (e.g. "signup_completed", "household_created").
+  final String milestone;
+
+  /// Optional household context for household-scoped milestones.
+  final String? householdId;
+
+  /// Optional key-value metadata for enrichment.
+  final Map<String, String>? metadata;
+
+  /// The UTC timestamp when the milestone occurred on the client.
+  final DateTime occurredAtUtc;
+
+  Map<String, dynamic> toJson() => {
+        'milestone': milestone,
+        if (householdId != null) 'householdId': householdId,
+        if (metadata != null) 'metadata': metadata,
+        'occurredAtUtc': occurredAtUtc.toUtc().toIso8601String(),
+      };
+
+  factory AnalyticsEvent.fromJson(Map<String, dynamic> json) {
+    return AnalyticsEvent(
+      milestone: json['milestone'] as String,
+      householdId: json['householdId'] as String?,
+      metadata: json['metadata'] != null
+          ? Map<String, String>.from(json['metadata'] as Map)
+          : null,
+      occurredAtUtc: DateTime.parse(json['occurredAtUtc'] as String),
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is AnalyticsEvent &&
+          runtimeType == other.runtimeType &&
+          milestone == other.milestone &&
+          householdId == other.householdId &&
+          occurredAtUtc == other.occurredAtUtc;
+
+  @override
+  int get hashCode =>
+      milestone.hashCode ^ householdId.hashCode ^ occurredAtUtc.hashCode;
+
+  @override
+  String toString() =>
+      'AnalyticsEvent(milestone: $milestone, householdId: $householdId, '
+      'occurredAtUtc: $occurredAtUtc)';
+}

--- a/mobile/lib/shared_kernel/analytics/analytics_queue.dart
+++ b/mobile/lib/shared_kernel/analytics/analytics_queue.dart
@@ -1,0 +1,143 @@
+import 'dart:async';
+import 'dart:collection';
+import 'dart:convert';
+
+import 'analytics_event.dart';
+
+/// Callback for sending a batch of events to the analytics API.
+typedef EventBatchSender = Future<bool> Function(List<AnalyticsEvent> batch);
+
+/// Callback for persisting the queue to durable storage.
+typedef QueuePersister = Future<void> Function(List<AnalyticsEvent> events);
+
+/// Callback for loading persisted queue from durable storage.
+typedef QueueLoader = Future<List<AnalyticsEvent>> Function();
+
+/// A local queue that batches [AnalyticsEvent] items and sends them
+/// asynchronously via [EventBatchSender]. Events are persisted to local
+/// storage so they survive app restarts.
+class AnalyticsQueue {
+  AnalyticsQueue({
+    required EventBatchSender sender,
+    QueuePersister? persister,
+    QueueLoader? loader,
+    int batchSize = 10,
+    Duration flushInterval = const Duration(seconds: 30),
+  })  : _sender = sender,
+        _persister = persister,
+        _loader = loader,
+        _batchSize = batchSize,
+        _flushInterval = flushInterval;
+
+  final EventBatchSender _sender;
+  final QueuePersister? _persister;
+  final QueueLoader? _loader;
+  final int _batchSize;
+  final Duration _flushInterval;
+
+  final Queue<AnalyticsEvent> _queue = Queue<AnalyticsEvent>();
+  Timer? _flushTimer;
+  bool _isFlushing = false;
+
+  /// The number of events currently queued.
+  int get length => _queue.length;
+
+  /// Loads any previously persisted events from local storage.
+  Future<void> restore() async {
+    if (_loader == null) return;
+    try {
+      final events = await _loader!();
+      _queue.addAll(events);
+    } catch (_) {
+      // Restore failure is tolerated; events may be lost.
+    }
+  }
+
+  /// Starts the periodic flush timer.
+  void start() {
+    _flushTimer?.cancel();
+    _flushTimer = Timer.periodic(_flushInterval, (_) => flush());
+  }
+
+  /// Stops the periodic flush timer.
+  void stop() {
+    _flushTimer?.cancel();
+    _flushTimer = null;
+  }
+
+  /// Enqueues an event and triggers a flush if the batch size is reached.
+  Future<void> enqueue(AnalyticsEvent event) async {
+    _queue.add(event);
+    await _persist();
+    if (_queue.length >= _batchSize) {
+      await flush();
+    }
+  }
+
+  /// Sends all queued events in batches. Events that fail to send remain
+  /// in the queue for the next flush cycle.
+  Future<void> flush() async {
+    if (_isFlushing || _queue.isEmpty) return;
+    _isFlushing = true;
+
+    try {
+      while (_queue.isNotEmpty) {
+        final batch = <AnalyticsEvent>[];
+        final count =
+            _queue.length < _batchSize ? _queue.length : _batchSize;
+        for (var i = 0; i < count; i++) {
+          batch.add(_queue.removeFirst());
+        }
+
+        try {
+          final success = await _sender(batch);
+          if (!success) {
+            // Put failed events back at the front of the queue.
+            for (final event in batch.reversed) {
+              _queue.addFirst(event);
+            }
+            break; // Stop trying; the next flush cycle will retry.
+          }
+        } catch (_) {
+          // Sender threw; put events back and stop retrying.
+          for (final event in batch.reversed) {
+            _queue.addFirst(event);
+          }
+          break;
+        }
+      }
+    } catch (_) {
+      // Flush failure is tolerated; events remain queued.
+    } finally {
+      _isFlushing = false;
+      await _persist();
+    }
+  }
+
+  Future<void> _persist() async {
+    if (_persister == null) return;
+    try {
+      await _persister!(_queue.toList());
+    } catch (_) {
+      // Persist failure is tolerated.
+    }
+  }
+
+  /// Disposes the queue, stopping the flush timer.
+  void dispose() {
+    stop();
+  }
+
+  /// Serializes the current queue contents to a JSON string.
+  static String serialize(List<AnalyticsEvent> events) {
+    return jsonEncode(events.map((e) => e.toJson()).toList());
+  }
+
+  /// Deserializes a JSON string to a list of events.
+  static List<AnalyticsEvent> deserialize(String json) {
+    final list = jsonDecode(json) as List;
+    return list
+        .map((e) => AnalyticsEvent.fromJson(e as Map<String, dynamic>))
+        .toList();
+  }
+}

--- a/mobile/lib/shared_kernel/analytics/analytics_service.dart
+++ b/mobile/lib/shared_kernel/analytics/analytics_service.dart
@@ -1,0 +1,67 @@
+import 'analytics_event.dart';
+import 'analytics_queue.dart';
+
+/// Callback that provides the current UTC time. Useful for testing.
+typedef UtcNowProvider = DateTime Function();
+
+/// Singleton event tracking service for analytics milestones.
+///
+/// Wraps an [AnalyticsQueue] and provides a simple `track()` API.
+/// All events are enqueued locally and sent asynchronously via the queue's
+/// flush mechanism (fire-and-forget).
+abstract interface class AnalyticsService {
+  /// Tracks a milestone event.
+  ///
+  /// [milestone] must be a valid activation milestone name (e.g.
+  /// "signup_completed", "household_created").
+  Future<void> track(
+    String milestone, {
+    String? householdId,
+    Map<String, String>? metadata,
+  });
+}
+
+/// Default implementation that delegates to an [AnalyticsQueue].
+class QueuedAnalyticsService implements AnalyticsService {
+  QueuedAnalyticsService({
+    required AnalyticsQueue queue,
+    UtcNowProvider utcNow = _defaultUtcNow,
+  })  : _queue = queue,
+        _utcNow = utcNow;
+
+  final AnalyticsQueue _queue;
+  final UtcNowProvider _utcNow;
+
+  static DateTime _defaultUtcNow() => DateTime.now().toUtc();
+
+  @override
+  Future<void> track(
+    String milestone, {
+    String? householdId,
+    Map<String, String>? metadata,
+  }) async {
+    final event = AnalyticsEvent(
+      milestone: milestone,
+      householdId: householdId,
+      metadata: metadata,
+      occurredAtUtc: _utcNow(),
+    );
+    try {
+      await _queue.enqueue(event);
+    } catch (_) {
+      // Fire-and-forget: tracking failures must not disrupt the app.
+    }
+  }
+}
+
+/// A no-op implementation for use in tests or when analytics is disabled.
+class NoopAnalyticsService implements AnalyticsService {
+  const NoopAnalyticsService();
+
+  @override
+  Future<void> track(
+    String milestone, {
+    String? householdId,
+    Map<String, String>? metadata,
+  }) async {}
+}

--- a/mobile/test/unit/analytics/activation_tracker_test.dart
+++ b/mobile/test/unit/analytics/activation_tracker_test.dart
@@ -1,0 +1,151 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:money_tracker/shared_kernel/analytics/activation_tracker.dart';
+import 'package:money_tracker/shared_kernel/analytics/analytics_event.dart';
+import 'package:money_tracker/shared_kernel/analytics/analytics_queue.dart';
+import 'package:money_tracker/shared_kernel/analytics/analytics_service.dart';
+
+void main() {
+  group('ActivationTracker', () {
+    QueuedAnalyticsService _makeService(List<List<AnalyticsEvent>> sent) {
+      final queue = AnalyticsQueue(
+        sender: (batch) async {
+          sent.add(List.of(batch));
+          return true;
+        },
+        batchSize: 1,
+      );
+      return QueuedAnalyticsService(
+        queue: queue,
+        utcNow: () => DateTime.utc(2026, 3, 7, 12, 0, 0),
+      );
+    }
+
+    test('trackIfNew tracks first occurrence and returns true', () async {
+      final sent = <List<AnalyticsEvent>>[];
+      final tracker = ActivationTracker(
+        analyticsService: _makeService(sent),
+      );
+
+      final result = await tracker.trackIfNew('signup_completed');
+
+      expect(result, true);
+      expect(sent.length, 1);
+      expect(sent.first.first.milestone, 'signup_completed');
+    });
+
+    test('trackIfNew returns false for duplicate milestone', () async {
+      final sent = <List<AnalyticsEvent>>[];
+      final tracker = ActivationTracker(
+        analyticsService: _makeService(sent),
+      );
+
+      await tracker.trackIfNew('signup_completed');
+      final result = await tracker.trackIfNew('signup_completed');
+
+      expect(result, false);
+      expect(sent.length, 1); // Only tracked once.
+    });
+
+    test('trackIfNew tracks different milestones independently', () async {
+      final sent = <List<AnalyticsEvent>>[];
+      final tracker = ActivationTracker(
+        analyticsService: _makeService(sent),
+      );
+
+      final r1 = await tracker.trackIfNew('signup_completed');
+      final r2 = await tracker.trackIfNew('household_created');
+
+      expect(r1, true);
+      expect(r2, true);
+      expect(sent.length, 2);
+    });
+
+    test('trackIfNew passes householdId and metadata through', () async {
+      final sent = <List<AnalyticsEvent>>[];
+      final tracker = ActivationTracker(
+        analyticsService: _makeService(sent),
+      );
+
+      await tracker.trackIfNew(
+        'household_created',
+        householdId: 'hh-1',
+        metadata: {'source': 'onboarding'},
+      );
+
+      expect(sent.first.first.householdId, 'hh-1');
+      expect(sent.first.first.metadata, {'source': 'onboarding'});
+    });
+
+    test('restore loads previously recorded milestones', () async {
+      final sent = <List<AnalyticsEvent>>[];
+      final tracker = ActivationTracker(
+        analyticsService: _makeService(sent),
+        loader: () async => {'signup_completed'},
+      );
+
+      await tracker.restore();
+
+      // Should be deduplicated because restore loaded it.
+      final result = await tracker.trackIfNew('signup_completed');
+      expect(result, false);
+      expect(sent.length, 0);
+    });
+
+    test('restore tolerates loader failure', () async {
+      final sent = <List<AnalyticsEvent>>[];
+      final tracker = ActivationTracker(
+        analyticsService: _makeService(sent),
+        loader: () async => throw Exception('storage error'),
+      );
+
+      await tracker.restore(); // Should not throw.
+
+      // Since restore failed, milestone is not in the recorded set.
+      final result = await tracker.trackIfNew('signup_completed');
+      expect(result, true);
+    });
+
+    test('saver is called when milestone is newly tracked', () async {
+      final saved = <Set<String>>[];
+      final tracker = ActivationTracker(
+        analyticsService: const NoopAnalyticsService(),
+        saver: (milestones) async => saved.add(Set.from(milestones)),
+      );
+
+      await tracker.trackIfNew('signup_completed');
+
+      expect(saved.length, 1);
+      expect(saved.first, {'signup_completed'});
+    });
+
+    test('reset clears recorded milestones', () async {
+      final sent = <List<AnalyticsEvent>>[];
+      final tracker = ActivationTracker(
+        analyticsService: _makeService(sent),
+      );
+
+      await tracker.trackIfNew('signup_completed');
+      expect(tracker.recorded, {'signup_completed'});
+
+      await tracker.reset();
+      expect(tracker.recorded, isEmpty);
+
+      // Can track again after reset.
+      final result = await tracker.trackIfNew('signup_completed');
+      expect(result, true);
+      expect(sent.length, 2);
+    });
+
+    test('auto-restores on first trackIfNew if loader is set', () async {
+      final sent = <List<AnalyticsEvent>>[];
+      final tracker = ActivationTracker(
+        analyticsService: _makeService(sent),
+        loader: () async => {'signup_completed'},
+      );
+
+      // Don't call restore() — trackIfNew should auto-restore.
+      final result = await tracker.trackIfNew('signup_completed');
+      expect(result, false); // Already recorded via auto-restore.
+    });
+  });
+}

--- a/mobile/test/unit/analytics/analytics_queue_test.dart
+++ b/mobile/test/unit/analytics/analytics_queue_test.dart
@@ -1,0 +1,163 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:money_tracker/shared_kernel/analytics/analytics_event.dart';
+import 'package:money_tracker/shared_kernel/analytics/analytics_queue.dart';
+
+void main() {
+  group('AnalyticsQueue', () {
+    AnalyticsEvent _makeEvent(String milestone) => AnalyticsEvent(
+          milestone: milestone,
+          occurredAtUtc: DateTime.utc(2026, 3, 7, 12, 0, 0),
+        );
+
+    test('enqueue adds events and flushes at batch size', () async {
+      final sent = <List<AnalyticsEvent>>[];
+      final queue = AnalyticsQueue(
+        sender: (batch) async {
+          sent.add(List.of(batch));
+          return true;
+        },
+        batchSize: 2,
+      );
+
+      await queue.enqueue(_makeEvent('signup_completed'));
+      expect(sent.length, 0); // Not yet at batch size.
+
+      await queue.enqueue(_makeEvent('household_created'));
+      expect(sent.length, 1);
+      expect(sent.first.length, 2);
+      expect(sent.first[0].milestone, 'signup_completed');
+      expect(sent.first[1].milestone, 'household_created');
+    });
+
+    test('flush sends all queued events', () async {
+      final sent = <List<AnalyticsEvent>>[];
+      final queue = AnalyticsQueue(
+        sender: (batch) async {
+          sent.add(List.of(batch));
+          return true;
+        },
+        batchSize: 100, // Large batch size to prevent auto-flush.
+      );
+
+      await queue.enqueue(_makeEvent('signup_completed'));
+      await queue.enqueue(_makeEvent('household_created'));
+      expect(sent.length, 0);
+
+      await queue.flush();
+      expect(sent.length, 1);
+      expect(sent.first.length, 2);
+    });
+
+    test('flush retains events on sender failure', () async {
+      var failCount = 0;
+      final sent = <List<AnalyticsEvent>>[];
+      final queue = AnalyticsQueue(
+        sender: (batch) async {
+          failCount++;
+          if (failCount <= 1) return false;
+          sent.add(List.of(batch));
+          return true;
+        },
+        batchSize: 100,
+      );
+
+      await queue.enqueue(_makeEvent('signup_completed'));
+      await queue.flush(); // First attempt fails.
+      expect(queue.length, 1); // Event retained.
+      expect(sent.length, 0);
+
+      await queue.flush(); // Second attempt succeeds.
+      expect(queue.length, 0);
+      expect(sent.length, 1);
+    });
+
+    test('flush tolerates sender exceptions', () async {
+      final queue = AnalyticsQueue(
+        sender: (_) async => throw Exception('network error'),
+        batchSize: 100,
+      );
+
+      await queue.enqueue(_makeEvent('signup_completed'));
+      await queue.flush(); // Should not throw.
+      expect(queue.length, 1); // Event retained.
+    });
+
+    test('flush is a no-op when queue is empty', () async {
+      var senderCalled = false;
+      final queue = AnalyticsQueue(
+        sender: (_) async {
+          senderCalled = true;
+          return true;
+        },
+        batchSize: 100,
+      );
+
+      await queue.flush();
+      expect(senderCalled, false);
+    });
+
+    test('persister is called on enqueue and flush', () async {
+      final persisted = <List<AnalyticsEvent>>[];
+      final queue = AnalyticsQueue(
+        sender: (_) async => true,
+        persister: (events) async => persisted.add(List.of(events)),
+        batchSize: 100,
+      );
+
+      await queue.enqueue(_makeEvent('signup_completed'));
+      expect(persisted.length, 1);
+      expect(persisted.last.length, 1);
+
+      await queue.flush();
+      // After flush, persist is called with empty queue.
+      expect(persisted.last.length, 0);
+    });
+
+    test('restore loads events from loader', () async {
+      final queue = AnalyticsQueue(
+        sender: (_) async => true,
+        loader: () async => [_makeEvent('signup_completed')],
+        batchSize: 100,
+      );
+
+      await queue.restore();
+      expect(queue.length, 1);
+    });
+
+    test('restore tolerates loader failure', () async {
+      final queue = AnalyticsQueue(
+        sender: (_) async => true,
+        loader: () async => throw Exception('storage error'),
+        batchSize: 100,
+      );
+
+      await queue.restore(); // Should not throw.
+      expect(queue.length, 0);
+    });
+
+    test('serialize and deserialize round-trips events', () {
+      final events = [
+        AnalyticsEvent(
+          milestone: 'signup_completed',
+          householdId: 'hh-1',
+          metadata: {'key': 'value'},
+          occurredAtUtc: DateTime.utc(2026, 3, 7, 12, 0, 0),
+        ),
+        AnalyticsEvent(
+          milestone: 'household_created',
+          occurredAtUtc: DateTime.utc(2026, 3, 7, 13, 0, 0),
+        ),
+      ];
+
+      final json = AnalyticsQueue.serialize(events);
+      final restored = AnalyticsQueue.deserialize(json);
+
+      expect(restored.length, 2);
+      expect(restored[0].milestone, 'signup_completed');
+      expect(restored[0].householdId, 'hh-1');
+      expect(restored[0].metadata, {'key': 'value'});
+      expect(restored[1].milestone, 'household_created');
+      expect(restored[1].householdId, isNull);
+    });
+  });
+}

--- a/mobile/test/unit/analytics/analytics_service_test.dart
+++ b/mobile/test/unit/analytics/analytics_service_test.dart
@@ -1,0 +1,80 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:money_tracker/shared_kernel/analytics/analytics_event.dart';
+import 'package:money_tracker/shared_kernel/analytics/analytics_queue.dart';
+import 'package:money_tracker/shared_kernel/analytics/analytics_service.dart';
+
+void main() {
+  group('QueuedAnalyticsService', () {
+    test('track enqueues an event with correct milestone', () async {
+      final sent = <List<AnalyticsEvent>>[];
+      final queue = AnalyticsQueue(
+        sender: (batch) async {
+          sent.add(batch);
+          return true;
+        },
+        batchSize: 1,
+      );
+
+      final fixedTime = DateTime.utc(2026, 3, 7, 12, 0, 0);
+      final service = QueuedAnalyticsService(
+        queue: queue,
+        utcNow: () => fixedTime,
+      );
+
+      await service.track('signup_completed');
+
+      expect(sent.length, 1);
+      expect(sent.first.length, 1);
+      expect(sent.first.first.milestone, 'signup_completed');
+      expect(sent.first.first.occurredAtUtc, fixedTime);
+    });
+
+    test('track includes householdId and metadata', () async {
+      final sent = <List<AnalyticsEvent>>[];
+      final queue = AnalyticsQueue(
+        sender: (batch) async {
+          sent.add(batch);
+          return true;
+        },
+        batchSize: 1,
+      );
+
+      final fixedTime = DateTime.utc(2026, 3, 7, 12, 0, 0);
+      final service = QueuedAnalyticsService(
+        queue: queue,
+        utcNow: () => fixedTime,
+      );
+
+      await service.track(
+        'household_created',
+        householdId: 'abc-123',
+        metadata: {'source': 'onboarding'},
+      );
+
+      expect(sent.length, 1);
+      final event = sent.first.first;
+      expect(event.milestone, 'household_created');
+      expect(event.householdId, 'abc-123');
+      expect(event.metadata, {'source': 'onboarding'});
+    });
+
+    test('track swallows queue errors', () async {
+      final queue = AnalyticsQueue(
+        sender: (_) async => throw Exception('network error'),
+        batchSize: 1,
+      );
+
+      final service = QueuedAnalyticsService(queue: queue);
+
+      // Should not throw.
+      await service.track('signup_completed');
+    });
+  });
+
+  group('NoopAnalyticsService', () {
+    test('track completes without error', () async {
+      const service = NoopAnalyticsService();
+      await expectLater(service.track('signup_completed'), completes);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- New **Analytics backend module** with `POST /analytics/events` (batch event ingestion, 202 Accepted) and `GET /admin/activation-funnel` (admin-gated funnel reporting with stage counts, conversion/drop-off rates, and ISO-week cohort grouping).
- **IAnalyticsEventPublisher** in SharedKernel enables cross-module fire-and-forget event publishing; 9 existing handlers instrumented (signup_completed, household_created, partner_invited, partner_joined, first_budget_created, first_transaction_created, bank_link_started, bank_link_completed, first_sync_completed).
- **Mobile analytics integration** with `AnalyticsService` (singleton tracking API), `AnalyticsQueue` (batched sending with local persistence and retry), and `ActivationTracker` (per-user milestone deduplication with persistent storage).
- OpenAPI spec updated with both analytics endpoints and all request/response schemas.

## Test plan
- [x] 19 backend unit tests (ActivationEventTests, RecordEventHandlerTests, GetActivationFunnelHandlerTests) -- all pass
- [x] All 272 existing backend tests pass (0 regressions from handler instrumentation)
- [x] 21 mobile unit tests (analytics_service_test, analytics_queue_test, activation_tracker_test) -- all pass
- [x] All 131 mobile tests pass (0 regressions)
- [x] `dotnet build MoneyTracker.slnx` -- 0 warnings, 0 errors
- [x] `flutter test` -- all pass

Closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)