### PR TITLE
Add funnel analytics dashboard and weekly reporting

### DIFF
--- a/backend/src/Modules/Analytics/Application/GenerateWeeklyReport/GenerateWeeklyReportCommand.cs
+++ b/backend/src/Modules/Analytics/Application/GenerateWeeklyReport/GenerateWeeklyReportCommand.cs
@@ -1,0 +1,3 @@
+namespace MoneyTracker.Modules.Analytics.Application.GenerateWeeklyReport;
+
+public sealed record GenerateWeeklyReportCommand;

--- a/backend/src/Modules/Analytics/Application/GenerateWeeklyReport/GenerateWeeklyReportHandler.cs
+++ b/backend/src/Modules/Analytics/Application/GenerateWeeklyReport/GenerateWeeklyReportHandler.cs
@@ -1,0 +1,54 @@
+using System.Text.Json;
+using MoneyTracker.Modules.Analytics.Domain;
+
+namespace MoneyTracker.Modules.Analytics.Application.GenerateWeeklyReport;
+
+public sealed class GenerateWeeklyReportHandler(
+    IFunnelDataSource funnelDataSource,
+    IRetentionDataSource retentionDataSource,
+    IRevenueDataSource revenueDataSource,
+    IWeeklyReportRepository weeklyReportRepository,
+    TimeProvider timeProvider)
+{
+    public async Task<GenerateWeeklyReportResult> HandleAsync(
+        GenerateWeeklyReportCommand command,
+        CancellationToken cancellationToken)
+    {
+        var nowUtc = timeProvider.GetUtcNow();
+        var periodEnd = nowUtc;
+        var periodStart = nowUtc.AddDays(-7);
+
+        var funnel = await funnelDataSource.GetFunnelReportAsync(
+            periodStart, periodEnd, cancellationToken);
+
+        var cohorts = await retentionDataSource.GetRetentionCohortsAsync(
+            8, nowUtc, cancellationToken);
+
+        var revenue = await revenueDataSource.GetRevenueMetricsAsync(
+            nowUtc, cancellationToken);
+
+        var reportData = new
+        {
+            Funnel = funnel,
+            Cohorts = cohorts,
+            Revenue = revenue
+        };
+
+        var dataJson = JsonSerializer.Serialize(reportData, new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            WriteIndented = false
+        });
+
+        var report = WeeklyReport.Create(
+            periodStart,
+            periodEnd,
+            "weekly_summary",
+            dataJson,
+            nowUtc);
+
+        await weeklyReportRepository.AddAsync(report, cancellationToken);
+
+        return GenerateWeeklyReportResult.Success(report.Id);
+    }
+}

--- a/backend/src/Modules/Analytics/Application/GenerateWeeklyReport/GenerateWeeklyReportResult.cs
+++ b/backend/src/Modules/Analytics/Application/GenerateWeeklyReport/GenerateWeeklyReportResult.cs
@@ -1,0 +1,24 @@
+namespace MoneyTracker.Modules.Analytics.Application.GenerateWeeklyReport;
+
+public sealed class GenerateWeeklyReportResult
+{
+    public bool IsSuccess { get; private init; }
+    public Guid? ReportId { get; private init; }
+    public string? ErrorCode { get; private init; }
+    public string? ErrorMessage { get; private init; }
+
+    public static GenerateWeeklyReportResult Success(Guid reportId) =>
+        new()
+        {
+            IsSuccess = true,
+            ReportId = reportId
+        };
+
+    public static GenerateWeeklyReportResult Failure(string errorCode, string errorMessage) =>
+        new()
+        {
+            IsSuccess = false,
+            ErrorCode = errorCode,
+            ErrorMessage = errorMessage
+        };
+}

--- a/backend/src/Modules/Analytics/Application/GetFunnelReport/GetFunnelReportHandler.cs
+++ b/backend/src/Modules/Analytics/Application/GetFunnelReport/GetFunnelReportHandler.cs
@@ -1,0 +1,25 @@
+using MoneyTracker.Modules.Analytics.Domain;
+
+namespace MoneyTracker.Modules.Analytics.Application.GetFunnelReport;
+
+public sealed class GetFunnelReportHandler(IFunnelDataSource funnelDataSource)
+{
+    public async Task<GetFunnelReportResult> HandleAsync(
+        GetFunnelReportQuery query,
+        CancellationToken cancellationToken)
+    {
+        if (query.PeriodStart >= query.PeriodEnd)
+        {
+            return GetFunnelReportResult.Failure(
+                AnalyticsErrors.ValidationError,
+                "periodStart must be before periodEnd.");
+        }
+
+        var report = await funnelDataSource.GetFunnelReportAsync(
+            query.PeriodStart,
+            query.PeriodEnd,
+            cancellationToken);
+
+        return GetFunnelReportResult.Success(report);
+    }
+}

--- a/backend/src/Modules/Analytics/Application/GetFunnelReport/GetFunnelReportQuery.cs
+++ b/backend/src/Modules/Analytics/Application/GetFunnelReport/GetFunnelReportQuery.cs
@@ -1,0 +1,5 @@
+namespace MoneyTracker.Modules.Analytics.Application.GetFunnelReport;
+
+public sealed record GetFunnelReportQuery(
+    DateTimeOffset PeriodStart,
+    DateTimeOffset PeriodEnd);

--- a/backend/src/Modules/Analytics/Application/GetFunnelReport/GetFunnelReportResult.cs
+++ b/backend/src/Modules/Analytics/Application/GetFunnelReport/GetFunnelReportResult.cs
@@ -1,0 +1,26 @@
+using MoneyTracker.Modules.Analytics.Domain;
+
+namespace MoneyTracker.Modules.Analytics.Application.GetFunnelReport;
+
+public sealed class GetFunnelReportResult
+{
+    public bool IsSuccess { get; private init; }
+    public FunnelReport? Report { get; private init; }
+    public string? ErrorCode { get; private init; }
+    public string? ErrorMessage { get; private init; }
+
+    public static GetFunnelReportResult Success(FunnelReport report) =>
+        new()
+        {
+            IsSuccess = true,
+            Report = report
+        };
+
+    public static GetFunnelReportResult Failure(string errorCode, string errorMessage) =>
+        new()
+        {
+            IsSuccess = false,
+            ErrorCode = errorCode,
+            ErrorMessage = errorMessage
+        };
+}

--- a/backend/src/Modules/Analytics/Application/GetRetentionCohorts/GetRetentionCohortsHandler.cs
+++ b/backend/src/Modules/Analytics/Application/GetRetentionCohorts/GetRetentionCohortsHandler.cs
@@ -1,0 +1,29 @@
+using MoneyTracker.Modules.Analytics.Domain;
+
+namespace MoneyTracker.Modules.Analytics.Application.GetRetentionCohorts;
+
+public sealed class GetRetentionCohortsHandler(
+    IRetentionDataSource retentionDataSource,
+    TimeProvider timeProvider)
+{
+    public async Task<GetRetentionCohortsResult> HandleAsync(
+        GetRetentionCohortsQuery query,
+        CancellationToken cancellationToken)
+    {
+        if (query.CohortCount <= 0)
+        {
+            return GetRetentionCohortsResult.Failure(
+                AnalyticsErrors.ValidationError,
+                "cohortCount must be greater than 0.");
+        }
+
+        var asOfUtc = timeProvider.GetUtcNow();
+
+        var cohorts = await retentionDataSource.GetRetentionCohortsAsync(
+            query.CohortCount,
+            asOfUtc,
+            cancellationToken);
+
+        return GetRetentionCohortsResult.Success(cohorts);
+    }
+}

--- a/backend/src/Modules/Analytics/Application/GetRetentionCohorts/GetRetentionCohortsQuery.cs
+++ b/backend/src/Modules/Analytics/Application/GetRetentionCohorts/GetRetentionCohortsQuery.cs
@@ -1,0 +1,3 @@
+namespace MoneyTracker.Modules.Analytics.Application.GetRetentionCohorts;
+
+public sealed record GetRetentionCohortsQuery(int CohortCount = 8);

--- a/backend/src/Modules/Analytics/Application/GetRetentionCohorts/GetRetentionCohortsResult.cs
+++ b/backend/src/Modules/Analytics/Application/GetRetentionCohorts/GetRetentionCohortsResult.cs
@@ -1,0 +1,26 @@
+using MoneyTracker.Modules.Analytics.Domain;
+
+namespace MoneyTracker.Modules.Analytics.Application.GetRetentionCohorts;
+
+public sealed class GetRetentionCohortsResult
+{
+    public bool IsSuccess { get; private init; }
+    public IReadOnlyList<CohortRetention> Cohorts { get; private init; } = [];
+    public string? ErrorCode { get; private init; }
+    public string? ErrorMessage { get; private init; }
+
+    public static GetRetentionCohortsResult Success(IReadOnlyList<CohortRetention> cohorts) =>
+        new()
+        {
+            IsSuccess = true,
+            Cohorts = cohorts
+        };
+
+    public static GetRetentionCohortsResult Failure(string errorCode, string errorMessage) =>
+        new()
+        {
+            IsSuccess = false,
+            ErrorCode = errorCode,
+            ErrorMessage = errorMessage
+        };
+}

--- a/backend/src/Modules/Analytics/Application/GetRevenueMetrics/GetRevenueMetricsHandler.cs
+++ b/backend/src/Modules/Analytics/Application/GetRevenueMetrics/GetRevenueMetricsHandler.cs
@@ -1,0 +1,21 @@
+using MoneyTracker.Modules.Analytics.Domain;
+
+namespace MoneyTracker.Modules.Analytics.Application.GetRevenueMetrics;
+
+public sealed class GetRevenueMetricsHandler(
+    IRevenueDataSource revenueDataSource,
+    TimeProvider timeProvider)
+{
+    public async Task<GetRevenueMetricsResult> HandleAsync(
+        GetRevenueMetricsQuery query,
+        CancellationToken cancellationToken)
+    {
+        var asOf = query.AsOf ?? timeProvider.GetUtcNow();
+
+        var metrics = await revenueDataSource.GetRevenueMetricsAsync(
+            asOf,
+            cancellationToken);
+
+        return GetRevenueMetricsResult.Success(metrics);
+    }
+}

--- a/backend/src/Modules/Analytics/Application/GetRevenueMetrics/GetRevenueMetricsQuery.cs
+++ b/backend/src/Modules/Analytics/Application/GetRevenueMetrics/GetRevenueMetricsQuery.cs
@@ -1,0 +1,3 @@
+namespace MoneyTracker.Modules.Analytics.Application.GetRevenueMetrics;
+
+public sealed record GetRevenueMetricsQuery(DateTimeOffset? AsOf = null);

--- a/backend/src/Modules/Analytics/Application/GetRevenueMetrics/GetRevenueMetricsResult.cs
+++ b/backend/src/Modules/Analytics/Application/GetRevenueMetrics/GetRevenueMetricsResult.cs
@@ -1,0 +1,26 @@
+using MoneyTracker.Modules.Analytics.Domain;
+
+namespace MoneyTracker.Modules.Analytics.Application.GetRevenueMetrics;
+
+public sealed class GetRevenueMetricsResult
+{
+    public bool IsSuccess { get; private init; }
+    public RevenueMetrics? Metrics { get; private init; }
+    public string? ErrorCode { get; private init; }
+    public string? ErrorMessage { get; private init; }
+
+    public static GetRevenueMetricsResult Success(RevenueMetrics metrics) =>
+        new()
+        {
+            IsSuccess = true,
+            Metrics = metrics
+        };
+
+    public static GetRevenueMetricsResult Failure(string errorCode, string errorMessage) =>
+        new()
+        {
+            IsSuccess = false,
+            ErrorCode = errorCode,
+            ErrorMessage = errorMessage
+        };
+}

--- a/backend/src/Modules/Analytics/Domain/CohortRetention.cs
+++ b/backend/src/Modules/Analytics/Domain/CohortRetention.cs
@@ -1,0 +1,9 @@
+namespace MoneyTracker.Modules.Analytics.Domain;
+
+public sealed record CohortRetention(
+    string Week,
+    int Signups,
+    double? D1,
+    double? D7,
+    double? D14,
+    double? D30);

--- a/backend/src/Modules/Analytics/Domain/DropOffAnalysis.cs
+++ b/backend/src/Modules/Analytics/Domain/DropOffAnalysis.cs
@@ -1,0 +1,7 @@
+namespace MoneyTracker.Modules.Analytics.Domain;
+
+public sealed record DropOffAnalysis(
+    string FromStage,
+    string ToStage,
+    double DropOffRate,
+    int LostUsers);

--- a/backend/src/Modules/Analytics/Domain/FunnelReport.cs
+++ b/backend/src/Modules/Analytics/Domain/FunnelReport.cs
@@ -1,0 +1,9 @@
+namespace MoneyTracker.Modules.Analytics.Domain;
+
+public sealed record FunnelReport(
+    DateTimeOffset PeriodStart,
+    DateTimeOffset PeriodEnd,
+    IReadOnlyList<FunnelReportStage> Stages,
+    double OverallConversion,
+    IReadOnlyList<DropOffAnalysis> TopDropOffs,
+    FunnelTrends Trends);

--- a/backend/src/Modules/Analytics/Domain/FunnelReportStage.cs
+++ b/backend/src/Modules/Analytics/Domain/FunnelReportStage.cs
@@ -1,0 +1,7 @@
+namespace MoneyTracker.Modules.Analytics.Domain;
+
+public sealed record FunnelReportStage(
+    string Name,
+    int Count,
+    double ConversionRate,
+    double DropOffRate);

--- a/backend/src/Modules/Analytics/Domain/FunnelTrends.cs
+++ b/backend/src/Modules/Analytics/Domain/FunnelTrends.cs
@@ -1,0 +1,5 @@
+namespace MoneyTracker.Modules.Analytics.Domain;
+
+public sealed record FunnelTrends(
+    double? WeekOverWeek,
+    double? MonthOverMonth);

--- a/backend/src/Modules/Analytics/Domain/IFunnelDataSource.cs
+++ b/backend/src/Modules/Analytics/Domain/IFunnelDataSource.cs
@@ -1,0 +1,9 @@
+namespace MoneyTracker.Modules.Analytics.Domain;
+
+public interface IFunnelDataSource
+{
+    Task<FunnelReport> GetFunnelReportAsync(
+        DateTimeOffset periodStart,
+        DateTimeOffset periodEnd,
+        CancellationToken cancellationToken);
+}

--- a/backend/src/Modules/Analytics/Domain/IRetentionDataSource.cs
+++ b/backend/src/Modules/Analytics/Domain/IRetentionDataSource.cs
@@ -1,0 +1,9 @@
+namespace MoneyTracker.Modules.Analytics.Domain;
+
+public interface IRetentionDataSource
+{
+    Task<IReadOnlyList<CohortRetention>> GetRetentionCohortsAsync(
+        int cohortCount,
+        DateTimeOffset asOfUtc,
+        CancellationToken cancellationToken);
+}

--- a/backend/src/Modules/Analytics/Domain/IRevenueDataSource.cs
+++ b/backend/src/Modules/Analytics/Domain/IRevenueDataSource.cs
@@ -1,0 +1,8 @@
+namespace MoneyTracker.Modules.Analytics.Domain;
+
+public interface IRevenueDataSource
+{
+    Task<RevenueMetrics> GetRevenueMetricsAsync(
+        DateTimeOffset asOfUtc,
+        CancellationToken cancellationToken);
+}

--- a/backend/src/Modules/Analytics/Domain/IWeeklyReportRepository.cs
+++ b/backend/src/Modules/Analytics/Domain/IWeeklyReportRepository.cs
@@ -1,0 +1,11 @@
+namespace MoneyTracker.Modules.Analytics.Domain;
+
+public interface IWeeklyReportRepository
+{
+    Task AddAsync(WeeklyReport report, CancellationToken cancellationToken);
+
+    Task<IReadOnlyList<WeeklyReport>> GetByTypeAsync(
+        string reportType,
+        int limit,
+        CancellationToken cancellationToken);
+}

--- a/backend/src/Modules/Analytics/Domain/RevenueMetrics.cs
+++ b/backend/src/Modules/Analytics/Domain/RevenueMetrics.cs
@@ -1,0 +1,10 @@
+namespace MoneyTracker.Modules.Analytics.Domain;
+
+public sealed record RevenueMetrics(
+    decimal Mrr,
+    decimal Arpu,
+    double ChurnRate,
+    decimal? EstimatedLtv,
+    int ActiveSubscribers,
+    int TrialUsers,
+    FunnelTrends Trends);

--- a/backend/src/Modules/Analytics/Domain/WeeklyReport.cs
+++ b/backend/src/Modules/Analytics/Domain/WeeklyReport.cs
@@ -1,0 +1,50 @@
+namespace MoneyTracker.Modules.Analytics.Domain;
+
+public sealed class WeeklyReport
+{
+    public Guid Id { get; }
+    public DateTimeOffset PeriodStart { get; }
+    public DateTimeOffset PeriodEnd { get; }
+    public string ReportType { get; }
+    public string Data { get; }
+    public DateTimeOffset GeneratedAtUtc { get; }
+
+    private WeeklyReport(
+        Guid id,
+        DateTimeOffset periodStart,
+        DateTimeOffset periodEnd,
+        string reportType,
+        string data,
+        DateTimeOffset generatedAtUtc)
+    {
+        Id = id;
+        PeriodStart = periodStart;
+        PeriodEnd = periodEnd;
+        ReportType = reportType;
+        Data = data;
+        GeneratedAtUtc = generatedAtUtc;
+    }
+
+    public static WeeklyReport Create(
+        DateTimeOffset periodStart,
+        DateTimeOffset periodEnd,
+        string reportType,
+        string data,
+        DateTimeOffset generatedAtUtc)
+    {
+        if (string.IsNullOrWhiteSpace(reportType))
+        {
+            throw new AnalyticsDomainException(
+                AnalyticsErrors.ValidationError,
+                "Report type is required.");
+        }
+
+        return new WeeklyReport(
+            Guid.NewGuid(),
+            periodStart,
+            periodEnd,
+            reportType,
+            data,
+            generatedAtUtc);
+    }
+}

--- a/backend/src/Modules/Analytics/Infrastructure/FunnelDataAggregator.cs
+++ b/backend/src/Modules/Analytics/Infrastructure/FunnelDataAggregator.cs
@@ -1,0 +1,197 @@
+using MoneyTracker.Modules.Analytics.Domain;
+
+namespace MoneyTracker.Modules.Analytics.Infrastructure;
+
+public sealed class FunnelDataAggregator(
+    IActivationEventRepository activationEventRepository,
+    TimeProvider timeProvider) : IFunnelDataSource
+{
+    // The 7 funnel stages from the issue specification, mapped to ActivationMilestone values.
+    internal static readonly (string Name, ActivationMilestone Milestone)[] FunnelStages =
+    [
+        ("signup", ActivationMilestone.SignupCompleted),
+        ("onboarding_complete", ActivationMilestone.HouseholdCreated),
+        ("first_transaction", ActivationMilestone.FirstTransactionCreated),
+        ("bank_link", ActivationMilestone.BankLinkCompleted),
+        ("paywall_view", ActivationMilestone.PaywallViewed),
+        ("trial_start", ActivationMilestone.TrialStarted),
+        ("paid_conversion", ActivationMilestone.PaidConversion),
+    ];
+
+    public async Task<FunnelReport> GetFunnelReportAsync(
+        DateTimeOffset periodStart,
+        DateTimeOffset periodEnd,
+        CancellationToken cancellationToken)
+    {
+        var currentPeriodEvents = await GetEventsInPeriodAsync(periodStart, periodEnd, cancellationToken);
+        var stages = ComputeStages(currentPeriodEvents);
+        var topDropOffs = ComputeTopDropOffs(stages);
+        var overallConversion = ComputeOverallConversion(stages);
+        var trends = await ComputeTrendsAsync(periodStart, periodEnd, cancellationToken);
+
+        return new FunnelReport(
+            periodStart,
+            periodEnd,
+            stages,
+            overallConversion,
+            topDropOffs,
+            trends);
+    }
+
+    private async Task<IReadOnlyCollection<ActivationEvent>> GetEventsInPeriodAsync(
+        DateTimeOffset periodStart,
+        DateTimeOffset periodEnd,
+        CancellationToken cancellationToken)
+    {
+        var allEvents = await activationEventRepository.GetByPeriodAsync(
+            periodStart, platform: null, region: null, cancellationToken);
+
+        return allEvents.Where(e => e.OccurredAtUtc <= periodEnd).ToArray();
+    }
+
+    internal static IReadOnlyList<FunnelReportStage> ComputeStages(
+        IReadOnlyCollection<ActivationEvent> events)
+    {
+        var usersByMilestone = new Dictionary<ActivationMilestone, HashSet<Guid>>();
+        foreach (var (_, milestone) in FunnelStages)
+        {
+            usersByMilestone[milestone] = [];
+        }
+
+        foreach (var evt in events)
+        {
+            if (usersByMilestone.TryGetValue(evt.Milestone, out var userSet))
+            {
+                userSet.Add(evt.UserId);
+            }
+        }
+
+        var stages = new List<FunnelReportStage>();
+        for (var i = 0; i < FunnelStages.Length; i++)
+        {
+            var (name, milestone) = FunnelStages[i];
+            var count = usersByMilestone[milestone].Count;
+
+            double conversionRate;
+            double dropOffRate;
+
+            if (i == 0)
+            {
+                conversionRate = 1.0;
+                dropOffRate = 0.0;
+            }
+            else
+            {
+                var previousMilestone = FunnelStages[i - 1].Milestone;
+                var previousCount = usersByMilestone[previousMilestone].Count;
+
+                conversionRate = previousCount > 0
+                    ? (double)count / previousCount
+                    : 0.0;
+
+                dropOffRate = previousCount > 0
+                    ? 1.0 - conversionRate
+                    : 0.0;
+            }
+
+            stages.Add(new FunnelReportStage(
+                name,
+                count,
+                Math.Round(conversionRate, 4),
+                Math.Round(dropOffRate, 4)));
+        }
+
+        return stages;
+    }
+
+    internal static IReadOnlyList<DropOffAnalysis> ComputeTopDropOffs(
+        IReadOnlyList<FunnelReportStage> stages)
+    {
+        var dropOffs = new List<DropOffAnalysis>();
+        for (var i = 1; i < stages.Count; i++)
+        {
+            var fromStage = stages[i - 1];
+            var toStage = stages[i];
+            var lostUsers = fromStage.Count - toStage.Count;
+
+            if (lostUsers > 0)
+            {
+                dropOffs.Add(new DropOffAnalysis(
+                    fromStage.Name,
+                    toStage.Name,
+                    toStage.DropOffRate,
+                    lostUsers));
+            }
+        }
+
+        return dropOffs
+            .OrderByDescending(d => d.LostUsers)
+            .Take(3)
+            .ToArray();
+    }
+
+    internal static double ComputeOverallConversion(IReadOnlyList<FunnelReportStage> stages)
+    {
+        if (stages.Count < 2)
+        {
+            return 0.0;
+        }
+
+        var firstCount = stages[0].Count;
+        var lastCount = stages[^1].Count;
+
+        return firstCount > 0
+            ? Math.Round((double)lastCount / firstCount, 4)
+            : 0.0;
+    }
+
+    private async Task<FunnelTrends> ComputeTrendsAsync(
+        DateTimeOffset periodStart,
+        DateTimeOffset periodEnd,
+        CancellationToken cancellationToken)
+    {
+        var periodLength = periodEnd - periodStart;
+        var nowUtc = timeProvider.GetUtcNow();
+
+        // Week-over-week: compare this week's signups to last week's signups
+        var thisWeekSignups = await CountSignupsInPeriodAsync(
+            periodStart, periodEnd, cancellationToken);
+
+        var lastWeekStart = periodStart.AddDays(-7);
+        var lastWeekEnd = periodStart;
+        var lastWeekSignups = await CountSignupsInPeriodAsync(
+            lastWeekStart, lastWeekEnd, cancellationToken);
+
+        double? wow = lastWeekSignups > 0
+            ? Math.Round((double)(thisWeekSignups - lastWeekSignups) / lastWeekSignups, 4)
+            : null;
+
+        // Month-over-month: compare this period's signups to the equivalent period one month ago
+        var lastMonthStart = periodStart.AddDays(-30);
+        var lastMonthEnd = periodEnd.AddDays(-30);
+        var lastMonthSignups = await CountSignupsInPeriodAsync(
+            lastMonthStart, lastMonthEnd, cancellationToken);
+
+        double? mom = lastMonthSignups > 0
+            ? Math.Round((double)(thisWeekSignups - lastMonthSignups) / lastMonthSignups, 4)
+            : null;
+
+        return new FunnelTrends(wow, mom);
+    }
+
+    private async Task<int> CountSignupsInPeriodAsync(
+        DateTimeOffset start,
+        DateTimeOffset end,
+        CancellationToken cancellationToken)
+    {
+        var events = await activationEventRepository.GetByPeriodAsync(
+            start, platform: null, region: null, cancellationToken);
+
+        return events
+            .Where(e => e.Milestone == ActivationMilestone.SignupCompleted
+                        && e.OccurredAtUtc <= end)
+            .Select(e => e.UserId)
+            .Distinct()
+            .Count();
+    }
+}

--- a/backend/src/Modules/Analytics/Infrastructure/InMemoryWeeklyReportRepository.cs
+++ b/backend/src/Modules/Analytics/Infrastructure/InMemoryWeeklyReportRepository.cs
@@ -1,0 +1,46 @@
+using MoneyTracker.Modules.Analytics.Domain;
+
+namespace MoneyTracker.Modules.Analytics.Infrastructure;
+
+public sealed class InMemoryWeeklyReportRepository : IWeeklyReportRepository
+{
+    private readonly object _sync = new();
+    private readonly List<WeeklyReport> _reports = [];
+
+    public Task AddAsync(WeeklyReport report, CancellationToken cancellationToken)
+    {
+        if (cancellationToken.IsCancellationRequested)
+        {
+            return Task.FromCanceled(cancellationToken);
+        }
+
+        lock (_sync)
+        {
+            _reports.Add(report);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public Task<IReadOnlyList<WeeklyReport>> GetByTypeAsync(
+        string reportType,
+        int limit,
+        CancellationToken cancellationToken)
+    {
+        if (cancellationToken.IsCancellationRequested)
+        {
+            return Task.FromCanceled<IReadOnlyList<WeeklyReport>>(cancellationToken);
+        }
+
+        lock (_sync)
+        {
+            var result = _reports
+                .Where(r => string.Equals(r.ReportType, reportType, StringComparison.OrdinalIgnoreCase))
+                .OrderByDescending(r => r.GeneratedAtUtc)
+                .Take(limit)
+                .ToList();
+
+            return Task.FromResult<IReadOnlyList<WeeklyReport>>(result);
+        }
+    }
+}

--- a/backend/src/Modules/Analytics/Infrastructure/RetentionCalculator.cs
+++ b/backend/src/Modules/Analytics/Infrastructure/RetentionCalculator.cs
@@ -1,0 +1,101 @@
+using MoneyTracker.Modules.Analytics.Domain;
+
+namespace MoneyTracker.Modules.Analytics.Infrastructure;
+
+public sealed class RetentionCalculator(
+    IActivationEventRepository activationEventRepository) : IRetentionDataSource
+{
+    private static readonly int[] RetentionDays = [1, 7, 14, 30];
+
+    public async Task<IReadOnlyList<CohortRetention>> GetRetentionCohortsAsync(
+        int cohortCount,
+        DateTimeOffset asOfUtc,
+        CancellationToken cancellationToken)
+    {
+        var allEvents = await activationEventRepository.GetAllAsync(cancellationToken);
+
+        // Group signup events by ISO week
+        var signupEvents = allEvents
+            .Where(e => e.Milestone == ActivationMilestone.SignupCompleted)
+            .ToArray();
+
+        var cohortGroups = signupEvents
+            .GroupBy(e => CohortKey.FromDate(e.OccurredAtUtc).Value)
+            .OrderByDescending(g => g.Key)
+            .Take(cohortCount)
+            .OrderBy(g => g.Key)
+            .ToArray();
+
+        // Build a lookup of all activity events (any milestone after signup) per user
+        var activityByUser = allEvents
+            .GroupBy(e => e.UserId)
+            .ToDictionary(
+                g => g.Key,
+                g => g.Select(e => e.OccurredAtUtc).ToArray());
+
+        var cohorts = new List<CohortRetention>();
+        foreach (var group in cohortGroups)
+        {
+            var signups = group.Select(e => e.UserId).Distinct().ToArray();
+            var signupCount = signups.Length;
+
+            // Determine the earliest signup date for this cohort
+            var earliestSignup = group.Min(e => e.OccurredAtUtc);
+
+            var retentionRates = new double?[RetentionDays.Length];
+            for (var i = 0; i < RetentionDays.Length; i++)
+            {
+                var days = RetentionDays[i];
+                var checkDate = earliestSignup.AddDays(days);
+
+                // If the check date hasn't elapsed yet, retention is null (AC-6)
+                if (checkDate > asOfUtc)
+                {
+                    retentionRates[i] = null;
+                    continue;
+                }
+
+                // Count users who had any activity on or after the check date
+                var activeCount = 0;
+                foreach (var userId in signups)
+                {
+                    if (!activityByUser.TryGetValue(userId, out var activities))
+                    {
+                        continue;
+                    }
+
+                    // Find the user's signup date
+                    var userSignupDate = group
+                        .Where(e => e.UserId == userId)
+                        .Min(e => e.OccurredAtUtc);
+
+                    var userCheckDate = userSignupDate.AddDays(days);
+
+                    // User is active if they have any event at or after their check date
+                    // that is not the signup event itself
+                    var hasActivity = activities.Any(a =>
+                        a >= userCheckDate && a > userSignupDate);
+
+                    if (hasActivity)
+                    {
+                        activeCount++;
+                    }
+                }
+
+                retentionRates[i] = signupCount > 0
+                    ? Math.Round((double)activeCount / signupCount, 4)
+                    : 0.0;
+            }
+
+            cohorts.Add(new CohortRetention(
+                group.Key,
+                signupCount,
+                retentionRates[0],
+                retentionRates[1],
+                retentionRates[2],
+                retentionRates[3]));
+        }
+
+        return cohorts;
+    }
+}

--- a/backend/src/Modules/Analytics/Infrastructure/RevenueCalculator.cs
+++ b/backend/src/Modules/Analytics/Infrastructure/RevenueCalculator.cs
@@ -1,0 +1,128 @@
+using MoneyTracker.Modules.Analytics.Domain;
+using MoneyTracker.Modules.Subscriptions.Domain;
+
+namespace MoneyTracker.Modules.Analytics.Infrastructure;
+
+public sealed class RevenueCalculator(
+    ISubscriptionRepository subscriptionRepository) : IRevenueDataSource
+{
+    // Known product price mappings (monthly-equivalent amounts).
+    // In a production system, these would come from a product catalog.
+    private static readonly Dictionary<string, (decimal MonthlyAmount, bool IsAnnual)> ProductPrices = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["mt_premium_monthly"] = (9.99m, false),
+        ["mt_premium_annual"] = (99.99m, true),
+    };
+
+    private const decimal DefaultMonthlyPrice = 9.99m;
+
+    public async Task<RevenueMetrics> GetRevenueMetricsAsync(
+        DateTimeOffset asOfUtc,
+        CancellationToken cancellationToken)
+    {
+        var allSubscriptions = await subscriptionRepository.GetAllAsync(cancellationToken);
+
+        var activeSubscriptions = allSubscriptions
+            .Where(s => s.Status == SubscriptionStatus.Active)
+            .ToArray();
+
+        var trialSubscriptions = allSubscriptions
+            .Where(s => s.Status == SubscriptionStatus.Trial)
+            .ToArray();
+
+        var activeSubscribers = activeSubscriptions.Length;
+        var trialUsers = trialSubscriptions.Length;
+
+        // MRR: Sum of monthly-equivalent subscription amounts
+        var mrr = 0m;
+        foreach (var sub in activeSubscriptions)
+        {
+            mrr += GetMonthlyEquivalent(sub.ProductId);
+        }
+
+        // ARPU: MRR / active subscribers
+        var arpu = activeSubscribers > 0
+            ? Math.Round(mrr / activeSubscribers, 2)
+            : 0m;
+
+        // Churn rate: cancellations in the last 30 days / active subscribers at start of period
+        var thirtyDaysAgo = asOfUtc.AddDays(-30);
+        var cancellationsInPeriod = allSubscriptions
+            .Count(s => s.CancelledAtUtc.HasValue
+                        && s.CancelledAtUtc.Value >= thirtyDaysAgo
+                        && s.CancelledAtUtc.Value <= asOfUtc);
+
+        // Active at start = current active + those who cancelled in the period
+        var activeAtStart = activeSubscribers + cancellationsInPeriod;
+        var churnRate = activeAtStart > 0
+            ? Math.Round((double)cancellationsInPeriod / activeAtStart, 4)
+            : 0.0;
+
+        // LTV: ARPU / churnRate (null if churnRate = 0)
+        decimal? estimatedLtv = churnRate > 0
+            ? Math.Round(arpu / (decimal)churnRate, 2)
+            : null;
+
+        // Revenue trends
+        var trends = ComputeRevenueTrends(allSubscriptions, asOfUtc);
+
+        return new RevenueMetrics(
+            mrr,
+            arpu,
+            churnRate,
+            estimatedLtv,
+            activeSubscribers,
+            trialUsers,
+            trends);
+    }
+
+    internal static decimal GetMonthlyEquivalent(string productId)
+    {
+        if (ProductPrices.TryGetValue(productId, out var price))
+        {
+            return price.IsAnnual
+                ? Math.Round(price.MonthlyAmount / 12, 2)
+                : price.MonthlyAmount;
+        }
+
+        return DefaultMonthlyPrice;
+    }
+
+    private static FunnelTrends ComputeRevenueTrends(
+        IReadOnlyList<Subscription> allSubscriptions,
+        DateTimeOffset asOfUtc)
+    {
+        // Week-over-week: compare new subscriptions this week vs last week
+        var thisWeekStart = asOfUtc.AddDays(-7);
+        var lastWeekStart = asOfUtc.AddDays(-14);
+
+        var thisWeekNew = CountNewSubscriptions(allSubscriptions, thisWeekStart, asOfUtc);
+        var lastWeekNew = CountNewSubscriptions(allSubscriptions, lastWeekStart, thisWeekStart);
+
+        double? wow = lastWeekNew > 0
+            ? Math.Round((double)(thisWeekNew - lastWeekNew) / lastWeekNew, 4)
+            : null;
+
+        // Month-over-month
+        var thisMonthStart = asOfUtc.AddDays(-30);
+        var lastMonthStart = asOfUtc.AddDays(-60);
+
+        var thisMonthNew = CountNewSubscriptions(allSubscriptions, thisMonthStart, asOfUtc);
+        var lastMonthNew = CountNewSubscriptions(allSubscriptions, lastMonthStart, thisMonthStart);
+
+        double? mom = lastMonthNew > 0
+            ? Math.Round((double)(thisMonthNew - lastMonthNew) / lastMonthNew, 4)
+            : null;
+
+        return new FunnelTrends(wow, mom);
+    }
+
+    private static int CountNewSubscriptions(
+        IReadOnlyList<Subscription> subscriptions,
+        DateTimeOffset start,
+        DateTimeOffset end)
+    {
+        return subscriptions.Count(s =>
+            s.CreatedAtUtc >= start && s.CreatedAtUtc < end);
+    }
+}

--- a/backend/src/Modules/Analytics/Infrastructure/WeeklyReportWorker.cs
+++ b/backend/src/Modules/Analytics/Infrastructure/WeeklyReportWorker.cs
@@ -1,0 +1,46 @@
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using MoneyTracker.Modules.Analytics.Application.GenerateWeeklyReport;
+
+namespace MoneyTracker.Modules.Analytics.Infrastructure;
+
+public sealed class WeeklyReportWorker(
+    GenerateWeeklyReportHandler handler,
+    ILogger<WeeklyReportWorker> logger) : BackgroundService
+{
+    private static readonly TimeSpan Interval = TimeSpan.FromDays(7);
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        using var timer = new PeriodicTimer(Interval);
+        while (await timer.WaitForNextTickAsync(stoppingToken))
+        {
+            try
+            {
+                var result = await handler.HandleAsync(
+                    new GenerateWeeklyReportCommand(),
+                    stoppingToken);
+                logger.LogInformation(
+                    "Weekly report generated: reportId={ReportId} success={Success}",
+                    result.ReportId,
+                    result.IsSuccess);
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                return;
+            }
+            catch (Exception exception)
+            {
+                logger.LogError(exception, "Weekly report worker failed.");
+                try
+                {
+                    await Task.Delay(TimeSpan.FromSeconds(5), stoppingToken);
+                }
+                catch (OperationCanceledException)
+                {
+                    return;
+                }
+            }
+        }
+    }
+}

--- a/backend/src/Modules/Analytics/MoneyTracker.Modules.Analytics.csproj
+++ b/backend/src/Modules/Analytics/MoneyTracker.Modules.Analytics.csproj
@@ -7,9 +7,14 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="MoneyTracker.Modules.Analytics.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <ProjectReference Include="..\Auth\MoneyTracker.Modules.Auth.csproj" />
     <ProjectReference Include="..\SharedKernel\MoneyTracker.Modules.SharedKernel.csproj" />
+    <ProjectReference Include="..\Subscriptions\MoneyTracker.Modules.Subscriptions.csproj" />
   </ItemGroup>
 
 </Project>

--- a/backend/src/Modules/Analytics/Presentation/AnalyticsEndpoints.cs
+++ b/backend/src/Modules/Analytics/Presentation/AnalyticsEndpoints.cs
@@ -2,7 +2,11 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
+using MoneyTracker.Modules.Analytics.Application.GenerateWeeklyReport;
 using MoneyTracker.Modules.Analytics.Application.GetActivationFunnel;
+using MoneyTracker.Modules.Analytics.Application.GetFunnelReport;
+using MoneyTracker.Modules.Analytics.Application.GetRetentionCohorts;
+using MoneyTracker.Modules.Analytics.Application.GetRevenueMetrics;
 using MoneyTracker.Modules.Analytics.Application.RecordEvent;
 using MoneyTracker.Modules.Analytics.Domain;
 using MoneyTracker.Modules.Analytics.Infrastructure;
@@ -25,6 +29,17 @@ public static class AnalyticsEndpoints
         services.AddSingleton<IUserDeletionParticipant, AnalyticsDataExportParticipant>();
         services.AddSingleton<IModuleHealthCheck, AnalyticsModuleHealthCheck>();
 
+        // Funnel dashboard services (Issue #81)
+        services.AddSingleton<IWeeklyReportRepository, InMemoryWeeklyReportRepository>();
+        services.AddScoped<IFunnelDataSource, FunnelDataAggregator>();
+        services.AddScoped<IRetentionDataSource, RetentionCalculator>();
+        services.AddScoped<IRevenueDataSource, RevenueCalculator>();
+        services.AddScoped<GetFunnelReportHandler>();
+        services.AddScoped<GetRetentionCohortsHandler>();
+        services.AddScoped<GetRevenueMetricsHandler>();
+        services.AddScoped<GenerateWeeklyReportHandler>();
+        services.AddHostedService<WeeklyReportWorker>();
+
         return services;
     }
 
@@ -46,6 +61,33 @@ public static class AnalyticsEndpoints
             .WithSummary("Get activation funnel metrics.")
             .WithDescription("Returns ordered funnel stages with conversion and drop-off rates. Admin access required.")
             .Produces<ActivationFunnelResponse>(StatusCodes.Status200OK)
+            .ProducesProblem(StatusCodes.Status401Unauthorized)
+            .ProducesProblem(StatusCodes.Status403Forbidden);
+
+        var funnelReportEndpoint = (RouteHandlerBuilder)app.MapGet("/admin/funnel-report", GetFunnelReport);
+        funnelReportEndpoint
+            .WithName("GetFunnelReport")
+            .WithSummary("Get funnel report with trends and drop-off analysis.")
+            .WithDescription("Returns funnel stages, top drop-offs, and WoW/MoM trends. Admin access required.")
+            .Produces<FunnelReportResponse>(StatusCodes.Status200OK)
+            .ProducesProblem(StatusCodes.Status401Unauthorized)
+            .ProducesProblem(StatusCodes.Status403Forbidden);
+
+        var retentionEndpoint = (RouteHandlerBuilder)app.MapGet("/admin/retention-cohorts", GetRetentionCohorts);
+        retentionEndpoint
+            .WithName("GetRetentionCohorts")
+            .WithSummary("Get retention cohort data.")
+            .WithDescription("Returns D1/D7/D14/D30 retention rates by signup week. Admin access required.")
+            .Produces<RetentionCohortsResponse>(StatusCodes.Status200OK)
+            .ProducesProblem(StatusCodes.Status401Unauthorized)
+            .ProducesProblem(StatusCodes.Status403Forbidden);
+
+        var revenueEndpoint = (RouteHandlerBuilder)app.MapGet("/admin/revenue-metrics", GetRevenueMetrics);
+        revenueEndpoint
+            .WithName("GetRevenueMetrics")
+            .WithSummary("Get revenue metrics.")
+            .WithDescription("Returns MRR, ARPU, churn rate, and estimated LTV. Admin access required.")
+            .Produces<RevenueMetricsResponse>(StatusCodes.Status200OK)
             .ProducesProblem(StatusCodes.Status401Unauthorized)
             .ProducesProblem(StatusCodes.Status403Forbidden);
 
@@ -188,6 +230,173 @@ public static class AnalyticsEndpoints
 
         await TypedResults.Ok(response).ExecuteAsync(httpContext);
     }
+
+    private static async Task GetFunnelReport(HttpContext httpContext)
+    {
+        if (!await RequireAdminAsync(httpContext, "Admin access is required to view funnel report."))
+        {
+            return;
+        }
+
+        var periodStartRaw = httpContext.Request.Query["periodStart"].FirstOrDefault();
+        var periodEndRaw = httpContext.Request.Query["periodEnd"].FirstOrDefault();
+
+        if (!DateTimeOffset.TryParse(periodStartRaw, out var periodStart)
+            || !DateTimeOffset.TryParse(periodEndRaw, out var periodEnd))
+        {
+            await EndpointHelpers.WriteProblemAsync(
+                httpContext,
+                StatusCodes.Status400BadRequest,
+                "Validation failed.",
+                "Both periodStart and periodEnd query parameters are required in ISO 8601 format.",
+                AnalyticsErrors.ValidationError,
+                AnalyticsErrors.ValidationError);
+            return;
+        }
+
+        var handler = httpContext.RequestServices.GetRequiredService<GetFunnelReportHandler>();
+        var result = await handler.HandleAsync(
+            new GetFunnelReportQuery(periodStart, periodEnd),
+            httpContext.RequestAborted);
+
+        if (!result.IsSuccess)
+        {
+            await EndpointHelpers.WriteProblemAsync(
+                httpContext,
+                StatusCodes.Status400BadRequest,
+                "Request failed.",
+                result.ErrorMessage ?? "Request rejected.",
+                result.ErrorCode,
+                AnalyticsErrors.ValidationError);
+            return;
+        }
+
+        var report = result.Report!;
+        var response = new FunnelReportResponse(
+            report.PeriodStart,
+            report.PeriodEnd,
+            report.Stages
+                .Select(s => new FunnelReportStageResponse(s.Name, s.Count, s.ConversionRate, s.DropOffRate))
+                .ToArray(),
+            report.OverallConversion,
+            report.TopDropOffs
+                .Select(d => new DropOffResponse(d.FromStage, d.ToStage, d.DropOffRate, d.LostUsers))
+                .ToArray(),
+            new TrendsResponse(report.Trends.WeekOverWeek, report.Trends.MonthOverMonth));
+
+        await TypedResults.Ok(response).ExecuteAsync(httpContext);
+    }
+
+    private static async Task GetRetentionCohorts(HttpContext httpContext)
+    {
+        if (!await RequireAdminAsync(httpContext, "Admin access is required to view retention cohorts."))
+        {
+            return;
+        }
+
+        var cohortCountRaw = httpContext.Request.Query["cohortCount"].FirstOrDefault();
+        var cohortCount = 8;
+        if (cohortCountRaw is not null && int.TryParse(cohortCountRaw, out var parsed) && parsed > 0)
+        {
+            cohortCount = parsed;
+        }
+
+        var handler = httpContext.RequestServices.GetRequiredService<GetRetentionCohortsHandler>();
+        var result = await handler.HandleAsync(
+            new GetRetentionCohortsQuery(cohortCount),
+            httpContext.RequestAborted);
+
+        if (!result.IsSuccess)
+        {
+            await EndpointHelpers.WriteProblemAsync(
+                httpContext,
+                StatusCodes.Status400BadRequest,
+                "Request failed.",
+                result.ErrorMessage ?? "Request rejected.",
+                result.ErrorCode,
+                AnalyticsErrors.ValidationError);
+            return;
+        }
+
+        var response = new RetentionCohortsResponse(
+            result.Cohorts
+                .Select(c => new CohortRetentionResponse(c.Week, c.Signups, c.D1, c.D7, c.D14, c.D30))
+                .ToArray());
+
+        await TypedResults.Ok(response).ExecuteAsync(httpContext);
+    }
+
+    private static async Task GetRevenueMetrics(HttpContext httpContext)
+    {
+        if (!await RequireAdminAsync(httpContext, "Admin access is required to view revenue metrics."))
+        {
+            return;
+        }
+
+        var asOfRaw = httpContext.Request.Query["asOf"].FirstOrDefault();
+        DateTimeOffset? asOf = null;
+        if (asOfRaw is not null && DateTimeOffset.TryParse(asOfRaw, out var parsed))
+        {
+            asOf = parsed;
+        }
+
+        var handler = httpContext.RequestServices.GetRequiredService<GetRevenueMetricsHandler>();
+        var result = await handler.HandleAsync(
+            new GetRevenueMetricsQuery(asOf),
+            httpContext.RequestAborted);
+
+        if (!result.IsSuccess)
+        {
+            await EndpointHelpers.WriteProblemAsync(
+                httpContext,
+                StatusCodes.Status400BadRequest,
+                "Request failed.",
+                result.ErrorMessage ?? "Request rejected.",
+                result.ErrorCode,
+                AnalyticsErrors.ValidationError);
+            return;
+        }
+
+        var metrics = result.Metrics!;
+        var response = new RevenueMetricsResponse(
+            metrics.Mrr,
+            metrics.Arpu,
+            metrics.ChurnRate,
+            metrics.EstimatedLtv,
+            metrics.ActiveSubscribers,
+            metrics.TrialUsers,
+            new TrendsResponse(metrics.Trends.WeekOverWeek, metrics.Trends.MonthOverMonth));
+
+        await TypedResults.Ok(response).ExecuteAsync(httpContext);
+    }
+
+    private static async Task<bool> RequireAdminAsync(HttpContext httpContext, string accessDeniedMessage)
+    {
+        var authResult = await EndpointHelpers.ResolveAuthenticatedUser(httpContext);
+        if (!authResult.Success)
+        {
+            await authResult.Problem!.ExecuteAsync(httpContext);
+            return false;
+        }
+
+        var adminService = httpContext.RequestServices.GetRequiredService<IAdminAccessService>();
+        var isAdmin = await adminService.IsAdminAsync(
+            authResult.AuthenticatedUser!.UserId,
+            httpContext.RequestAborted);
+        if (!isAdmin)
+        {
+            await EndpointHelpers.WriteProblemAsync(
+                httpContext,
+                StatusCodes.Status403Forbidden,
+                "Access denied.",
+                accessDeniedMessage,
+                AnalyticsErrors.AccessDenied,
+                AnalyticsErrors.AccessDenied);
+            return false;
+        }
+
+        return true;
+    }
 }
 
 // Request DTOs
@@ -220,3 +429,50 @@ public sealed record CohortSummaryResponse(
     string CohortKey,
     int SignupCount,
     double PaidConversionRate);
+
+// Funnel report response DTOs
+public sealed record FunnelReportResponse(
+    DateTimeOffset PeriodStart,
+    DateTimeOffset PeriodEnd,
+    FunnelReportStageResponse[] Stages,
+    double OverallConversion,
+    DropOffResponse[] TopDropOffs,
+    TrendsResponse Trends);
+
+public sealed record FunnelReportStageResponse(
+    string Name,
+    int Count,
+    double ConversionRate,
+    double DropOffRate);
+
+public sealed record DropOffResponse(
+    string FromStage,
+    string ToStage,
+    double DropOffRate,
+    int LostUsers);
+
+public sealed record TrendsResponse(
+    double? WeekOverWeek,
+    double? MonthOverMonth);
+
+// Retention response DTOs
+public sealed record RetentionCohortsResponse(
+    CohortRetentionResponse[] Cohorts);
+
+public sealed record CohortRetentionResponse(
+    string Week,
+    int Signups,
+    double? D1,
+    double? D7,
+    double? D14,
+    double? D30);
+
+// Revenue response DTOs
+public sealed record RevenueMetricsResponse(
+    decimal Mrr,
+    decimal Arpu,
+    double ChurnRate,
+    decimal? EstimatedLtv,
+    int ActiveSubscribers,
+    int TrialUsers,
+    TrendsResponse Trends);

--- a/backend/src/Modules/Subscriptions/Domain/ISubscriptionRepository.cs
+++ b/backend/src/Modules/Subscriptions/Domain/ISubscriptionRepository.cs
@@ -8,4 +8,5 @@ public interface ISubscriptionRepository
     Task<Subscription?> GetByHouseholdIdAsync(Guid householdId, CancellationToken cancellationToken);
     Task<Subscription?> GetByRevenueCatAppUserIdAsync(string appUserId, CancellationToken cancellationToken);
     Task<IReadOnlyList<Subscription>> GetExpiredTrialsAsync(DateTimeOffset asOfUtc, CancellationToken cancellationToken);
+    Task<IReadOnlyList<Subscription>> GetAllAsync(CancellationToken cancellationToken);
 }

--- a/backend/src/Modules/Subscriptions/Infrastructure/InMemorySubscriptionRepository.cs
+++ b/backend/src/Modules/Subscriptions/Infrastructure/InMemorySubscriptionRepository.cs
@@ -106,4 +106,18 @@ public sealed class InMemorySubscriptionRepository : ISubscriptionRepository
             return Task.FromResult<IReadOnlyList<Subscription>>(expired);
         }
     }
+
+    public Task<IReadOnlyList<Subscription>> GetAllAsync(CancellationToken cancellationToken)
+    {
+        if (cancellationToken.IsCancellationRequested)
+        {
+            return Task.FromCanceled<IReadOnlyList<Subscription>>(cancellationToken);
+        }
+
+        lock (_sync)
+        {
+            return Task.FromResult<IReadOnlyList<Subscription>>(
+                _subscriptionsByHousehold.Values.ToList());
+        }
+    }
 }

--- a/backend/tests/MoneyTracker.Modules.Analytics.Tests/FunnelDashboardTests.cs
+++ b/backend/tests/MoneyTracker.Modules.Analytics.Tests/FunnelDashboardTests.cs
@@ -1,0 +1,572 @@
+using MoneyTracker.Modules.Analytics.Application.GetFunnelReport;
+using MoneyTracker.Modules.Analytics.Application.GetRetentionCohorts;
+using MoneyTracker.Modules.Analytics.Application.GetRevenueMetrics;
+using MoneyTracker.Modules.Analytics.Domain;
+using MoneyTracker.Modules.Analytics.Infrastructure;
+using MoneyTracker.Modules.Subscriptions.Domain;
+using MoneyTracker.Modules.Subscriptions.Infrastructure;
+
+namespace MoneyTracker.Modules.Analytics.Tests;
+
+public sealed class FunnelDashboardTests
+{
+    private static readonly DateTimeOffset NowUtc = DateTimeOffset.Parse("2026-03-10T12:00:00Z");
+
+    #region FunnelReport Tests
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void ComputeStages_ConversionRateCalculation()
+    {
+        // AC-1: Conversion rate = count at stage / count at previous stage
+        // Test: 840/1200 = 0.70
+        var events = new List<ActivationEvent>();
+
+        // Create 1200 users at signup stage
+        var userIds = Enumerable.Range(0, 1200).Select(_ => Guid.NewGuid()).ToArray();
+        foreach (var uid in userIds)
+        {
+            events.Add(CreateEvent(uid, ActivationMilestone.SignupCompleted, NowUtc.AddDays(-5)));
+        }
+
+        // 840 users at onboarding_complete (HouseholdCreated)
+        foreach (var uid in userIds.Take(840))
+        {
+            events.Add(CreateEvent(uid, ActivationMilestone.HouseholdCreated, NowUtc.AddDays(-4)));
+        }
+
+        var stages = FunnelDataAggregator.ComputeStages(events);
+
+        Assert.Equal(7, stages.Count);
+
+        var signupStage = stages[0];
+        Assert.Equal("signup", signupStage.Name);
+        Assert.Equal(1200, signupStage.Count);
+        Assert.Equal(1.0, signupStage.ConversionRate);
+        Assert.Equal(0.0, signupStage.DropOffRate);
+
+        var onboardingStage = stages[1];
+        Assert.Equal("onboarding_complete", onboardingStage.Name);
+        Assert.Equal(840, onboardingStage.Count);
+        Assert.Equal(0.70, onboardingStage.ConversionRate);
+        Assert.Equal(0.30, onboardingStage.DropOffRate);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void ComputeStages_Returns7FunnelStages()
+    {
+        // AC-2: 7 funnel stages: signup through paid_conversion
+        var stages = FunnelDataAggregator.ComputeStages([]);
+
+        Assert.Equal(7, stages.Count);
+        Assert.Equal("signup", stages[0].Name);
+        Assert.Equal("onboarding_complete", stages[1].Name);
+        Assert.Equal("first_transaction", stages[2].Name);
+        Assert.Equal("bank_link", stages[3].Name);
+        Assert.Equal("paywall_view", stages[4].Name);
+        Assert.Equal("trial_start", stages[5].Name);
+        Assert.Equal("paid_conversion", stages[6].Name);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void ComputeTopDropOffs_RankedByLostUserCount()
+    {
+        // AC-3: Top 3 drop-offs ranked by lost user count
+        var events = new List<ActivationEvent>();
+        var userIds = Enumerable.Range(0, 1000).Select(_ => Guid.NewGuid()).ToArray();
+
+        // Signup: 1000
+        foreach (var uid in userIds) events.Add(CreateEvent(uid, ActivationMilestone.SignupCompleted, NowUtc.AddDays(-7)));
+        // Onboarding: 800 (lost 200)
+        foreach (var uid in userIds.Take(800)) events.Add(CreateEvent(uid, ActivationMilestone.HouseholdCreated, NowUtc.AddDays(-6)));
+        // FirstTransaction: 500 (lost 300)
+        foreach (var uid in userIds.Take(500)) events.Add(CreateEvent(uid, ActivationMilestone.FirstTransactionCreated, NowUtc.AddDays(-5)));
+        // BankLink: 400 (lost 100)
+        foreach (var uid in userIds.Take(400)) events.Add(CreateEvent(uid, ActivationMilestone.BankLinkCompleted, NowUtc.AddDays(-4)));
+        // PaywallView: 200 (lost 200)
+        foreach (var uid in userIds.Take(200)) events.Add(CreateEvent(uid, ActivationMilestone.PaywallViewed, NowUtc.AddDays(-3)));
+        // TrialStart: 150 (lost 50)
+        foreach (var uid in userIds.Take(150)) events.Add(CreateEvent(uid, ActivationMilestone.TrialStarted, NowUtc.AddDays(-2)));
+        // PaidConversion: 100 (lost 50)
+        foreach (var uid in userIds.Take(100)) events.Add(CreateEvent(uid, ActivationMilestone.PaidConversion, NowUtc.AddDays(-1)));
+
+        var stages = FunnelDataAggregator.ComputeStages(events);
+        var topDropOffs = FunnelDataAggregator.ComputeTopDropOffs(stages);
+
+        Assert.Equal(3, topDropOffs.Count);
+
+        // Highest drop-off: onboarding_complete -> first_transaction (300 lost)
+        Assert.Equal("onboarding_complete", topDropOffs[0].FromStage);
+        Assert.Equal("first_transaction", topDropOffs[0].ToStage);
+        Assert.Equal(300, topDropOffs[0].LostUsers);
+
+        // Second: signup -> onboarding_complete (200 lost) OR bank_link -> paywall_view (200 lost)
+        // Both have 200 lost users - order depends on stable sort
+        Assert.Equal(200, topDropOffs[1].LostUsers);
+        Assert.Equal(200, topDropOffs[2].LostUsers);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task GetFunnelReport_TrendsCalculation_WoW()
+    {
+        // AC-4: WoW trend = (thisWeek - lastWeek) / lastWeek
+        // Test: 1200 this week vs 1071 last week = ~12% increase
+        var repository = new InMemoryActivationEventRepository();
+
+        // Last week: 1071 signups (2026-02-24 to 2026-03-03)
+        for (var i = 0; i < 1071; i++)
+        {
+            await SeedEvent(repository, Guid.NewGuid(), ActivationMilestone.SignupCompleted,
+                NowUtc.AddDays(-10)); // Falls in last week relative to the period
+        }
+
+        // This week: 1200 signups (2026-03-03 to 2026-03-10)
+        for (var i = 0; i < 1200; i++)
+        {
+            await SeedEvent(repository, Guid.NewGuid(), ActivationMilestone.SignupCompleted,
+                NowUtc.AddDays(-3)); // Falls in this week
+        }
+
+        var aggregator = new FunnelDataAggregator(repository, new StubTimeProvider(NowUtc));
+        var report = await aggregator.GetFunnelReportAsync(
+            NowUtc.AddDays(-7), NowUtc, CancellationToken.None);
+
+        Assert.NotNull(report.Trends.WeekOverWeek);
+        // (1200 - 1071) / 1071 = 0.1204
+        Assert.Equal(0.1204, report.Trends.WeekOverWeek!.Value, 4);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task GetFunnelReport_TrendsCalculation_ZeroLastWeek_ReturnsNull()
+    {
+        // AC-4 edge case: when last week has 0 signups, WoW is null
+        var repository = new InMemoryActivationEventRepository();
+
+        // Only this week signups
+        for (var i = 0; i < 100; i++)
+        {
+            await SeedEvent(repository, Guid.NewGuid(), ActivationMilestone.SignupCompleted,
+                NowUtc.AddDays(-3));
+        }
+
+        var aggregator = new FunnelDataAggregator(repository, new StubTimeProvider(NowUtc));
+        var report = await aggregator.GetFunnelReportAsync(
+            NowUtc.AddDays(-7), NowUtc, CancellationToken.None);
+
+        Assert.Null(report.Trends.WeekOverWeek);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void ComputeOverallConversion_CalculatesCorrectly()
+    {
+        var events = new List<ActivationEvent>();
+        var userIds = Enumerable.Range(0, 100).Select(_ => Guid.NewGuid()).ToArray();
+
+        foreach (var uid in userIds)
+            events.Add(CreateEvent(uid, ActivationMilestone.SignupCompleted, NowUtc.AddDays(-5)));
+        foreach (var uid in userIds.Take(10))
+            events.Add(CreateEvent(uid, ActivationMilestone.PaidConversion, NowUtc.AddDays(-1)));
+
+        var stages = FunnelDataAggregator.ComputeStages(events);
+        var overall = FunnelDataAggregator.ComputeOverallConversion(stages);
+
+        Assert.Equal(0.10, overall);
+    }
+
+    #endregion
+
+    #region Retention Tests
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task RetentionCalculator_D1D7Rates()
+    {
+        // AC-5: D1/D7 retention rates from known data
+        var repository = new InMemoryActivationEventRepository();
+        var signupDate = NowUtc.AddDays(-14);
+
+        // 10 users signed up 14 days ago
+        var userIds = new Guid[10];
+        for (var i = 0; i < 10; i++)
+        {
+            userIds[i] = Guid.NewGuid();
+            await SeedEvent(repository, userIds[i], ActivationMilestone.SignupCompleted, signupDate);
+        }
+
+        // 8 users had activity on D+1 (HouseholdCreated)
+        for (var i = 0; i < 8; i++)
+        {
+            await SeedEvent(repository, userIds[i], ActivationMilestone.HouseholdCreated, signupDate.AddDays(1));
+        }
+
+        // 5 users had activity on D+7 (FirstTransactionCreated)
+        for (var i = 0; i < 5; i++)
+        {
+            await SeedEvent(repository, userIds[i], ActivationMilestone.FirstTransactionCreated, signupDate.AddDays(7));
+        }
+
+        var calculator = new RetentionCalculator(repository);
+        var cohorts = await calculator.GetRetentionCohortsAsync(8, NowUtc, CancellationToken.None);
+
+        Assert.Single(cohorts);
+        var cohort = cohorts[0];
+        Assert.Equal(10, cohort.Signups);
+        Assert.Equal(0.8, cohort.D1);
+        Assert.Equal(0.5, cohort.D7);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task RetentionCalculator_NullForElapsedPeriods()
+    {
+        // AC-6: Retention null for periods that haven't elapsed
+        var repository = new InMemoryActivationEventRepository();
+        var recentSignup = NowUtc.AddDays(-2); // Only 2 days ago
+
+        for (var i = 0; i < 5; i++)
+        {
+            await SeedEvent(repository, Guid.NewGuid(), ActivationMilestone.SignupCompleted, recentSignup);
+        }
+
+        var calculator = new RetentionCalculator(repository);
+        var cohorts = await calculator.GetRetentionCohortsAsync(8, NowUtc, CancellationToken.None);
+
+        Assert.Single(cohorts);
+        var cohort = cohorts[0];
+        Assert.NotNull(cohort.D1); // D1 has elapsed (2 > 1)
+        Assert.Null(cohort.D7);    // D7 hasn't elapsed (2 < 7)
+        Assert.Null(cohort.D14);   // D14 hasn't elapsed
+        Assert.Null(cohort.D30);   // D30 hasn't elapsed
+    }
+
+    #endregion
+
+    #region Revenue Tests
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task RevenueCalculator_MrrWithMonthlyAndAnnualSubs()
+    {
+        // AC-7: MRR with monthly + annual subscriptions
+        var repository = new InMemorySubscriptionRepository();
+
+        // Monthly sub: $9.99/month
+        var monthlySub = Subscription.CreateTrial(
+            Guid.NewGuid(), $"user-monthly-{Guid.NewGuid()}", "mt_premium_monthly",
+            NowUtc.AddDays(-30), NowUtc.AddDays(30), NowUtc.AddDays(-30));
+        monthlySub.Activate(NowUtc.AddDays(-30), NowUtc.AddDays(30), NowUtc.AddDays(-30), "evt-1", NowUtc.AddDays(-29));
+        await repository.AddAsync(monthlySub, CancellationToken.None);
+
+        // Annual sub: $99.99/year = $8.33/month
+        var annualSub = Subscription.CreateTrial(
+            Guid.NewGuid(), $"user-annual-{Guid.NewGuid()}", "mt_premium_annual",
+            NowUtc.AddDays(-30), NowUtc.AddDays(335), NowUtc.AddDays(-30));
+        annualSub.Activate(NowUtc.AddDays(-30), NowUtc.AddDays(335), NowUtc.AddDays(-30), "evt-2", NowUtc.AddDays(-29));
+        await repository.AddAsync(annualSub, CancellationToken.None);
+
+        var calculator = new RevenueCalculator(repository);
+        var metrics = await calculator.GetRevenueMetricsAsync(NowUtc, CancellationToken.None);
+
+        // MRR = 9.99 + (99.99/12) = 9.99 + 8.33 = 18.32
+        Assert.Equal(18.32m, metrics.Mrr);
+        Assert.Equal(2, metrics.ActiveSubscribers);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task RevenueCalculator_ArpuCalculation()
+    {
+        // AC-7: ARPU = MRR / active subscribers
+        var repository = new InMemorySubscriptionRepository();
+
+        for (var i = 0; i < 3; i++)
+        {
+            var sub = Subscription.CreateTrial(
+                Guid.NewGuid(), $"user-{i}-{Guid.NewGuid()}", "mt_premium_monthly",
+                NowUtc.AddDays(-30), NowUtc.AddDays(30), NowUtc.AddDays(-30));
+            sub.Activate(NowUtc.AddDays(-30), NowUtc.AddDays(30), NowUtc.AddDays(-30), $"evt-{i}", NowUtc.AddDays(-29));
+            await repository.AddAsync(sub, CancellationToken.None);
+        }
+
+        var calculator = new RevenueCalculator(repository);
+        var metrics = await calculator.GetRevenueMetricsAsync(NowUtc, CancellationToken.None);
+
+        // ARPU = 29.97 / 3 = 9.99
+        Assert.Equal(9.99m, metrics.Arpu);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task RevenueCalculator_ChurnRate()
+    {
+        // AC-7: Churn rate = cancellations in period / active at start
+        var repository = new InMemorySubscriptionRepository();
+
+        // 4 active subs
+        for (var i = 0; i < 4; i++)
+        {
+            var sub = Subscription.CreateTrial(
+                Guid.NewGuid(), $"user-active-{i}-{Guid.NewGuid()}", "mt_premium_monthly",
+                NowUtc.AddDays(-60), NowUtc.AddDays(30), NowUtc.AddDays(-60));
+            sub.Activate(NowUtc.AddDays(-60), NowUtc.AddDays(30), NowUtc.AddDays(-60), $"evt-a-{i}", NowUtc.AddDays(-59));
+            await repository.AddAsync(sub, CancellationToken.None);
+        }
+
+        // 1 cancelled sub (within last 30 days)
+        var cancelledSub = Subscription.CreateTrial(
+            Guid.NewGuid(), $"user-cancelled-{Guid.NewGuid()}", "mt_premium_monthly",
+            NowUtc.AddDays(-60), NowUtc.AddDays(30), NowUtc.AddDays(-60));
+        cancelledSub.Activate(NowUtc.AddDays(-60), NowUtc.AddDays(30), NowUtc.AddDays(-60), "evt-c-1", NowUtc.AddDays(-59));
+        cancelledSub.Cancel(NowUtc.AddDays(-10), "evt-c-2", NowUtc.AddDays(-10));
+        await repository.AddAsync(cancelledSub, CancellationToken.None);
+
+        var calculator = new RevenueCalculator(repository);
+        var metrics = await calculator.GetRevenueMetricsAsync(NowUtc, CancellationToken.None);
+
+        // Active at start = 4 (current active) + 1 (cancelled in period) = 5
+        // Churn = 1 / 5 = 0.2
+        Assert.Equal(0.2, metrics.ChurnRate);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task RevenueCalculator_Ltv()
+    {
+        // AC-7: LTV = ARPU / churnRate
+        var repository = new InMemorySubscriptionRepository();
+
+        // 9 active, 1 cancelled in period
+        for (var i = 0; i < 9; i++)
+        {
+            var sub = Subscription.CreateTrial(
+                Guid.NewGuid(), $"user-ltv-{i}-{Guid.NewGuid()}", "mt_premium_monthly",
+                NowUtc.AddDays(-60), NowUtc.AddDays(30), NowUtc.AddDays(-60));
+            sub.Activate(NowUtc.AddDays(-60), NowUtc.AddDays(30), NowUtc.AddDays(-60), $"evt-l-{i}", NowUtc.AddDays(-59));
+            await repository.AddAsync(sub, CancellationToken.None);
+        }
+
+        var cancelledSub = Subscription.CreateTrial(
+            Guid.NewGuid(), $"user-ltv-cancelled-{Guid.NewGuid()}", "mt_premium_monthly",
+            NowUtc.AddDays(-60), NowUtc.AddDays(30), NowUtc.AddDays(-60));
+        cancelledSub.Activate(NowUtc.AddDays(-60), NowUtc.AddDays(30), NowUtc.AddDays(-60), "evt-lc-1", NowUtc.AddDays(-59));
+        cancelledSub.Cancel(NowUtc.AddDays(-5), "evt-lc-2", NowUtc.AddDays(-5));
+        await repository.AddAsync(cancelledSub, CancellationToken.None);
+
+        var calculator = new RevenueCalculator(repository);
+        var metrics = await calculator.GetRevenueMetricsAsync(NowUtc, CancellationToken.None);
+
+        // ARPU = 89.91 / 9 = 9.99
+        // Churn = 1 / 10 = 0.1
+        // LTV = 9.99 / 0.1 = 99.90
+        Assert.NotNull(metrics.EstimatedLtv);
+        Assert.Equal(99.90m, metrics.EstimatedLtv!.Value);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task RevenueCalculator_LtvNull_WhenZeroChurn()
+    {
+        // AC-7: LTV = null when churnRate = 0
+        var repository = new InMemorySubscriptionRepository();
+
+        var sub = Subscription.CreateTrial(
+            Guid.NewGuid(), $"user-nochurn-{Guid.NewGuid()}", "mt_premium_monthly",
+            NowUtc.AddDays(-60), NowUtc.AddDays(30), NowUtc.AddDays(-60));
+        sub.Activate(NowUtc.AddDays(-60), NowUtc.AddDays(30), NowUtc.AddDays(-60), "evt-nc-1", NowUtc.AddDays(-59));
+        await repository.AddAsync(sub, CancellationToken.None);
+
+        var calculator = new RevenueCalculator(repository);
+        var metrics = await calculator.GetRevenueMetricsAsync(NowUtc, CancellationToken.None);
+
+        Assert.Equal(0.0, metrics.ChurnRate);
+        Assert.Null(metrics.EstimatedLtv);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task RevenueCalculator_TrialUsersCount()
+    {
+        // AC-7: Trial users counted separately
+        var repository = new InMemorySubscriptionRepository();
+
+        // 1 active sub
+        var activeSub = Subscription.CreateTrial(
+            Guid.NewGuid(), $"user-a-{Guid.NewGuid()}", "mt_premium_monthly",
+            NowUtc.AddDays(-30), NowUtc.AddDays(30), NowUtc.AddDays(-30));
+        activeSub.Activate(NowUtc.AddDays(-30), NowUtc.AddDays(30), NowUtc.AddDays(-30), "evt-a", NowUtc.AddDays(-29));
+        await repository.AddAsync(activeSub, CancellationToken.None);
+
+        // 2 trial subs
+        for (var i = 0; i < 2; i++)
+        {
+            var trialSub = Subscription.CreateTrial(
+                Guid.NewGuid(), $"user-t-{i}-{Guid.NewGuid()}", "mt_premium_monthly",
+                NowUtc.AddDays(-5), NowUtc.AddDays(9), NowUtc.AddDays(-5));
+            await repository.AddAsync(trialSub, CancellationToken.None);
+        }
+
+        var calculator = new RevenueCalculator(repository);
+        var metrics = await calculator.GetRevenueMetricsAsync(NowUtc, CancellationToken.None);
+
+        Assert.Equal(1, metrics.ActiveSubscribers);
+        Assert.Equal(2, metrics.TrialUsers);
+    }
+
+    #endregion
+
+    #region GetMonthlyEquivalent Tests
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void GetMonthlyEquivalent_MonthlyProduct()
+    {
+        var result = RevenueCalculator.GetMonthlyEquivalent("mt_premium_monthly");
+        Assert.Equal(9.99m, result);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void GetMonthlyEquivalent_AnnualProduct()
+    {
+        var result = RevenueCalculator.GetMonthlyEquivalent("mt_premium_annual");
+        Assert.Equal(8.33m, result);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void GetMonthlyEquivalent_UnknownProduct_ReturnsDefault()
+    {
+        var result = RevenueCalculator.GetMonthlyEquivalent("unknown_product");
+        Assert.Equal(9.99m, result);
+    }
+
+    #endregion
+
+    #region Handler Tests
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task GetFunnelReportHandler_InvalidPeriod_ReturnsFailure()
+    {
+        var aggregator = new FunnelDataAggregator(
+            new InMemoryActivationEventRepository(), new StubTimeProvider(NowUtc));
+        var handler = new GetFunnelReportHandler(aggregator);
+
+        var result = await handler.HandleAsync(
+            new GetFunnelReportQuery(NowUtc, NowUtc.AddDays(-1)),
+            CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(AnalyticsErrors.ValidationError, result.ErrorCode);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task GetRetentionCohortsHandler_InvalidCohortCount_ReturnsFailure()
+    {
+        var calculator = new RetentionCalculator(new InMemoryActivationEventRepository());
+        var handler = new GetRetentionCohortsHandler(calculator, new StubTimeProvider(NowUtc));
+
+        var result = await handler.HandleAsync(
+            new GetRetentionCohortsQuery(0),
+            CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(AnalyticsErrors.ValidationError, result.ErrorCode);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task GetRevenueMetricsHandler_Success()
+    {
+        var calculator = new RevenueCalculator(new InMemorySubscriptionRepository());
+        var handler = new GetRevenueMetricsHandler(calculator, new StubTimeProvider(NowUtc));
+
+        var result = await handler.HandleAsync(
+            new GetRevenueMetricsQuery(),
+            CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        Assert.NotNull(result.Metrics);
+    }
+
+    #endregion
+
+    #region WeeklyReport Domain Tests
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void WeeklyReport_Create_SetsPropertiesCorrectly()
+    {
+        var periodStart = NowUtc.AddDays(-7);
+        var periodEnd = NowUtc;
+
+        var report = WeeklyReport.Create(periodStart, periodEnd, "weekly_summary", "{}", NowUtc);
+
+        Assert.NotEqual(Guid.Empty, report.Id);
+        Assert.Equal(periodStart, report.PeriodStart);
+        Assert.Equal(periodEnd, report.PeriodEnd);
+        Assert.Equal("weekly_summary", report.ReportType);
+        Assert.Equal("{}", report.Data);
+        Assert.Equal(NowUtc, report.GeneratedAtUtc);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void WeeklyReport_Create_EmptyReportType_Throws()
+    {
+        Assert.Throws<AnalyticsDomainException>(() =>
+            WeeklyReport.Create(NowUtc.AddDays(-7), NowUtc, "", "{}", NowUtc));
+    }
+
+    #endregion
+
+    #region InMemoryWeeklyReportRepository Tests
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task InMemoryWeeklyReportRepository_AddAndGetByType()
+    {
+        var repository = new InMemoryWeeklyReportRepository();
+        var report = WeeklyReport.Create(NowUtc.AddDays(-7), NowUtc, "weekly_summary", "{}", NowUtc);
+
+        await repository.AddAsync(report, CancellationToken.None);
+
+        var results = await repository.GetByTypeAsync("weekly_summary", 10, CancellationToken.None);
+        Assert.Single(results);
+        Assert.Equal(report.Id, results[0].Id);
+    }
+
+    #endregion
+
+    #region Helpers
+
+    private static ActivationEvent CreateEvent(
+        Guid userId,
+        ActivationMilestone milestone,
+        DateTimeOffset occurredAtUtc)
+    {
+        return ActivationEvent.Create(
+            userId, milestone, householdId: null, "backend", region: null,
+            metadata: null, occurredAtUtc, occurredAtUtc);
+    }
+
+    private static async Task SeedEvent(
+        InMemoryActivationEventRepository repository,
+        Guid userId,
+        ActivationMilestone milestone,
+        DateTimeOffset occurredAtUtc)
+    {
+        var evt = ActivationEvent.Create(
+            userId, milestone, householdId: null, "backend", region: null,
+            metadata: null, occurredAtUtc, occurredAtUtc);
+        await repository.AddAsync(evt, CancellationToken.None);
+    }
+
+    #endregion
+}

--- a/backend/tests/MoneyTracker.Modules.Subscriptions.Tests/Infrastructure/SubscriptionEntitlementServiceTests.cs
+++ b/backend/tests/MoneyTracker.Modules.Subscriptions.Tests/Infrastructure/SubscriptionEntitlementServiceTests.cs
@@ -184,5 +184,8 @@ public sealed class SubscriptionEntitlementServiceTests
 
         public Task<IReadOnlyList<Subscription>> GetExpiredTrialsAsync(DateTimeOffset asOfUtc, CancellationToken cancellationToken)
             => Task.FromResult<IReadOnlyList<Subscription>>(Array.Empty<Subscription>());
+
+        public Task<IReadOnlyList<Subscription>> GetAllAsync(CancellationToken cancellationToken)
+            => Task.FromResult<IReadOnlyList<Subscription>>(subscription is not null ? [subscription] : Array.Empty<Subscription>());
     }
 }


### PR DESCRIPTION
## Summary
- Extends existing Analytics module with funnel report, retention cohort, and revenue metrics endpoints (admin-gated via IAdminAccessService)
- Adds FunnelDataAggregator (7-stage funnel: signup through paid_conversion), RetentionCalculator (D1/D7/D14/D30 by signup week), and RevenueCalculator (MRR/ARPU/churn/LTV from subscription data)
- Adds WeeklyReportWorker BackgroundService following the TransactionSyncWorker pattern, with InMemoryWeeklyReportRepository for report persistence
- Includes 24 new unit tests covering conversion rates, drop-off ranking, WoW/MoM trends, retention null for un-elapsed periods, and revenue metric edge cases

## Acceptance Criteria
- [x] AC-1: GET /admin/funnel-report returns funnel stages with counts, conversion rates, drop-off rates
- [x] AC-2: 7 funnel stages: signup through paid_conversion
- [x] AC-3: Top 3 drop-offs ranked by lost user count
- [x] AC-4: Week-over-week and month-over-month trend deltas
- [x] AC-5: GET /admin/retention-cohorts returns D1/D7/D14/D30 by signup week
- [x] AC-6: Retention null for periods that haven't elapsed
- [x] AC-7: GET /admin/revenue-metrics returns MRR, ARPU, churn, LTV
- [x] AC-8: Revenue trends (WoW, MoM)
- [x] AC-9: Weekly report worker (BackgroundService)
- [x] AC-11: All endpoints admin-gated via IAdminAccessService
- [x] AC-12: Cross-module queries are read-only

## Test plan
- [x] FunnelReport: conversion rate calculation (840/1200 = 0.70)
- [x] DropOff: top 3 ranked by lostUsers
- [x] Trends: WoW calculation (1200 vs 1071 = ~12% increase), edge case (0 last week = null)
- [x] Retention: D1/D7 rates from known data, null for un-elapsed periods
- [x] Revenue: MRR with monthly + annual subs, ARPU, churn rate, LTV, LTV with 0 churn = null
- [x] All 409 backend tests pass (42 Analytics, including 24 new)
- [x] All 171 Flutter tests pass (no regressions)

Closes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)