### PR TITLE
Add post-launch issue triage and user feedback loop

### DIFF
--- a/backend/MoneyTracker.slnx
+++ b/backend/MoneyTracker.slnx
@@ -13,6 +13,7 @@
     <Project Path="src/Modules/Analytics/MoneyTracker.Modules.Analytics.csproj" />
     <Project Path="src/Modules/Insights/MoneyTracker.Modules.Insights.csproj" />
     <Project Path="src/Modules/Experiments/MoneyTracker.Modules.Experiments.csproj" />
+    <Project Path="src/Modules/Feedback/MoneyTracker.Modules.Feedback.csproj" />
   </Folder>
   <Folder Name="/tests/">
     <Project Path="tests/MoneyTracker.Api.Tests/MoneyTracker.Api.Tests.csproj" />
@@ -26,5 +27,6 @@
     <Project Path="tests/MoneyTracker.Modules.Insights.Tests/MoneyTracker.Modules.Insights.Tests.csproj" />
     <Project Path="tests/MoneyTracker.Modules.Auth.Tests/MoneyTracker.Modules.Auth.Tests.csproj" />
     <Project Path="tests/MoneyTracker.Modules.Experiments.Tests/MoneyTracker.Modules.Experiments.Tests.csproj" />
+    <Project Path="tests/MoneyTracker.Modules.Feedback.Tests/MoneyTracker.Modules.Feedback.Tests.csproj" />
   </Folder>
 </Solution>

--- a/backend/src/Modules/Feedback/Application/GetCrashSummary/GetCrashSummaryHandler.cs
+++ b/backend/src/Modules/Feedback/Application/GetCrashSummary/GetCrashSummaryHandler.cs
@@ -1,0 +1,45 @@
+using MoneyTracker.Modules.Feedback.Domain;
+
+namespace MoneyTracker.Modules.Feedback.Application.GetCrashSummary;
+
+public sealed class GetCrashSummaryHandler(
+    ICrashReportRepository crashReportRepository)
+{
+    // Placeholder total sessions count for crash-free rate calculation.
+    // In production, this would come from an analytics/telemetry source.
+    private const int EstimatedTotalSessions = 10000;
+
+    public async Task<GetCrashSummaryResult> HandleAsync(
+        GetCrashSummaryQuery query,
+        CancellationToken cancellationToken)
+    {
+        var reports = await crashReportRepository.GetRecentAsync(
+            query.PeriodDays,
+            cancellationToken);
+
+        var totalCrashes = await crashReportRepository.GetTotalCrashCountAsync(
+            query.PeriodDays,
+            cancellationToken);
+
+        var crashFreeRate = EstimatedTotalSessions > 0
+            ? Math.Max(0, 1.0 - ((double)totalCrashes / EstimatedTotalSessions)) * 100
+            : 100.0;
+
+        var topCrashes = reports
+            .Take(10)
+            .Select(r => new CrashReportSummary(
+                r.Signature,
+                r.Count,
+                r.AffectedUsers,
+                r.FirstSeen,
+                r.LastSeen))
+            .ToArray();
+
+        var data = new CrashSummaryData(
+            crashFreeRate,
+            totalCrashes,
+            topCrashes);
+
+        return GetCrashSummaryResult.Success(data);
+    }
+}

--- a/backend/src/Modules/Feedback/Application/GetCrashSummary/GetCrashSummaryQuery.cs
+++ b/backend/src/Modules/Feedback/Application/GetCrashSummary/GetCrashSummaryQuery.cs
@@ -1,0 +1,3 @@
+namespace MoneyTracker.Modules.Feedback.Application.GetCrashSummary;
+
+public sealed record GetCrashSummaryQuery(int PeriodDays);

--- a/backend/src/Modules/Feedback/Application/GetCrashSummary/GetCrashSummaryResult.cs
+++ b/backend/src/Modules/Feedback/Application/GetCrashSummary/GetCrashSummaryResult.cs
@@ -1,0 +1,42 @@
+namespace MoneyTracker.Modules.Feedback.Application.GetCrashSummary;
+
+public sealed class GetCrashSummaryResult
+{
+    private GetCrashSummaryResult(
+        CrashSummaryData? data,
+        string? errorCode,
+        string? errorMessage)
+    {
+        Data = data;
+        ErrorCode = errorCode;
+        ErrorMessage = errorMessage;
+    }
+
+    public CrashSummaryData? Data { get; }
+    public string? ErrorCode { get; }
+    public string? ErrorMessage { get; }
+
+    public bool IsSuccess => Data is not null;
+
+    public static GetCrashSummaryResult Success(CrashSummaryData data)
+    {
+        return new GetCrashSummaryResult(data, errorCode: null, errorMessage: null);
+    }
+
+    public static GetCrashSummaryResult Error(string code, string message)
+    {
+        return new GetCrashSummaryResult(data: null, code, message);
+    }
+}
+
+public sealed record CrashSummaryData(
+    double CrashFreeRate,
+    int TotalCrashes,
+    CrashReportSummary[] TopCrashes);
+
+public sealed record CrashReportSummary(
+    string Signature,
+    int Count,
+    int AffectedUsers,
+    DateTimeOffset FirstSeen,
+    DateTimeOffset LastSeen);

--- a/backend/src/Modules/Feedback/Application/GetFeedbackSummary/GetFeedbackSummaryHandler.cs
+++ b/backend/src/Modules/Feedback/Application/GetFeedbackSummary/GetFeedbackSummaryHandler.cs
@@ -1,0 +1,69 @@
+using MoneyTracker.Modules.Feedback.Domain;
+
+namespace MoneyTracker.Modules.Feedback.Application.GetFeedbackSummary;
+
+public sealed class GetFeedbackSummaryHandler(
+    IFeedbackRepository feedbackRepository,
+    INpsRepository npsRepository,
+    TimeProvider timeProvider)
+{
+    public async Task<GetFeedbackSummaryResult> HandleAsync(
+        GetFeedbackSummaryQuery query,
+        CancellationToken cancellationToken)
+    {
+        var feedback = await feedbackRepository.GetByPeriodAsync(
+            query.PeriodStart,
+            query.PeriodEnd,
+            cancellationToken);
+
+        var npsScores = await npsRepository.GetByPeriodAsync(
+            query.PeriodStart,
+            query.PeriodEnd,
+            cancellationToken);
+
+        var byCategory = feedback
+            .GroupBy(f => f.Category.ToString())
+            .ToDictionary(g => g.Key, g => g.Count());
+
+        var avgSatisfaction = feedback.Count > 0
+            ? feedback.Average(f => f.Rating)
+            : 0;
+
+        // NPS = % Promoters - % Detractors
+        var npsValue = 0.0;
+        if (npsScores.Count > 0)
+        {
+            var promoters = npsScores.Count(s => s.Category == NpsCategory.Promoter);
+            var detractors = npsScores.Count(s => s.Category == NpsCategory.Detractor);
+            npsValue = ((double)(promoters - detractors) / npsScores.Count) * 100;
+        }
+
+        var priorityDistribution = feedback
+            .GroupBy(f => f.PriorityScore.Bucket.ToString())
+            .ToDictionary(g => g.Key, g => g.Count());
+
+        // AC-7: WoW trends
+        var nowUtc = timeProvider.GetUtcNow();
+        var oneWeekAgo = nowUtc.AddDays(-7);
+        var twoWeeksAgo = nowUtc.AddDays(-14);
+
+        var currentWeekCount = feedback.Count(f => f.CreatedAtUtc >= oneWeekAgo);
+        var previousWeekCount = feedback.Count(f => f.CreatedAtUtc >= twoWeeksAgo && f.CreatedAtUtc < oneWeekAgo);
+
+        var wowChangePercent = previousWeekCount > 0
+            ? ((double)(currentWeekCount - previousWeekCount) / previousWeekCount) * 100
+            : 0;
+
+        var trends = new TrendData(currentWeekCount, previousWeekCount, wowChangePercent);
+
+        var data = new FeedbackSummaryData(
+            feedback.Count,
+            byCategory,
+            avgSatisfaction,
+            npsValue,
+            priorityDistribution,
+            trends);
+
+        return GetFeedbackSummaryResult.Success(data);
+    }
+}

--- a/backend/src/Modules/Feedback/Application/GetFeedbackSummary/GetFeedbackSummaryQuery.cs
+++ b/backend/src/Modules/Feedback/Application/GetFeedbackSummary/GetFeedbackSummaryQuery.cs
@@ -1,0 +1,5 @@
+namespace MoneyTracker.Modules.Feedback.Application.GetFeedbackSummary;
+
+public sealed record GetFeedbackSummaryQuery(
+    DateTimeOffset PeriodStart,
+    DateTimeOffset PeriodEnd);

--- a/backend/src/Modules/Feedback/Application/GetFeedbackSummary/GetFeedbackSummaryResult.cs
+++ b/backend/src/Modules/Feedback/Application/GetFeedbackSummary/GetFeedbackSummaryResult.cs
@@ -1,0 +1,45 @@
+using MoneyTracker.Modules.Feedback.Domain;
+
+namespace MoneyTracker.Modules.Feedback.Application.GetFeedbackSummary;
+
+public sealed class GetFeedbackSummaryResult
+{
+    private GetFeedbackSummaryResult(
+        FeedbackSummaryData? data,
+        string? errorCode,
+        string? errorMessage)
+    {
+        Data = data;
+        ErrorCode = errorCode;
+        ErrorMessage = errorMessage;
+    }
+
+    public FeedbackSummaryData? Data { get; }
+    public string? ErrorCode { get; }
+    public string? ErrorMessage { get; }
+
+    public bool IsSuccess => Data is not null;
+
+    public static GetFeedbackSummaryResult Success(FeedbackSummaryData data)
+    {
+        return new GetFeedbackSummaryResult(data, errorCode: null, errorMessage: null);
+    }
+
+    public static GetFeedbackSummaryResult Error(string code, string message)
+    {
+        return new GetFeedbackSummaryResult(data: null, code, message);
+    }
+}
+
+public sealed record FeedbackSummaryData(
+    int TotalFeedback,
+    Dictionary<string, int> ByCategory,
+    double AvgSatisfaction,
+    double NpsScore,
+    Dictionary<string, int> PriorityDistribution,
+    TrendData? Trends);
+
+public sealed record TrendData(
+    int CurrentWeekCount,
+    int PreviousWeekCount,
+    double WowChangePercent);

--- a/backend/src/Modules/Feedback/Application/SubmitFeedback/SubmitFeedbackCommand.cs
+++ b/backend/src/Modules/Feedback/Application/SubmitFeedback/SubmitFeedbackCommand.cs
@@ -1,0 +1,14 @@
+using MoneyTracker.Modules.Feedback.Domain;
+
+namespace MoneyTracker.Modules.Feedback.Application.SubmitFeedback;
+
+public sealed record SubmitFeedbackCommand(
+    Guid UserId,
+    FeedbackCategory Category,
+    string Description,
+    int Rating,
+    string? ScreenName,
+    string? AppVersion,
+    string? DeviceModel,
+    string? OsVersion,
+    string UserTier);

--- a/backend/src/Modules/Feedback/Application/SubmitFeedback/SubmitFeedbackHandler.cs
+++ b/backend/src/Modules/Feedback/Application/SubmitFeedback/SubmitFeedbackHandler.cs
@@ -1,0 +1,69 @@
+using MoneyTracker.Modules.Feedback.Domain;
+using MoneyTracker.Modules.Feedback.Infrastructure;
+
+namespace MoneyTracker.Modules.Feedback.Application.SubmitFeedback;
+
+public sealed class SubmitFeedbackHandler(
+    IFeedbackRepository feedbackRepository,
+    PriorityScorer priorityScorer,
+    TimeProvider timeProvider)
+{
+    private const int MaxFeedbackPerDay = 5;
+
+    public async Task<SubmitFeedbackResult> HandleAsync(
+        SubmitFeedbackCommand command,
+        CancellationToken cancellationToken)
+    {
+        var nowUtc = timeProvider.GetUtcNow();
+
+        // AC-15: Rate limit — 5 per user per 24h
+        var recentFeedback = await feedbackRepository.GetByUserSinceAsync(
+            command.UserId,
+            nowUtc.AddHours(-24),
+            cancellationToken);
+
+        if (recentFeedback.Count >= MaxFeedbackPerDay)
+        {
+            return SubmitFeedbackResult.RateLimited();
+        }
+
+        // AC-3: Auto-computed priority score
+        var similarCount = await feedbackRepository.CountSimilarInPeriodAsync(
+            command.Category,
+            nowUtc.AddDays(-7),
+            cancellationToken);
+
+        var priorityScore = priorityScorer.ComputeScore(
+            command.Category,
+            command.Description,
+            command.UserTier,
+            similarCount);
+
+        var metadata = new FeedbackMetadata(
+            command.ScreenName,
+            command.AppVersion,
+            command.DeviceModel,
+            command.OsVersion);
+
+        FeedbackItem feedback;
+        try
+        {
+            feedback = FeedbackItem.Create(
+                command.UserId,
+                command.Category,
+                command.Description,
+                command.Rating,
+                metadata,
+                priorityScore,
+                nowUtc);
+        }
+        catch (FeedbackDomainException ex)
+        {
+            return SubmitFeedbackResult.Validation(ex.Code, ex.Message);
+        }
+
+        await feedbackRepository.AddAsync(feedback, cancellationToken);
+
+        return SubmitFeedbackResult.Success(feedback.Id.Value, feedback.Status.ToString());
+    }
+}

--- a/backend/src/Modules/Feedback/Application/SubmitFeedback/SubmitFeedbackResult.cs
+++ b/backend/src/Modules/Feedback/Application/SubmitFeedback/SubmitFeedbackResult.cs
@@ -1,0 +1,42 @@
+namespace MoneyTracker.Modules.Feedback.Application.SubmitFeedback;
+
+public sealed class SubmitFeedbackResult
+{
+    private SubmitFeedbackResult(
+        Guid? feedbackId,
+        string? status,
+        string? errorCode,
+        string? errorMessage)
+    {
+        FeedbackId = feedbackId;
+        Status = status;
+        ErrorCode = errorCode;
+        ErrorMessage = errorMessage;
+    }
+
+    public Guid? FeedbackId { get; }
+    public string? Status { get; }
+    public string? ErrorCode { get; }
+    public string? ErrorMessage { get; }
+
+    public bool IsSuccess => FeedbackId is not null;
+
+    public static SubmitFeedbackResult Success(Guid feedbackId, string status)
+    {
+        return new SubmitFeedbackResult(feedbackId, status, errorCode: null, errorMessage: null);
+    }
+
+    public static SubmitFeedbackResult Validation(string code, string message)
+    {
+        return new SubmitFeedbackResult(feedbackId: null, status: null, code, message);
+    }
+
+    public static SubmitFeedbackResult RateLimited()
+    {
+        return new SubmitFeedbackResult(
+            feedbackId: null,
+            status: null,
+            Domain.FeedbackErrors.RateLimitExceeded,
+            "Maximum of 5 feedback submissions per 24 hours exceeded.");
+    }
+}

--- a/backend/src/Modules/Feedback/Application/SubmitNps/SubmitNpsCommand.cs
+++ b/backend/src/Modules/Feedback/Application/SubmitNps/SubmitNpsCommand.cs
@@ -1,0 +1,6 @@
+namespace MoneyTracker.Modules.Feedback.Application.SubmitNps;
+
+public sealed record SubmitNpsCommand(
+    Guid UserId,
+    int Score,
+    string? Comment);

--- a/backend/src/Modules/Feedback/Application/SubmitNps/SubmitNpsHandler.cs
+++ b/backend/src/Modules/Feedback/Application/SubmitNps/SubmitNpsHandler.cs
@@ -1,0 +1,31 @@
+using MoneyTracker.Modules.Feedback.Domain;
+
+namespace MoneyTracker.Modules.Feedback.Application.SubmitNps;
+
+public sealed class SubmitNpsHandler(
+    INpsRepository npsRepository,
+    TimeProvider timeProvider)
+{
+    public async Task<SubmitNpsResult> HandleAsync(
+        SubmitNpsCommand command,
+        CancellationToken cancellationToken)
+    {
+        NpsScore npsScore;
+        try
+        {
+            npsScore = NpsScore.Create(
+                command.UserId,
+                command.Score,
+                command.Comment,
+                timeProvider.GetUtcNow());
+        }
+        catch (FeedbackDomainException ex)
+        {
+            return SubmitNpsResult.Validation(ex.Code, ex.Message);
+        }
+
+        await npsRepository.AddAsync(npsScore, cancellationToken);
+
+        return SubmitNpsResult.Success(npsScore.Id);
+    }
+}

--- a/backend/src/Modules/Feedback/Application/SubmitNps/SubmitNpsResult.cs
+++ b/backend/src/Modules/Feedback/Application/SubmitNps/SubmitNpsResult.cs
@@ -1,0 +1,30 @@
+namespace MoneyTracker.Modules.Feedback.Application.SubmitNps;
+
+public sealed class SubmitNpsResult
+{
+    private SubmitNpsResult(
+        Guid? npsId,
+        string? errorCode,
+        string? errorMessage)
+    {
+        NpsId = npsId;
+        ErrorCode = errorCode;
+        ErrorMessage = errorMessage;
+    }
+
+    public Guid? NpsId { get; }
+    public string? ErrorCode { get; }
+    public string? ErrorMessage { get; }
+
+    public bool IsSuccess => NpsId is not null;
+
+    public static SubmitNpsResult Success(Guid npsId)
+    {
+        return new SubmitNpsResult(npsId, errorCode: null, errorMessage: null);
+    }
+
+    public static SubmitNpsResult Validation(string code, string message)
+    {
+        return new SubmitNpsResult(npsId: null, code, message);
+    }
+}

--- a/backend/src/Modules/Feedback/Application/TriageFeedback/TriageFeedbackCommand.cs
+++ b/backend/src/Modules/Feedback/Application/TriageFeedback/TriageFeedbackCommand.cs
@@ -1,0 +1,8 @@
+using MoneyTracker.Modules.Feedback.Domain;
+
+namespace MoneyTracker.Modules.Feedback.Application.TriageFeedback;
+
+public sealed record TriageFeedbackCommand(
+    FeedbackId FeedbackId,
+    FeedbackStatus Status,
+    double? PriorityOverride);

--- a/backend/src/Modules/Feedback/Application/TriageFeedback/TriageFeedbackHandler.cs
+++ b/backend/src/Modules/Feedback/Application/TriageFeedback/TriageFeedbackHandler.cs
@@ -1,0 +1,39 @@
+using MoneyTracker.Modules.Feedback.Domain;
+
+namespace MoneyTracker.Modules.Feedback.Application.TriageFeedback;
+
+public sealed class TriageFeedbackHandler(
+    IFeedbackRepository feedbackRepository,
+    TimeProvider timeProvider)
+{
+    public async Task<TriageFeedbackResult> HandleAsync(
+        TriageFeedbackCommand command,
+        CancellationToken cancellationToken)
+    {
+        var feedback = await feedbackRepository.GetByIdAsync(
+            command.FeedbackId,
+            cancellationToken);
+
+        if (feedback is null)
+        {
+            return TriageFeedbackResult.NotFound();
+        }
+
+        var priorityOverride = command.PriorityOverride.HasValue
+            ? PriorityScore.Compute(command.PriorityOverride.Value)
+            : null;
+
+        try
+        {
+            feedback.Triage(command.Status, priorityOverride, timeProvider.GetUtcNow());
+        }
+        catch (FeedbackDomainException ex)
+        {
+            return TriageFeedbackResult.Validation(ex.Code, ex.Message);
+        }
+
+        await feedbackRepository.UpdateAsync(feedback, cancellationToken);
+
+        return TriageFeedbackResult.Success();
+    }
+}

--- a/backend/src/Modules/Feedback/Application/TriageFeedback/TriageFeedbackResult.cs
+++ b/backend/src/Modules/Feedback/Application/TriageFeedback/TriageFeedbackResult.cs
@@ -1,0 +1,33 @@
+namespace MoneyTracker.Modules.Feedback.Application.TriageFeedback;
+
+public sealed class TriageFeedbackResult
+{
+    private TriageFeedbackResult(
+        bool isSuccess,
+        string? errorCode,
+        string? errorMessage)
+    {
+        IsSuccess = isSuccess;
+        ErrorCode = errorCode;
+        ErrorMessage = errorMessage;
+    }
+
+    public bool IsSuccess { get; }
+    public string? ErrorCode { get; }
+    public string? ErrorMessage { get; }
+
+    public static TriageFeedbackResult Success()
+    {
+        return new TriageFeedbackResult(true, errorCode: null, errorMessage: null);
+    }
+
+    public static TriageFeedbackResult NotFound()
+    {
+        return new TriageFeedbackResult(false, Domain.FeedbackErrors.NotFound, "Feedback not found.");
+    }
+
+    public static TriageFeedbackResult Validation(string code, string message)
+    {
+        return new TriageFeedbackResult(false, code, message);
+    }
+}

--- a/backend/src/Modules/Feedback/Domain/CrashReport.cs
+++ b/backend/src/Modules/Feedback/Domain/CrashReport.cs
@@ -1,0 +1,35 @@
+namespace MoneyTracker.Modules.Feedback.Domain;
+
+public sealed class CrashReport
+{
+    public string Signature { get; }
+    public int Count { get; private set; }
+    public int AffectedUsers { get; private set; }
+    public DateTimeOffset FirstSeen { get; }
+    public DateTimeOffset LastSeen { get; private set; }
+
+    public CrashReport(
+        string signature,
+        int count,
+        int affectedUsers,
+        DateTimeOffset firstSeen,
+        DateTimeOffset lastSeen)
+    {
+        Signature = signature;
+        Count = count;
+        AffectedUsers = affectedUsers;
+        FirstSeen = firstSeen;
+        LastSeen = lastSeen;
+    }
+
+    public void IncrementCount(DateTimeOffset nowUtc)
+    {
+        Count++;
+        LastSeen = nowUtc;
+    }
+
+    public void IncrementAffectedUsers()
+    {
+        AffectedUsers++;
+    }
+}

--- a/backend/src/Modules/Feedback/Domain/FeedbackCategory.cs
+++ b/backend/src/Modules/Feedback/Domain/FeedbackCategory.cs
@@ -1,0 +1,8 @@
+namespace MoneyTracker.Modules.Feedback.Domain;
+
+public enum FeedbackCategory
+{
+    Bug,
+    Feature,
+    General
+}

--- a/backend/src/Modules/Feedback/Domain/FeedbackDomainException.cs
+++ b/backend/src/Modules/Feedback/Domain/FeedbackDomainException.cs
@@ -1,0 +1,6 @@
+namespace MoneyTracker.Modules.Feedback.Domain;
+
+public sealed class FeedbackDomainException(string code, string message) : InvalidOperationException(message)
+{
+    public string Code { get; } = code;
+}

--- a/backend/src/Modules/Feedback/Domain/FeedbackErrors.cs
+++ b/backend/src/Modules/Feedback/Domain/FeedbackErrors.cs
@@ -1,0 +1,13 @@
+namespace MoneyTracker.Modules.Feedback.Domain;
+
+public static class FeedbackErrors
+{
+    public const string ValidationError = "feedback_validation_error";
+    public const string NotFound = "feedback_not_found";
+    public const string InvalidStatusTransition = "feedback_invalid_status_transition";
+    public const string NpsScoreOutOfRange = "feedback_nps_score_out_of_range";
+    public const string RateLimitExceeded = "feedback_rate_limit_exceeded";
+    public const string AccessDenied = "feedback_access_denied";
+    public const string SummaryQueryFailed = "feedback_summary_query_failed";
+    public const string CrashSummaryQueryFailed = "feedback_crash_summary_query_failed";
+}

--- a/backend/src/Modules/Feedback/Domain/FeedbackId.cs
+++ b/backend/src/Modules/Feedback/Domain/FeedbackId.cs
@@ -1,0 +1,6 @@
+namespace MoneyTracker.Modules.Feedback.Domain;
+
+public readonly record struct FeedbackId(Guid Value)
+{
+    public static FeedbackId New() => new(Guid.NewGuid());
+}

--- a/backend/src/Modules/Feedback/Domain/FeedbackItem.cs
+++ b/backend/src/Modules/Feedback/Domain/FeedbackItem.cs
@@ -1,0 +1,102 @@
+namespace MoneyTracker.Modules.Feedback.Domain;
+
+public sealed class FeedbackItem
+{
+    public FeedbackId Id { get; }
+    public Guid UserId { get; }
+    public FeedbackCategory Category { get; }
+    public string Description { get; }
+    public int Rating { get; }
+    public FeedbackMetadata Metadata { get; }
+    public PriorityScore PriorityScore { get; private set; }
+    public FeedbackStatus Status { get; private set; }
+    public DateTimeOffset CreatedAtUtc { get; }
+    public DateTimeOffset? TriagedAtUtc { get; private set; }
+
+    private FeedbackItem(
+        FeedbackId id,
+        Guid userId,
+        FeedbackCategory category,
+        string description,
+        int rating,
+        FeedbackMetadata metadata,
+        PriorityScore priorityScore,
+        DateTimeOffset createdAtUtc)
+    {
+        Id = id;
+        UserId = userId;
+        Category = category;
+        Description = description;
+        Rating = rating;
+        Metadata = metadata;
+        PriorityScore = priorityScore;
+        Status = FeedbackStatus.New;
+        CreatedAtUtc = createdAtUtc;
+    }
+
+    public static FeedbackItem Create(
+        Guid userId,
+        FeedbackCategory category,
+        string description,
+        int rating,
+        FeedbackMetadata metadata,
+        PriorityScore priorityScore,
+        DateTimeOffset nowUtc)
+    {
+        if (userId == Guid.Empty)
+        {
+            throw new FeedbackDomainException(
+                FeedbackErrors.ValidationError,
+                "User ID is required.");
+        }
+
+        if (string.IsNullOrWhiteSpace(description))
+        {
+            throw new FeedbackDomainException(
+                FeedbackErrors.ValidationError,
+                "Description is required.");
+        }
+
+        if (description.Length > 5000)
+        {
+            throw new FeedbackDomainException(
+                FeedbackErrors.ValidationError,
+                "Description exceeds maximum length of 5000 characters.");
+        }
+
+        if (rating < 1 || rating > 5)
+        {
+            throw new FeedbackDomainException(
+                FeedbackErrors.ValidationError,
+                "Rating must be between 1 and 5.");
+        }
+
+        return new FeedbackItem(
+            FeedbackId.New(),
+            userId,
+            category,
+            description.Trim(),
+            rating,
+            metadata,
+            priorityScore,
+            nowUtc);
+    }
+
+    public void Triage(FeedbackStatus newStatus, PriorityScore? priorityOverride, DateTimeOffset nowUtc)
+    {
+        if (newStatus == FeedbackStatus.New)
+        {
+            throw new FeedbackDomainException(
+                FeedbackErrors.InvalidStatusTransition,
+                "Cannot triage feedback back to New status.");
+        }
+
+        Status = newStatus;
+        TriagedAtUtc = nowUtc;
+
+        if (priorityOverride is not null)
+        {
+            PriorityScore = priorityOverride;
+        }
+    }
+}

--- a/backend/src/Modules/Feedback/Domain/FeedbackMetadata.cs
+++ b/backend/src/Modules/Feedback/Domain/FeedbackMetadata.cs
@@ -1,0 +1,7 @@
+namespace MoneyTracker.Modules.Feedback.Domain;
+
+public sealed record FeedbackMetadata(
+    string? ScreenName,
+    string? AppVersion,
+    string? DeviceModel,
+    string? OsVersion);

--- a/backend/src/Modules/Feedback/Domain/FeedbackStatus.cs
+++ b/backend/src/Modules/Feedback/Domain/FeedbackStatus.cs
@@ -1,0 +1,9 @@
+namespace MoneyTracker.Modules.Feedback.Domain;
+
+public enum FeedbackStatus
+{
+    New,
+    Triaged,
+    Resolved,
+    Dismissed
+}

--- a/backend/src/Modules/Feedback/Domain/ICrashReportRepository.cs
+++ b/backend/src/Modules/Feedback/Domain/ICrashReportRepository.cs
@@ -1,0 +1,11 @@
+namespace MoneyTracker.Modules.Feedback.Domain;
+
+public interface ICrashReportRepository
+{
+    Task<IReadOnlyCollection<CrashReport>> GetRecentAsync(
+        int periodDays,
+        CancellationToken cancellationToken);
+    Task<int> GetTotalCrashCountAsync(
+        int periodDays,
+        CancellationToken cancellationToken);
+}

--- a/backend/src/Modules/Feedback/Domain/IFeedbackRepository.cs
+++ b/backend/src/Modules/Feedback/Domain/IFeedbackRepository.cs
@@ -1,0 +1,20 @@
+namespace MoneyTracker.Modules.Feedback.Domain;
+
+public interface IFeedbackRepository
+{
+    Task AddAsync(FeedbackItem feedback, CancellationToken cancellationToken);
+    Task UpdateAsync(FeedbackItem feedback, CancellationToken cancellationToken);
+    Task<FeedbackItem?> GetByIdAsync(FeedbackId id, CancellationToken cancellationToken);
+    Task<IReadOnlyCollection<FeedbackItem>> GetByUserSinceAsync(
+        Guid userId,
+        DateTimeOffset since,
+        CancellationToken cancellationToken);
+    Task<IReadOnlyCollection<FeedbackItem>> GetByPeriodAsync(
+        DateTimeOffset periodStart,
+        DateTimeOffset periodEnd,
+        CancellationToken cancellationToken);
+    Task<int> CountSimilarInPeriodAsync(
+        FeedbackCategory category,
+        DateTimeOffset since,
+        CancellationToken cancellationToken);
+}

--- a/backend/src/Modules/Feedback/Domain/IGitHubIssueCreator.cs
+++ b/backend/src/Modules/Feedback/Domain/IGitHubIssueCreator.cs
@@ -1,0 +1,10 @@
+namespace MoneyTracker.Modules.Feedback.Domain;
+
+public interface IGitHubIssueCreator
+{
+    Task CreateIssueAsync(
+        string title,
+        string body,
+        string[] labels,
+        CancellationToken cancellationToken);
+}

--- a/backend/src/Modules/Feedback/Domain/INpsRepository.cs
+++ b/backend/src/Modules/Feedback/Domain/INpsRepository.cs
@@ -1,0 +1,10 @@
+namespace MoneyTracker.Modules.Feedback.Domain;
+
+public interface INpsRepository
+{
+    Task AddAsync(NpsScore npsScore, CancellationToken cancellationToken);
+    Task<IReadOnlyCollection<NpsScore>> GetByPeriodAsync(
+        DateTimeOffset periodStart,
+        DateTimeOffset periodEnd,
+        CancellationToken cancellationToken);
+}

--- a/backend/src/Modules/Feedback/Domain/ISupportTicketService.cs
+++ b/backend/src/Modules/Feedback/Domain/ISupportTicketService.cs
@@ -1,0 +1,10 @@
+namespace MoneyTracker.Modules.Feedback.Domain;
+
+public interface ISupportTicketService
+{
+    Task CreateTicketAsync(
+        string subject,
+        string description,
+        string priority,
+        CancellationToken cancellationToken);
+}

--- a/backend/src/Modules/Feedback/Domain/NpsCategory.cs
+++ b/backend/src/Modules/Feedback/Domain/NpsCategory.cs
@@ -1,0 +1,8 @@
+namespace MoneyTracker.Modules.Feedback.Domain;
+
+public enum NpsCategory
+{
+    Promoter,
+    Passive,
+    Detractor
+}

--- a/backend/src/Modules/Feedback/Domain/NpsScore.cs
+++ b/backend/src/Modules/Feedback/Domain/NpsScore.cs
@@ -1,0 +1,70 @@
+namespace MoneyTracker.Modules.Feedback.Domain;
+
+public sealed class NpsScore
+{
+    public Guid Id { get; }
+    public Guid UserId { get; }
+    public int Score { get; }
+    public string? Comment { get; }
+    public NpsCategory Category { get; }
+    public DateTimeOffset RecordedAtUtc { get; }
+
+    private NpsScore(
+        Guid id,
+        Guid userId,
+        int score,
+        string? comment,
+        NpsCategory category,
+        DateTimeOffset recordedAtUtc)
+    {
+        Id = id;
+        UserId = userId;
+        Score = score;
+        Comment = comment;
+        Category = category;
+        RecordedAtUtc = recordedAtUtc;
+    }
+
+    public static NpsScore Create(
+        Guid userId,
+        int score,
+        string? comment,
+        DateTimeOffset nowUtc)
+    {
+        if (userId == Guid.Empty)
+        {
+            throw new FeedbackDomainException(
+                FeedbackErrors.ValidationError,
+                "User ID is required.");
+        }
+
+        if (score < 0 || score > 10)
+        {
+            throw new FeedbackDomainException(
+                FeedbackErrors.NpsScoreOutOfRange,
+                "NPS score must be between 0 and 10.");
+        }
+
+        if (comment is not null && comment.Length > 1000)
+        {
+            throw new FeedbackDomainException(
+                FeedbackErrors.ValidationError,
+                "Comment exceeds maximum length of 1000 characters.");
+        }
+
+        var category = score switch
+        {
+            >= 9 => NpsCategory.Promoter,
+            >= 7 => NpsCategory.Passive,
+            _ => NpsCategory.Detractor
+        };
+
+        return new NpsScore(
+            Guid.NewGuid(),
+            userId,
+            score,
+            comment?.Trim(),
+            category,
+            nowUtc);
+    }
+}

--- a/backend/src/Modules/Feedback/Domain/PriorityScore.cs
+++ b/backend/src/Modules/Feedback/Domain/PriorityScore.cs
@@ -1,0 +1,25 @@
+namespace MoneyTracker.Modules.Feedback.Domain;
+
+public sealed record PriorityScore(double Score, PriorityBucket Bucket)
+{
+    public static PriorityScore Compute(double score)
+    {
+        var bucket = score switch
+        {
+            >= 10 => PriorityBucket.Critical,
+            >= 6 => PriorityBucket.High,
+            >= 3 => PriorityBucket.Medium,
+            _ => PriorityBucket.Low
+        };
+
+        return new PriorityScore(score, bucket);
+    }
+}
+
+public enum PriorityBucket
+{
+    Low,
+    Medium,
+    High,
+    Critical
+}

--- a/backend/src/Modules/Feedback/Infrastructure/InMemoryCrashReportRepository.cs
+++ b/backend/src/Modules/Feedback/Infrastructure/InMemoryCrashReportRepository.cs
@@ -1,0 +1,56 @@
+using MoneyTracker.Modules.Feedback.Domain;
+
+namespace MoneyTracker.Modules.Feedback.Infrastructure;
+
+public sealed class InMemoryCrashReportRepository : ICrashReportRepository
+{
+    private readonly object _sync = new();
+    private readonly List<CrashReport> _reports = [];
+
+    public void Add(CrashReport report)
+    {
+        lock (_sync)
+        {
+            _reports.Add(report);
+        }
+    }
+
+    public Task<IReadOnlyCollection<CrashReport>> GetRecentAsync(
+        int periodDays,
+        CancellationToken cancellationToken)
+    {
+        if (cancellationToken.IsCancellationRequested)
+        {
+            return Task.FromCanceled<IReadOnlyCollection<CrashReport>>(cancellationToken);
+        }
+
+        lock (_sync)
+        {
+            var cutoff = DateTimeOffset.UtcNow.AddDays(-periodDays);
+            var reports = _reports
+                .Where(r => r.LastSeen >= cutoff)
+                .OrderByDescending(r => r.Count)
+                .ToArray();
+            return Task.FromResult<IReadOnlyCollection<CrashReport>>(reports);
+        }
+    }
+
+    public Task<int> GetTotalCrashCountAsync(
+        int periodDays,
+        CancellationToken cancellationToken)
+    {
+        if (cancellationToken.IsCancellationRequested)
+        {
+            return Task.FromCanceled<int>(cancellationToken);
+        }
+
+        lock (_sync)
+        {
+            var cutoff = DateTimeOffset.UtcNow.AddDays(-periodDays);
+            var totalCount = _reports
+                .Where(r => r.LastSeen >= cutoff)
+                .Sum(r => r.Count);
+            return Task.FromResult(totalCount);
+        }
+    }
+}

--- a/backend/src/Modules/Feedback/Infrastructure/InMemoryFeedbackRepository.cs
+++ b/backend/src/Modules/Feedback/Infrastructure/InMemoryFeedbackRepository.cs
@@ -1,0 +1,104 @@
+using MoneyTracker.Modules.Feedback.Domain;
+
+namespace MoneyTracker.Modules.Feedback.Infrastructure;
+
+public sealed class InMemoryFeedbackRepository : IFeedbackRepository
+{
+    private readonly object _sync = new();
+    private readonly List<FeedbackItem> _items = [];
+
+    public Task AddAsync(FeedbackItem feedback, CancellationToken cancellationToken)
+    {
+        if (cancellationToken.IsCancellationRequested)
+        {
+            return Task.FromCanceled(cancellationToken);
+        }
+
+        lock (_sync)
+        {
+            _items.Add(feedback);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public Task UpdateAsync(FeedbackItem feedback, CancellationToken cancellationToken)
+    {
+        if (cancellationToken.IsCancellationRequested)
+        {
+            return Task.FromCanceled(cancellationToken);
+        }
+
+        // In-memory: object is already updated by reference.
+        return Task.CompletedTask;
+    }
+
+    public Task<FeedbackItem?> GetByIdAsync(FeedbackId id, CancellationToken cancellationToken)
+    {
+        if (cancellationToken.IsCancellationRequested)
+        {
+            return Task.FromCanceled<FeedbackItem?>(cancellationToken);
+        }
+
+        lock (_sync)
+        {
+            var item = _items.FirstOrDefault(f => f.Id == id);
+            return Task.FromResult(item);
+        }
+    }
+
+    public Task<IReadOnlyCollection<FeedbackItem>> GetByUserSinceAsync(
+        Guid userId,
+        DateTimeOffset since,
+        CancellationToken cancellationToken)
+    {
+        if (cancellationToken.IsCancellationRequested)
+        {
+            return Task.FromCanceled<IReadOnlyCollection<FeedbackItem>>(cancellationToken);
+        }
+
+        lock (_sync)
+        {
+            var items = _items
+                .Where(f => f.UserId == userId && f.CreatedAtUtc >= since)
+                .ToArray();
+            return Task.FromResult<IReadOnlyCollection<FeedbackItem>>(items);
+        }
+    }
+
+    public Task<IReadOnlyCollection<FeedbackItem>> GetByPeriodAsync(
+        DateTimeOffset periodStart,
+        DateTimeOffset periodEnd,
+        CancellationToken cancellationToken)
+    {
+        if (cancellationToken.IsCancellationRequested)
+        {
+            return Task.FromCanceled<IReadOnlyCollection<FeedbackItem>>(cancellationToken);
+        }
+
+        lock (_sync)
+        {
+            var items = _items
+                .Where(f => f.CreatedAtUtc >= periodStart && f.CreatedAtUtc <= periodEnd)
+                .ToArray();
+            return Task.FromResult<IReadOnlyCollection<FeedbackItem>>(items);
+        }
+    }
+
+    public Task<int> CountSimilarInPeriodAsync(
+        FeedbackCategory category,
+        DateTimeOffset since,
+        CancellationToken cancellationToken)
+    {
+        if (cancellationToken.IsCancellationRequested)
+        {
+            return Task.FromCanceled<int>(cancellationToken);
+        }
+
+        lock (_sync)
+        {
+            var count = _items.Count(f => f.Category == category && f.CreatedAtUtc >= since);
+            return Task.FromResult(count);
+        }
+    }
+}

--- a/backend/src/Modules/Feedback/Infrastructure/InMemoryNpsRepository.cs
+++ b/backend/src/Modules/Feedback/Infrastructure/InMemoryNpsRepository.cs
@@ -1,0 +1,43 @@
+using MoneyTracker.Modules.Feedback.Domain;
+
+namespace MoneyTracker.Modules.Feedback.Infrastructure;
+
+public sealed class InMemoryNpsRepository : INpsRepository
+{
+    private readonly object _sync = new();
+    private readonly List<NpsScore> _scores = [];
+
+    public Task AddAsync(NpsScore npsScore, CancellationToken cancellationToken)
+    {
+        if (cancellationToken.IsCancellationRequested)
+        {
+            return Task.FromCanceled(cancellationToken);
+        }
+
+        lock (_sync)
+        {
+            _scores.Add(npsScore);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public Task<IReadOnlyCollection<NpsScore>> GetByPeriodAsync(
+        DateTimeOffset periodStart,
+        DateTimeOffset periodEnd,
+        CancellationToken cancellationToken)
+    {
+        if (cancellationToken.IsCancellationRequested)
+        {
+            return Task.FromCanceled<IReadOnlyCollection<NpsScore>>(cancellationToken);
+        }
+
+        lock (_sync)
+        {
+            var scores = _scores
+                .Where(s => s.RecordedAtUtc >= periodStart && s.RecordedAtUtc <= periodEnd)
+                .ToArray();
+            return Task.FromResult<IReadOnlyCollection<NpsScore>>(scores);
+        }
+    }
+}

--- a/backend/src/Modules/Feedback/Infrastructure/NoOpGitHubIssueCreator.cs
+++ b/backend/src/Modules/Feedback/Infrastructure/NoOpGitHubIssueCreator.cs
@@ -1,0 +1,16 @@
+using MoneyTracker.Modules.Feedback.Domain;
+
+namespace MoneyTracker.Modules.Feedback.Infrastructure;
+
+public sealed class NoOpGitHubIssueCreator : IGitHubIssueCreator
+{
+    public Task CreateIssueAsync(
+        string title,
+        string body,
+        string[] labels,
+        CancellationToken cancellationToken)
+    {
+        // No-op stub for testing. Will be replaced with real GitHub integration.
+        return Task.CompletedTask;
+    }
+}

--- a/backend/src/Modules/Feedback/Infrastructure/NoOpSupportTicketService.cs
+++ b/backend/src/Modules/Feedback/Infrastructure/NoOpSupportTicketService.cs
@@ -1,0 +1,16 @@
+using MoneyTracker.Modules.Feedback.Domain;
+
+namespace MoneyTracker.Modules.Feedback.Infrastructure;
+
+public sealed class NoOpSupportTicketService : ISupportTicketService
+{
+    public Task CreateTicketAsync(
+        string subject,
+        string description,
+        string priority,
+        CancellationToken cancellationToken)
+    {
+        // No-op stub for testing. Will be replaced with real support ticket integration.
+        return Task.CompletedTask;
+    }
+}

--- a/backend/src/Modules/Feedback/Infrastructure/PriorityScorer.cs
+++ b/backend/src/Modules/Feedback/Infrastructure/PriorityScorer.cs
@@ -1,0 +1,57 @@
+using MoneyTracker.Modules.Feedback.Domain;
+
+namespace MoneyTracker.Modules.Feedback.Infrastructure;
+
+public sealed class PriorityScorer
+{
+    private static readonly string[] CrashWords = ["crash", "crashes", "crashing", "crashed", "freeze", "frozen", "hung", "unresponsive"];
+    private static readonly string[] DataLossWords = ["lost data", "data loss", "lost my", "deleted", "missing transactions", "wiped", "disappeared", "gone"];
+
+    /// <summary>
+    /// Computes a priority score for a feedback item.
+    /// Formula: base score (Bug=3, Feature=1, General=1)
+    ///          * tier multiplier (Paid=2.0, Trial=1.5, Free=1.0)
+    ///          + frequency bonus (+1 per similar in 7 days)
+    ///          + severity bonus (+2 crash words, +3 data loss words)
+    /// </summary>
+    public PriorityScore ComputeScore(
+        FeedbackCategory category,
+        string description,
+        string userTier,
+        int similarCountLast7Days)
+    {
+        double baseScore = category switch
+        {
+            FeedbackCategory.Bug => 3,
+            FeedbackCategory.Feature => 1,
+            FeedbackCategory.General => 1,
+            _ => 1
+        };
+
+        double tierMultiplier = userTier.ToLowerInvariant() switch
+        {
+            "paid" or "premium" => 2.0,
+            "trial" => 1.5,
+            _ => 1.0
+        };
+
+        double frequencyBonus = similarCountLast7Days;
+
+        double severityBonus = 0;
+        var lowerDescription = description.ToLowerInvariant();
+
+        if (CrashWords.Any(word => lowerDescription.Contains(word)))
+        {
+            severityBonus += 2;
+        }
+
+        if (DataLossWords.Any(phrase => lowerDescription.Contains(phrase)))
+        {
+            severityBonus += 3;
+        }
+
+        var totalScore = (baseScore * tierMultiplier) + frequencyBonus + severityBonus;
+
+        return PriorityScore.Compute(totalScore);
+    }
+}

--- a/backend/src/Modules/Feedback/MoneyTracker.Modules.Feedback.csproj
+++ b/backend/src/Modules/Feedback/MoneyTracker.Modules.Feedback.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    <ProjectReference Include="..\Auth\MoneyTracker.Modules.Auth.csproj" />
+    <ProjectReference Include="..\SharedKernel\MoneyTracker.Modules.SharedKernel.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/backend/src/Modules/Feedback/Presentation/FeedbackEndpoints.cs
+++ b/backend/src/Modules/Feedback/Presentation/FeedbackEndpoints.cs
@@ -1,0 +1,500 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using MoneyTracker.Modules.Feedback.Application.GetCrashSummary;
+using MoneyTracker.Modules.Feedback.Application.GetFeedbackSummary;
+using MoneyTracker.Modules.Feedback.Application.SubmitFeedback;
+using MoneyTracker.Modules.Feedback.Application.SubmitNps;
+using MoneyTracker.Modules.Feedback.Application.TriageFeedback;
+using MoneyTracker.Modules.Feedback.Domain;
+using MoneyTracker.Modules.SharedKernel.Presentation;
+
+namespace MoneyTracker.Modules.Feedback.Presentation;
+
+public static class FeedbackEndpoints
+{
+    public static IServiceCollection AddFeedbackModule(this IServiceCollection services)
+    {
+        services.AddSingleton<IFeedbackRepository, Infrastructure.InMemoryFeedbackRepository>();
+        services.AddSingleton<INpsRepository, Infrastructure.InMemoryNpsRepository>();
+        services.AddSingleton<ICrashReportRepository, Infrastructure.InMemoryCrashReportRepository>();
+        services.AddSingleton<IGitHubIssueCreator, Infrastructure.NoOpGitHubIssueCreator>();
+        services.AddSingleton<ISupportTicketService, Infrastructure.NoOpSupportTicketService>();
+        services.AddSingleton<Infrastructure.PriorityScorer>();
+        services.AddSingleton(TimeProvider.System);
+        services.AddScoped<SubmitFeedbackHandler>();
+        services.AddScoped<SubmitNpsHandler>();
+        services.AddScoped<GetFeedbackSummaryHandler>();
+        services.AddScoped<GetCrashSummaryHandler>();
+        services.AddScoped<TriageFeedbackHandler>();
+
+        return services;
+    }
+
+    public static IEndpointRouteBuilder MapFeedbackEndpoints(this IEndpointRouteBuilder app)
+    {
+        var submitFeedbackEndpoint = (RouteHandlerBuilder)app.MapPost("/feedback", SubmitFeedback);
+        submitFeedbackEndpoint
+            .WithName("SubmitFeedback")
+            .WithSummary("Submit user feedback.")
+            .WithDescription("Submits feedback with category, description, rating, and device metadata.")
+            .Accepts<SubmitFeedbackRequest>("application/json")
+            .Produces<SubmitFeedbackResponse>(StatusCodes.Status200OK)
+            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status401Unauthorized)
+            .ProducesProblem(StatusCodes.Status429TooManyRequests);
+
+        var submitNpsEndpoint = (RouteHandlerBuilder)app.MapPost("/feedback/nps", SubmitNps);
+        submitNpsEndpoint
+            .WithName("SubmitNps")
+            .WithSummary("Submit NPS score.")
+            .WithDescription("Records a Net Promoter Score (0-10) with optional comment.")
+            .Accepts<SubmitNpsRequest>("application/json")
+            .Produces<SubmitNpsResponse>(StatusCodes.Status200OK)
+            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status401Unauthorized);
+
+        var feedbackSummaryEndpoint = (RouteHandlerBuilder)app.MapGet("/admin/feedback-summary", GetFeedbackSummary);
+        feedbackSummaryEndpoint
+            .WithName("GetFeedbackSummary")
+            .WithSummary("Get feedback summary metrics.")
+            .WithDescription("Returns aggregated feedback metrics for a time period. Admin access required.")
+            .Produces<FeedbackSummaryResponse>(StatusCodes.Status200OK)
+            .ProducesProblem(StatusCodes.Status401Unauthorized)
+            .ProducesProblem(StatusCodes.Status403Forbidden);
+
+        var crashSummaryEndpoint = (RouteHandlerBuilder)app.MapGet("/admin/crash-summary", GetCrashSummary);
+        crashSummaryEndpoint
+            .WithName("GetCrashSummary")
+            .WithSummary("Get crash summary metrics.")
+            .WithDescription("Returns crash-free rate and top crash reports. Admin access required.")
+            .Produces<CrashSummaryResponse>(StatusCodes.Status200OK)
+            .ProducesProblem(StatusCodes.Status401Unauthorized)
+            .ProducesProblem(StatusCodes.Status403Forbidden);
+
+        var triageEndpoint = (RouteHandlerBuilder)app.MapMethods("/admin/feedback/{id}/triage", ["PATCH"], TriageFeedback);
+        triageEndpoint
+            .WithName("TriageFeedback")
+            .WithSummary("Triage feedback item.")
+            .WithDescription("Updates feedback status and optionally overrides priority. Admin access required.")
+            .Accepts<TriageFeedbackRequest>("application/json")
+            .Produces(StatusCodes.Status200OK)
+            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status401Unauthorized)
+            .ProducesProblem(StatusCodes.Status403Forbidden)
+            .ProducesProblem(StatusCodes.Status404NotFound);
+
+        return app;
+    }
+
+    private static async Task SubmitFeedback(HttpContext httpContext)
+    {
+        var authResult = await EndpointHelpers.ResolveAuthenticatedUser(httpContext);
+        if (!authResult.Success)
+        {
+            await authResult.Problem!.ExecuteAsync(httpContext);
+            return;
+        }
+
+        var (isValidRequest, request, parseProblem) =
+            await EndpointHelpers.ReadJsonRequestAsync<SubmitFeedbackRequest>(httpContext, FeedbackErrors.ValidationError);
+        if (!isValidRequest || request is null)
+        {
+            if (parseProblem is not null)
+            {
+                await parseProblem.ExecuteAsync(httpContext);
+            }
+            else
+            {
+                await EndpointHelpers.WriteProblemAsync(
+                    httpContext,
+                    StatusCodes.Status400BadRequest,
+                    "Validation failed.",
+                    "The request payload is required.",
+                    FeedbackErrors.ValidationError,
+                    FeedbackErrors.ValidationError);
+            }
+            return;
+        }
+
+        if (!Enum.TryParse<FeedbackCategory>(request.Category, ignoreCase: true, out var category))
+        {
+            await EndpointHelpers.WriteProblemAsync(
+                httpContext,
+                StatusCodes.Status400BadRequest,
+                "Validation failed.",
+                "Invalid category. Must be Bug, Feature, or General.",
+                FeedbackErrors.ValidationError,
+                FeedbackErrors.ValidationError);
+            return;
+        }
+
+        var handler = httpContext.RequestServices.GetRequiredService<SubmitFeedbackHandler>();
+        var result = await handler.HandleAsync(
+            new SubmitFeedbackCommand(
+                authResult.AuthenticatedUser!.UserId,
+                category,
+                request.Description ?? string.Empty,
+                request.Rating,
+                request.ScreenName,
+                request.AppVersion,
+                request.DeviceModel,
+                request.OsVersion,
+                request.UserTier ?? "free"),
+            httpContext.RequestAborted);
+
+        if (!result.IsSuccess)
+        {
+            var statusCode = result.ErrorCode switch
+            {
+                FeedbackErrors.RateLimitExceeded => StatusCodes.Status429TooManyRequests,
+                _ => StatusCodes.Status400BadRequest
+            };
+
+            await EndpointHelpers.WriteProblemAsync(
+                httpContext,
+                statusCode,
+                statusCode == StatusCodes.Status429TooManyRequests ? "Rate limit exceeded." : "Validation failed.",
+                result.ErrorMessage ?? "Request rejected.",
+                result.ErrorCode,
+                FeedbackErrors.ValidationError);
+            return;
+        }
+
+        var response = new SubmitFeedbackResponse(result.FeedbackId!.Value, result.Status!);
+        await TypedResults.Ok(response).ExecuteAsync(httpContext);
+    }
+
+    private static async Task SubmitNps(HttpContext httpContext)
+    {
+        var authResult = await EndpointHelpers.ResolveAuthenticatedUser(httpContext);
+        if (!authResult.Success)
+        {
+            await authResult.Problem!.ExecuteAsync(httpContext);
+            return;
+        }
+
+        var (isValidRequest, request, parseProblem) =
+            await EndpointHelpers.ReadJsonRequestAsync<SubmitNpsRequest>(httpContext, FeedbackErrors.ValidationError);
+        if (!isValidRequest || request is null)
+        {
+            if (parseProblem is not null)
+            {
+                await parseProblem.ExecuteAsync(httpContext);
+            }
+            else
+            {
+                await EndpointHelpers.WriteProblemAsync(
+                    httpContext,
+                    StatusCodes.Status400BadRequest,
+                    "Validation failed.",
+                    "The request payload is required.",
+                    FeedbackErrors.ValidationError,
+                    FeedbackErrors.ValidationError);
+            }
+            return;
+        }
+
+        var handler = httpContext.RequestServices.GetRequiredService<SubmitNpsHandler>();
+        var result = await handler.HandleAsync(
+            new SubmitNpsCommand(
+                authResult.AuthenticatedUser!.UserId,
+                request.Score,
+                request.Comment),
+            httpContext.RequestAborted);
+
+        if (!result.IsSuccess)
+        {
+            await EndpointHelpers.WriteProblemAsync(
+                httpContext,
+                StatusCodes.Status400BadRequest,
+                "Validation failed.",
+                result.ErrorMessage ?? "Request rejected.",
+                result.ErrorCode,
+                FeedbackErrors.ValidationError);
+            return;
+        }
+
+        var response = new SubmitNpsResponse(result.NpsId!.Value);
+        await TypedResults.Ok(response).ExecuteAsync(httpContext);
+    }
+
+    private static async Task GetFeedbackSummary(HttpContext httpContext)
+    {
+        var authResult = await EndpointHelpers.ResolveAuthenticatedUser(httpContext);
+        if (!authResult.Success)
+        {
+            await authResult.Problem!.ExecuteAsync(httpContext);
+            return;
+        }
+
+        // AC-10: Admin role gate
+        var adminService = httpContext.RequestServices.GetRequiredService<IAdminAccessService>();
+        var isAdmin = await adminService.IsAdminAsync(authResult.AuthenticatedUser!.UserId, httpContext.RequestAborted);
+        if (!isAdmin)
+        {
+            await EndpointHelpers.WriteProblemAsync(
+                httpContext,
+                StatusCodes.Status403Forbidden,
+                "Access denied.",
+                "Admin access is required to view feedback summary.",
+                FeedbackErrors.AccessDenied,
+                FeedbackErrors.AccessDenied);
+            return;
+        }
+
+        var periodDaysRaw = httpContext.Request.Query["periodDays"].FirstOrDefault();
+        var periodDays = 30;
+        if (periodDaysRaw is not null && int.TryParse(periodDaysRaw, out var parsed) && parsed > 0)
+        {
+            periodDays = parsed;
+        }
+
+        var nowUtc = DateTimeOffset.UtcNow;
+        var periodStart = nowUtc.AddDays(-periodDays);
+
+        var handler = httpContext.RequestServices.GetRequiredService<GetFeedbackSummaryHandler>();
+        var result = await handler.HandleAsync(
+            new GetFeedbackSummaryQuery(periodStart, nowUtc),
+            httpContext.RequestAborted);
+
+        if (!result.IsSuccess)
+        {
+            await EndpointHelpers.WriteProblemAsync(
+                httpContext,
+                StatusCodes.Status400BadRequest,
+                "Request failed.",
+                result.ErrorMessage ?? "Request rejected.",
+                result.ErrorCode,
+                FeedbackErrors.SummaryQueryFailed);
+            return;
+        }
+
+        var data = result.Data!;
+        var response = new FeedbackSummaryResponse(
+            data.TotalFeedback,
+            data.ByCategory,
+            data.AvgSatisfaction,
+            data.NpsScore,
+            data.PriorityDistribution,
+            data.Trends is not null
+                ? new TrendResponse(
+                    data.Trends.CurrentWeekCount,
+                    data.Trends.PreviousWeekCount,
+                    data.Trends.WowChangePercent)
+                : null);
+
+        await TypedResults.Ok(response).ExecuteAsync(httpContext);
+    }
+
+    private static async Task GetCrashSummary(HttpContext httpContext)
+    {
+        var authResult = await EndpointHelpers.ResolveAuthenticatedUser(httpContext);
+        if (!authResult.Success)
+        {
+            await authResult.Problem!.ExecuteAsync(httpContext);
+            return;
+        }
+
+        // AC-10: Admin role gate
+        var adminService = httpContext.RequestServices.GetRequiredService<IAdminAccessService>();
+        var isAdmin = await adminService.IsAdminAsync(authResult.AuthenticatedUser!.UserId, httpContext.RequestAborted);
+        if (!isAdmin)
+        {
+            await EndpointHelpers.WriteProblemAsync(
+                httpContext,
+                StatusCodes.Status403Forbidden,
+                "Access denied.",
+                "Admin access is required to view crash summary.",
+                FeedbackErrors.AccessDenied,
+                FeedbackErrors.AccessDenied);
+            return;
+        }
+
+        var periodDaysRaw = httpContext.Request.Query["periodDays"].FirstOrDefault();
+        var periodDays = 30;
+        if (periodDaysRaw is not null && int.TryParse(periodDaysRaw, out var parsed) && parsed > 0)
+        {
+            periodDays = parsed;
+        }
+
+        var handler = httpContext.RequestServices.GetRequiredService<GetCrashSummaryHandler>();
+        var result = await handler.HandleAsync(
+            new GetCrashSummaryQuery(periodDays),
+            httpContext.RequestAborted);
+
+        if (!result.IsSuccess)
+        {
+            await EndpointHelpers.WriteProblemAsync(
+                httpContext,
+                StatusCodes.Status400BadRequest,
+                "Request failed.",
+                result.ErrorMessage ?? "Request rejected.",
+                result.ErrorCode,
+                FeedbackErrors.CrashSummaryQueryFailed);
+            return;
+        }
+
+        var data = result.Data!;
+        var response = new CrashSummaryResponse(
+            data.CrashFreeRate,
+            data.TotalCrashes,
+            data.TopCrashes.Select(c => new CrashReportResponse(
+                c.Signature,
+                c.Count,
+                c.AffectedUsers,
+                c.FirstSeen,
+                c.LastSeen)).ToArray());
+
+        await TypedResults.Ok(response).ExecuteAsync(httpContext);
+    }
+
+    private static async Task TriageFeedback(HttpContext httpContext)
+    {
+        var authResult = await EndpointHelpers.ResolveAuthenticatedUser(httpContext);
+        if (!authResult.Success)
+        {
+            await authResult.Problem!.ExecuteAsync(httpContext);
+            return;
+        }
+
+        // AC-10: Admin role gate
+        var adminService = httpContext.RequestServices.GetRequiredService<IAdminAccessService>();
+        var isAdmin = await adminService.IsAdminAsync(authResult.AuthenticatedUser!.UserId, httpContext.RequestAborted);
+        if (!isAdmin)
+        {
+            await EndpointHelpers.WriteProblemAsync(
+                httpContext,
+                StatusCodes.Status403Forbidden,
+                "Access denied.",
+                "Admin access is required to triage feedback.",
+                FeedbackErrors.AccessDenied,
+                FeedbackErrors.AccessDenied);
+            return;
+        }
+
+        if (!TryGetGuidRoute(httpContext, "id", out var feedbackIdGuid))
+        {
+            await EndpointHelpers.WriteProblemAsync(
+                httpContext,
+                StatusCodes.Status400BadRequest,
+                "Validation failed.",
+                "id route parameter is required.",
+                FeedbackErrors.ValidationError,
+                FeedbackErrors.ValidationError);
+            return;
+        }
+
+        var (isValidRequest, request, parseProblem) =
+            await EndpointHelpers.ReadJsonRequestAsync<TriageFeedbackRequest>(httpContext, FeedbackErrors.ValidationError);
+        if (!isValidRequest || request is null)
+        {
+            if (parseProblem is not null)
+            {
+                await parseProblem.ExecuteAsync(httpContext);
+            }
+            else
+            {
+                await EndpointHelpers.WriteProblemAsync(
+                    httpContext,
+                    StatusCodes.Status400BadRequest,
+                    "Validation failed.",
+                    "The request payload is required.",
+                    FeedbackErrors.ValidationError,
+                    FeedbackErrors.ValidationError);
+            }
+            return;
+        }
+
+        if (!Enum.TryParse<FeedbackStatus>(request.Status, ignoreCase: true, out var status))
+        {
+            await EndpointHelpers.WriteProblemAsync(
+                httpContext,
+                StatusCodes.Status400BadRequest,
+                "Validation failed.",
+                "Invalid status. Must be Triaged, Resolved, or Dismissed.",
+                FeedbackErrors.ValidationError,
+                FeedbackErrors.ValidationError);
+            return;
+        }
+
+        var handler = httpContext.RequestServices.GetRequiredService<TriageFeedbackHandler>();
+        var result = await handler.HandleAsync(
+            new TriageFeedbackCommand(
+                new FeedbackId(feedbackIdGuid),
+                status,
+                request.PriorityOverride),
+            httpContext.RequestAborted);
+
+        if (!result.IsSuccess)
+        {
+            var statusCode = result.ErrorCode switch
+            {
+                FeedbackErrors.NotFound => StatusCodes.Status404NotFound,
+                _ => StatusCodes.Status400BadRequest
+            };
+
+            await EndpointHelpers.WriteProblemAsync(
+                httpContext,
+                statusCode,
+                "Request failed.",
+                result.ErrorMessage ?? "Request rejected.",
+                result.ErrorCode,
+                FeedbackErrors.ValidationError);
+            return;
+        }
+
+        await TypedResults.Ok(new { triaged = true }).ExecuteAsync(httpContext);
+    }
+
+    private static bool TryGetGuidRoute(HttpContext httpContext, string key, out Guid value)
+    {
+        value = Guid.Empty;
+        var raw = httpContext.Request.RouteValues[key]?.ToString();
+        return raw is not null && Guid.TryParse(raw, out value);
+    }
+}
+
+public sealed record SubmitFeedbackRequest(
+    string? Category,
+    string? Description,
+    int Rating,
+    string? ScreenName,
+    string? AppVersion,
+    string? DeviceModel,
+    string? OsVersion,
+    string? UserTier);
+
+public sealed record SubmitFeedbackResponse(Guid FeedbackId, string Status);
+
+public sealed record SubmitNpsRequest(int Score, string? Comment);
+
+public sealed record SubmitNpsResponse(Guid NpsId);
+
+public sealed record TriageFeedbackRequest(string? Status, double? PriorityOverride);
+
+public sealed record FeedbackSummaryResponse(
+    int TotalFeedback,
+    Dictionary<string, int> ByCategory,
+    double AvgSatisfaction,
+    double NpsScore,
+    Dictionary<string, int> PriorityDistribution,
+    TrendResponse? Trends);
+
+public sealed record TrendResponse(
+    int CurrentWeekCount,
+    int PreviousWeekCount,
+    double WowChangePercent);
+
+public sealed record CrashSummaryResponse(
+    double CrashFreeRate,
+    int TotalCrashes,
+    CrashReportResponse[] TopCrashes);
+
+public sealed record CrashReportResponse(
+    string Signature,
+    int Count,
+    int AffectedUsers,
+    DateTimeOffset FirstSeen,
+    DateTimeOffset LastSeen);

--- a/backend/src/MoneyTracker.Api/MoneyTracker.Api.csproj
+++ b/backend/src/MoneyTracker.Api/MoneyTracker.Api.csproj
@@ -18,6 +18,7 @@
     <ProjectReference Include="..\Modules\Analytics\MoneyTracker.Modules.Analytics.csproj" />
     <ProjectReference Include="..\Modules\Insights\MoneyTracker.Modules.Insights.csproj" />
     <ProjectReference Include="..\Modules\Experiments\MoneyTracker.Modules.Experiments.csproj" />
+    <ProjectReference Include="..\Modules\Feedback\MoneyTracker.Modules.Feedback.csproj" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.0" />
   </ItemGroup>
 

--- a/backend/src/MoneyTracker.Api/Program.cs
+++ b/backend/src/MoneyTracker.Api/Program.cs
@@ -14,6 +14,7 @@ using MoneyTracker.Modules.Analytics.Presentation;
 using MoneyTracker.Modules.Insights.Presentation;
 using MoneyTracker.Api.Health;
 using MoneyTracker.Modules.Experiments.Presentation;
+using MoneyTracker.Modules.Feedback.Presentation;
 using MoneyTracker.Api.Observability;
 using MoneyTracker.Api.Security;
 using MoneyTracker.Modules.SharedKernel.Health;
@@ -38,6 +39,7 @@ builder.Services.AddSubscriptionsModule();
 builder.Services.AddAnalyticsModule();
 builder.Services.AddInsightsModule();
 builder.Services.AddExperimentsModule();
+builder.Services.AddFeedbackModule();
 builder.Services.AddOpenApi();
 
 var app = builder.Build();
@@ -68,6 +70,7 @@ app.MapSubscriptionEndpoints();
 app.MapAnalyticsEndpoints();
 app.MapInsightsEndpoints();
 app.MapExperimentEndpoints();
+app.MapFeedbackEndpoints();
 app.MapSystemHealthEndpoints();
 
 if (app.Environment.IsEnvironment("Testing"))

--- a/backend/tests/MoneyTracker.Modules.Feedback.Tests/Application/SubmitFeedbackHandlerTests.cs
+++ b/backend/tests/MoneyTracker.Modules.Feedback.Tests/Application/SubmitFeedbackHandlerTests.cs
@@ -1,0 +1,147 @@
+using MoneyTracker.Modules.Feedback.Application.SubmitFeedback;
+using MoneyTracker.Modules.Feedback.Domain;
+using MoneyTracker.Modules.Feedback.Infrastructure;
+
+namespace MoneyTracker.Modules.Feedback.Tests.Application;
+
+public sealed class SubmitFeedbackHandlerTests
+{
+    private static readonly DateTimeOffset NowUtc = DateTimeOffset.Parse("2026-03-01T12:00:00Z");
+
+    private static (SubmitFeedbackHandler handler, InMemoryFeedbackRepository repo) CreateHandler()
+    {
+        var repo = new InMemoryFeedbackRepository();
+        var scorer = new PriorityScorer();
+        var timeProvider = new FakeTimeProvider(NowUtc);
+        var handler = new SubmitFeedbackHandler(repo, scorer, timeProvider);
+        return (handler, repo);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task HandleAsync_ValidFeedback_ReturnsSuccess()
+    {
+        var (handler, _) = CreateHandler();
+
+        var result = await handler.HandleAsync(
+            new SubmitFeedbackCommand(
+                Guid.NewGuid(),
+                FeedbackCategory.Bug,
+                "The settings page crashes",
+                4,
+                "settings",
+                "1.0.0",
+                "iPhone 15",
+                "iOS 18",
+                "free"),
+            CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        Assert.NotNull(result.FeedbackId);
+        Assert.Equal("New", result.Status);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task HandleAsync_EmptyDescription_ReturnsValidationError()
+    {
+        var (handler, _) = CreateHandler();
+
+        var result = await handler.HandleAsync(
+            new SubmitFeedbackCommand(
+                Guid.NewGuid(),
+                FeedbackCategory.General,
+                "",
+                3,
+                null, null, null, null,
+                "free"),
+            CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(FeedbackErrors.ValidationError, result.ErrorCode);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task HandleAsync_RatingOutOfRange_ReturnsValidationError()
+    {
+        var (handler, _) = CreateHandler();
+
+        var result = await handler.HandleAsync(
+            new SubmitFeedbackCommand(
+                Guid.NewGuid(),
+                FeedbackCategory.General,
+                "Some feedback",
+                0,
+                null, null, null, null,
+                "free"),
+            CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(FeedbackErrors.ValidationError, result.ErrorCode);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task HandleAsync_ExceedsRateLimit_ReturnsRateLimited()
+    {
+        var (handler, _) = CreateHandler();
+        var userId = Guid.NewGuid();
+
+        // Submit 5 feedback items
+        for (int i = 0; i < 5; i++)
+        {
+            var result = await handler.HandleAsync(
+                new SubmitFeedbackCommand(
+                    userId,
+                    FeedbackCategory.General,
+                    $"Feedback #{i + 1}",
+                    3,
+                    null, null, null, null,
+                    "free"),
+                CancellationToken.None);
+            Assert.True(result.IsSuccess);
+        }
+
+        // 6th should be rate limited
+        var rateLimitedResult = await handler.HandleAsync(
+            new SubmitFeedbackCommand(
+                userId,
+                FeedbackCategory.General,
+                "One more feedback",
+                3,
+                null, null, null, null,
+                "free"),
+            CancellationToken.None);
+
+        Assert.False(rateLimitedResult.IsSuccess);
+        Assert.Equal(FeedbackErrors.RateLimitExceeded, rateLimitedResult.ErrorCode);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task HandleAsync_DifferentUsers_NoRateLimit()
+    {
+        var (handler, _) = CreateHandler();
+
+        // Each different user should succeed
+        for (int i = 0; i < 10; i++)
+        {
+            var result = await handler.HandleAsync(
+                new SubmitFeedbackCommand(
+                    Guid.NewGuid(),
+                    FeedbackCategory.General,
+                    $"Feedback #{i + 1}",
+                    3,
+                    null, null, null, null,
+                    "free"),
+                CancellationToken.None);
+            Assert.True(result.IsSuccess);
+        }
+    }
+
+    private sealed class FakeTimeProvider(DateTimeOffset utcNow) : TimeProvider
+    {
+        public override DateTimeOffset GetUtcNow() => utcNow;
+    }
+}

--- a/backend/tests/MoneyTracker.Modules.Feedback.Tests/Application/SubmitNpsHandlerTests.cs
+++ b/backend/tests/MoneyTracker.Modules.Feedback.Tests/Application/SubmitNpsHandlerTests.cs
@@ -1,0 +1,74 @@
+using MoneyTracker.Modules.Feedback.Application.SubmitNps;
+using MoneyTracker.Modules.Feedback.Domain;
+using MoneyTracker.Modules.Feedback.Infrastructure;
+
+namespace MoneyTracker.Modules.Feedback.Tests.Application;
+
+public sealed class SubmitNpsHandlerTests
+{
+    private static readonly DateTimeOffset NowUtc = DateTimeOffset.Parse("2026-03-01T12:00:00Z");
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task HandleAsync_ValidScore_ReturnsSuccess()
+    {
+        var repo = new InMemoryNpsRepository();
+        var handler = new SubmitNpsHandler(repo, new FakeTimeProvider(NowUtc));
+
+        var result = await handler.HandleAsync(
+            new SubmitNpsCommand(Guid.NewGuid(), 9, "Love it!"),
+            CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        Assert.NotNull(result.NpsId);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task HandleAsync_ScoreOutOfRange_ReturnsValidationError()
+    {
+        var repo = new InMemoryNpsRepository();
+        var handler = new SubmitNpsHandler(repo, new FakeTimeProvider(NowUtc));
+
+        var result = await handler.HandleAsync(
+            new SubmitNpsCommand(Guid.NewGuid(), 11, null),
+            CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(FeedbackErrors.NpsScoreOutOfRange, result.ErrorCode);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task HandleAsync_NegativeScore_ReturnsValidationError()
+    {
+        var repo = new InMemoryNpsRepository();
+        var handler = new SubmitNpsHandler(repo, new FakeTimeProvider(NowUtc));
+
+        var result = await handler.HandleAsync(
+            new SubmitNpsCommand(Guid.NewGuid(), -1, null),
+            CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(FeedbackErrors.NpsScoreOutOfRange, result.ErrorCode);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task HandleAsync_NullComment_Succeeds()
+    {
+        var repo = new InMemoryNpsRepository();
+        var handler = new SubmitNpsHandler(repo, new FakeTimeProvider(NowUtc));
+
+        var result = await handler.HandleAsync(
+            new SubmitNpsCommand(Guid.NewGuid(), 5, null),
+            CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+    }
+
+    private sealed class FakeTimeProvider(DateTimeOffset utcNow) : TimeProvider
+    {
+        public override DateTimeOffset GetUtcNow() => utcNow;
+    }
+}

--- a/backend/tests/MoneyTracker.Modules.Feedback.Tests/Application/TriageFeedbackHandlerTests.cs
+++ b/backend/tests/MoneyTracker.Modules.Feedback.Tests/Application/TriageFeedbackHandlerTests.cs
@@ -1,0 +1,108 @@
+using MoneyTracker.Modules.Feedback.Application.TriageFeedback;
+using MoneyTracker.Modules.Feedback.Domain;
+using MoneyTracker.Modules.Feedback.Infrastructure;
+
+namespace MoneyTracker.Modules.Feedback.Tests.Application;
+
+public sealed class TriageFeedbackHandlerTests
+{
+    private static readonly DateTimeOffset NowUtc = DateTimeOffset.Parse("2026-03-01T12:00:00Z");
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task HandleAsync_ExistingFeedback_TriagesSuccessfully()
+    {
+        var repo = new InMemoryFeedbackRepository();
+        var timeProvider = new FakeTimeProvider(NowUtc);
+        var handler = new TriageFeedbackHandler(repo, timeProvider);
+
+        var feedback = FeedbackItem.Create(
+            Guid.NewGuid(),
+            FeedbackCategory.Bug,
+            "Some bug",
+            3,
+            new FeedbackMetadata(null, null, null, null),
+            PriorityScore.Compute(5),
+            NowUtc);
+        await repo.AddAsync(feedback, CancellationToken.None);
+
+        var result = await handler.HandleAsync(
+            new TriageFeedbackCommand(feedback.Id, FeedbackStatus.Triaged, null),
+            CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task HandleAsync_FeedbackNotFound_ReturnsNotFound()
+    {
+        var repo = new InMemoryFeedbackRepository();
+        var timeProvider = new FakeTimeProvider(NowUtc);
+        var handler = new TriageFeedbackHandler(repo, timeProvider);
+
+        var result = await handler.HandleAsync(
+            new TriageFeedbackCommand(FeedbackId.New(), FeedbackStatus.Triaged, null),
+            CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(FeedbackErrors.NotFound, result.ErrorCode);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task HandleAsync_WithPriorityOverride_UpdatesPriority()
+    {
+        var repo = new InMemoryFeedbackRepository();
+        var timeProvider = new FakeTimeProvider(NowUtc);
+        var handler = new TriageFeedbackHandler(repo, timeProvider);
+
+        var feedback = FeedbackItem.Create(
+            Guid.NewGuid(),
+            FeedbackCategory.Feature,
+            "Some feature request",
+            4,
+            new FeedbackMetadata(null, null, null, null),
+            PriorityScore.Compute(2),
+            NowUtc);
+        await repo.AddAsync(feedback, CancellationToken.None);
+
+        var result = await handler.HandleAsync(
+            new TriageFeedbackCommand(feedback.Id, FeedbackStatus.Triaged, 10.0),
+            CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(PriorityBucket.Critical, feedback.PriorityScore.Bucket);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task HandleAsync_TriageBackToNew_ReturnsValidationError()
+    {
+        var repo = new InMemoryFeedbackRepository();
+        var timeProvider = new FakeTimeProvider(NowUtc);
+        var handler = new TriageFeedbackHandler(repo, timeProvider);
+
+        var feedback = FeedbackItem.Create(
+            Guid.NewGuid(),
+            FeedbackCategory.Bug,
+            "Some bug",
+            3,
+            new FeedbackMetadata(null, null, null, null),
+            PriorityScore.Compute(5),
+            NowUtc);
+        await repo.AddAsync(feedback, CancellationToken.None);
+
+        var result = await handler.HandleAsync(
+            new TriageFeedbackCommand(feedback.Id, FeedbackStatus.New, null),
+            CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(FeedbackErrors.InvalidStatusTransition, result.ErrorCode);
+    }
+
+    private sealed class FakeTimeProvider(DateTimeOffset utcNow) : TimeProvider
+    {
+        public override DateTimeOffset GetUtcNow() => utcNow;
+    }
+}

--- a/backend/tests/MoneyTracker.Modules.Feedback.Tests/Domain/FeedbackItemTests.cs
+++ b/backend/tests/MoneyTracker.Modules.Feedback.Tests/Domain/FeedbackItemTests.cs
@@ -1,0 +1,185 @@
+using MoneyTracker.Modules.Feedback.Domain;
+
+namespace MoneyTracker.Modules.Feedback.Tests.Domain;
+
+public sealed class FeedbackItemTests
+{
+    private static readonly DateTimeOffset NowUtc = DateTimeOffset.Parse("2026-03-01T00:00:00Z");
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void Create_ValidInputs_Succeeds()
+    {
+        var metadata = new FeedbackMetadata("home", "1.0.0", "iPhone 15", "iOS 18");
+        var priority = PriorityScore.Compute(5);
+
+        var feedback = FeedbackItem.Create(
+            Guid.NewGuid(),
+            FeedbackCategory.Bug,
+            "The app crashes when I open settings",
+            4,
+            metadata,
+            priority,
+            NowUtc);
+
+        Assert.Equal(FeedbackCategory.Bug, feedback.Category);
+        Assert.Equal("The app crashes when I open settings", feedback.Description);
+        Assert.Equal(4, feedback.Rating);
+        Assert.Equal(FeedbackStatus.New, feedback.Status);
+        Assert.Equal(NowUtc, feedback.CreatedAtUtc);
+        Assert.Null(feedback.TriagedAtUtc);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void Create_EmptyDescription_ThrowsDomainException()
+    {
+        var metadata = new FeedbackMetadata(null, null, null, null);
+        var priority = PriorityScore.Compute(1);
+
+        var exception = Assert.Throws<FeedbackDomainException>(
+            () => FeedbackItem.Create(
+                Guid.NewGuid(),
+                FeedbackCategory.General,
+                "",
+                3,
+                metadata,
+                priority,
+                NowUtc));
+
+        Assert.Equal(FeedbackErrors.ValidationError, exception.Code);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void Create_DescriptionExceedsMaxLength_ThrowsDomainException()
+    {
+        var metadata = new FeedbackMetadata(null, null, null, null);
+        var priority = PriorityScore.Compute(1);
+        var longDescription = new string('x', 5001);
+
+        var exception = Assert.Throws<FeedbackDomainException>(
+            () => FeedbackItem.Create(
+                Guid.NewGuid(),
+                FeedbackCategory.General,
+                longDescription,
+                3,
+                metadata,
+                priority,
+                NowUtc));
+
+        Assert.Equal(FeedbackErrors.ValidationError, exception.Code);
+        Assert.Contains("5000", exception.Message);
+    }
+
+    [Theory]
+    [Trait("Category", "Unit")]
+    [InlineData(0)]
+    [InlineData(6)]
+    [InlineData(-1)]
+    public void Create_InvalidRating_ThrowsDomainException(int rating)
+    {
+        var metadata = new FeedbackMetadata(null, null, null, null);
+        var priority = PriorityScore.Compute(1);
+
+        var exception = Assert.Throws<FeedbackDomainException>(
+            () => FeedbackItem.Create(
+                Guid.NewGuid(),
+                FeedbackCategory.General,
+                "Some feedback",
+                rating,
+                metadata,
+                priority,
+                NowUtc));
+
+        Assert.Equal(FeedbackErrors.ValidationError, exception.Code);
+        Assert.Contains("between 1 and 5", exception.Message);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void Create_EmptyUserId_ThrowsDomainException()
+    {
+        var metadata = new FeedbackMetadata(null, null, null, null);
+        var priority = PriorityScore.Compute(1);
+
+        var exception = Assert.Throws<FeedbackDomainException>(
+            () => FeedbackItem.Create(
+                Guid.Empty,
+                FeedbackCategory.General,
+                "Some feedback",
+                3,
+                metadata,
+                priority,
+                NowUtc));
+
+        Assert.Equal(FeedbackErrors.ValidationError, exception.Code);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void Triage_ToTriaged_UpdatesStatusAndTimestamp()
+    {
+        var metadata = new FeedbackMetadata(null, null, null, null);
+        var priority = PriorityScore.Compute(5);
+
+        var feedback = FeedbackItem.Create(
+            Guid.NewGuid(),
+            FeedbackCategory.Bug,
+            "Some bug",
+            3,
+            metadata,
+            priority,
+            NowUtc);
+
+        var triagedAt = NowUtc.AddHours(1);
+        feedback.Triage(FeedbackStatus.Triaged, null, triagedAt);
+
+        Assert.Equal(FeedbackStatus.Triaged, feedback.Status);
+        Assert.Equal(triagedAt, feedback.TriagedAtUtc);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void Triage_WithPriorityOverride_UpdatesPriority()
+    {
+        var metadata = new FeedbackMetadata(null, null, null, null);
+        var priority = PriorityScore.Compute(2);
+
+        var feedback = FeedbackItem.Create(
+            Guid.NewGuid(),
+            FeedbackCategory.Feature,
+            "Need dark mode",
+            5,
+            metadata,
+            priority,
+            NowUtc);
+
+        var override_ = PriorityScore.Compute(10);
+        feedback.Triage(FeedbackStatus.Triaged, override_, NowUtc.AddHours(1));
+
+        Assert.Equal(PriorityBucket.Critical, feedback.PriorityScore.Bucket);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void Triage_BackToNew_ThrowsDomainException()
+    {
+        var metadata = new FeedbackMetadata(null, null, null, null);
+        var priority = PriorityScore.Compute(5);
+
+        var feedback = FeedbackItem.Create(
+            Guid.NewGuid(),
+            FeedbackCategory.Bug,
+            "Some bug",
+            3,
+            metadata,
+            priority,
+            NowUtc);
+
+        var exception = Assert.Throws<FeedbackDomainException>(
+            () => feedback.Triage(FeedbackStatus.New, null, NowUtc.AddHours(1)));
+
+        Assert.Equal(FeedbackErrors.InvalidStatusTransition, exception.Code);
+    }
+}

--- a/backend/tests/MoneyTracker.Modules.Feedback.Tests/Domain/NpsScoreTests.cs
+++ b/backend/tests/MoneyTracker.Modules.Feedback.Tests/Domain/NpsScoreTests.cs
@@ -1,0 +1,67 @@
+using MoneyTracker.Modules.Feedback.Domain;
+
+namespace MoneyTracker.Modules.Feedback.Tests.Domain;
+
+public sealed class NpsScoreTests
+{
+    private static readonly DateTimeOffset NowUtc = DateTimeOffset.Parse("2026-03-01T00:00:00Z");
+
+    [Theory]
+    [Trait("Category", "Unit")]
+    [InlineData(10, NpsCategory.Promoter)]
+    [InlineData(9, NpsCategory.Promoter)]
+    [InlineData(8, NpsCategory.Passive)]
+    [InlineData(7, NpsCategory.Passive)]
+    [InlineData(6, NpsCategory.Detractor)]
+    [InlineData(0, NpsCategory.Detractor)]
+    public void Create_ValidScore_AssignsCorrectCategory(int score, NpsCategory expectedCategory)
+    {
+        var nps = NpsScore.Create(Guid.NewGuid(), score, null, NowUtc);
+
+        Assert.Equal(expectedCategory, nps.Category);
+        Assert.Equal(score, nps.Score);
+    }
+
+    [Theory]
+    [Trait("Category", "Unit")]
+    [InlineData(-1)]
+    [InlineData(11)]
+    public void Create_InvalidScore_ThrowsDomainException(int score)
+    {
+        var exception = Assert.Throws<FeedbackDomainException>(
+            () => NpsScore.Create(Guid.NewGuid(), score, null, NowUtc));
+
+        Assert.Equal(FeedbackErrors.NpsScoreOutOfRange, exception.Code);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void Create_WithComment_StoresComment()
+    {
+        var nps = NpsScore.Create(Guid.NewGuid(), 8, "Great app!", NowUtc);
+
+        Assert.Equal("Great app!", nps.Comment);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void Create_CommentExceedsMaxLength_ThrowsDomainException()
+    {
+        var longComment = new string('x', 1001);
+
+        var exception = Assert.Throws<FeedbackDomainException>(
+            () => NpsScore.Create(Guid.NewGuid(), 8, longComment, NowUtc));
+
+        Assert.Equal(FeedbackErrors.ValidationError, exception.Code);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void Create_EmptyUserId_ThrowsDomainException()
+    {
+        var exception = Assert.Throws<FeedbackDomainException>(
+            () => NpsScore.Create(Guid.Empty, 8, null, NowUtc));
+
+        Assert.Equal(FeedbackErrors.ValidationError, exception.Code);
+    }
+}

--- a/backend/tests/MoneyTracker.Modules.Feedback.Tests/Domain/PriorityScoreTests.cs
+++ b/backend/tests/MoneyTracker.Modules.Feedback.Tests/Domain/PriorityScoreTests.cs
@@ -1,0 +1,24 @@
+using MoneyTracker.Modules.Feedback.Domain;
+
+namespace MoneyTracker.Modules.Feedback.Tests.Domain;
+
+public sealed class PriorityScoreTests
+{
+    [Theory]
+    [Trait("Category", "Unit")]
+    [InlineData(10, PriorityBucket.Critical)]
+    [InlineData(15, PriorityBucket.Critical)]
+    [InlineData(6, PriorityBucket.High)]
+    [InlineData(9.9, PriorityBucket.High)]
+    [InlineData(3, PriorityBucket.Medium)]
+    [InlineData(5.9, PriorityBucket.Medium)]
+    [InlineData(0, PriorityBucket.Low)]
+    [InlineData(2.9, PriorityBucket.Low)]
+    public void Compute_AssignsCorrectBucket(double score, PriorityBucket expectedBucket)
+    {
+        var priority = PriorityScore.Compute(score);
+
+        Assert.Equal(expectedBucket, priority.Bucket);
+        Assert.Equal(score, priority.Score);
+    }
+}

--- a/backend/tests/MoneyTracker.Modules.Feedback.Tests/Infrastructure/PriorityScorerTests.cs
+++ b/backend/tests/MoneyTracker.Modules.Feedback.Tests/Infrastructure/PriorityScorerTests.cs
@@ -1,0 +1,122 @@
+using MoneyTracker.Modules.Feedback.Domain;
+using MoneyTracker.Modules.Feedback.Infrastructure;
+
+namespace MoneyTracker.Modules.Feedback.Tests.Infrastructure;
+
+public sealed class PriorityScorerTests
+{
+    private readonly PriorityScorer _scorer = new();
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void ComputeScore_Bug_FreeTier_NoBonus_ReturnsBaseScore()
+    {
+        // Bug base = 3, Free multiplier = 1.0, no frequency, no severity
+        var result = _scorer.ComputeScore(FeedbackCategory.Bug, "Something is wrong", "free", 0);
+
+        Assert.Equal(3.0, result.Score);
+        Assert.Equal(PriorityBucket.Medium, result.Bucket);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void ComputeScore_Bug_PaidTier_ReturnsMultiplied()
+    {
+        // Bug base = 3, Paid multiplier = 2.0 => 6.0
+        var result = _scorer.ComputeScore(FeedbackCategory.Bug, "Something is wrong", "paid", 0);
+
+        Assert.Equal(6.0, result.Score);
+        Assert.Equal(PriorityBucket.High, result.Bucket);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void ComputeScore_Bug_TrialTier_ReturnsMultiplied()
+    {
+        // Bug base = 3, Trial multiplier = 1.5 => 4.5
+        var result = _scorer.ComputeScore(FeedbackCategory.Bug, "Something is wrong", "trial", 0);
+
+        Assert.Equal(4.5, result.Score);
+        Assert.Equal(PriorityBucket.Medium, result.Bucket);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void ComputeScore_Feature_FreeTier_ReturnsLowScore()
+    {
+        // Feature base = 1, Free multiplier = 1.0 => 1.0
+        var result = _scorer.ComputeScore(FeedbackCategory.Feature, "Add dark mode", "free", 0);
+
+        Assert.Equal(1.0, result.Score);
+        Assert.Equal(PriorityBucket.Low, result.Bucket);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void ComputeScore_WithFrequencyBonus_AddsToScore()
+    {
+        // Bug base = 3, Free multiplier = 1.0 => 3.0 + 5 frequency = 8.0
+        var result = _scorer.ComputeScore(FeedbackCategory.Bug, "Something is wrong", "free", 5);
+
+        Assert.Equal(8.0, result.Score);
+        Assert.Equal(PriorityBucket.High, result.Bucket);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void ComputeScore_CrashKeyword_AddsSeverityBonus()
+    {
+        // Bug base = 3, Free multiplier = 1.0 => 3.0 + 2 crash bonus = 5.0
+        var result = _scorer.ComputeScore(FeedbackCategory.Bug, "The app crashes on startup", "free", 0);
+
+        Assert.Equal(5.0, result.Score);
+        Assert.Equal(PriorityBucket.Medium, result.Bucket);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void ComputeScore_DataLossKeyword_AddsSeverityBonus()
+    {
+        // Bug base = 3, Free multiplier = 1.0 => 3.0 + 3 data loss bonus = 6.0
+        var result = _scorer.ComputeScore(FeedbackCategory.Bug, "I lost my transactions", "free", 0);
+
+        Assert.Equal(6.0, result.Score);
+        Assert.Equal(PriorityBucket.High, result.Bucket);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void ComputeScore_BothCrashAndDataLoss_AddsBothBonuses()
+    {
+        // Bug base = 3, Free multiplier = 1.0 => 3.0 + 2 crash + 3 data loss = 8.0
+        var result = _scorer.ComputeScore(FeedbackCategory.Bug, "App crashed and I lost data", "free", 0);
+
+        Assert.Equal(8.0, result.Score);
+        Assert.Equal(PriorityBucket.High, result.Bucket);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void ComputeScore_AllFactors_CriticalPriority()
+    {
+        // Bug base = 3, Paid multiplier = 2.0 => 6.0 + 3 frequency + 2 crash + 3 data loss = 14.0
+        var result = _scorer.ComputeScore(
+            FeedbackCategory.Bug,
+            "App crashed and data loss occurred",
+            "premium",
+            3);
+
+        Assert.Equal(14.0, result.Score);
+        Assert.Equal(PriorityBucket.Critical, result.Bucket);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void ComputeScore_PremiumTier_SameAsPaid()
+    {
+        var paidResult = _scorer.ComputeScore(FeedbackCategory.Bug, "test", "paid", 0);
+        var premiumResult = _scorer.ComputeScore(FeedbackCategory.Bug, "test", "premium", 0);
+
+        Assert.Equal(paidResult.Score, premiumResult.Score);
+    }
+}

--- a/backend/tests/MoneyTracker.Modules.Feedback.Tests/MoneyTracker.Modules.Feedback.Tests.csproj
+++ b/backend/tests/MoneyTracker.Modules.Feedback.Tests/MoneyTracker.Modules.Feedback.Tests.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Modules\Feedback\MoneyTracker.Modules.Feedback.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>

--- a/docs/runbooks/app-store-review-workflow.md
+++ b/docs/runbooks/app-store-review-workflow.md
@@ -1,0 +1,71 @@
+# App Store Review Workflow
+
+## Monitoring Cadence
+
+### Daily
+
+- Check new app store reviews (iOS App Store Connect, Google Play Console)
+- Review crash-free rate in crash reporting dashboard
+- Check feedback submissions via `GET /admin/feedback-summary`
+
+### Weekly
+
+- Review aggregated NPS trends and week-over-week changes
+- Triage new feedback items with priority >= High
+- Review crash summary via `GET /admin/crash-summary`
+- Respond to unanswered app store reviews older than 48 hours
+
+### Monthly
+
+- Publish internal feedback summary report
+- Review priority distribution trends
+- Update escalation criteria if needed
+
+## Response Templates
+
+### Positive Review (4-5 stars)
+
+Thank you for the kind review! We are glad Money Tracker is helping you manage your finances. If you ever have suggestions or run into any issues, please use the in-app feedback form in Settings.
+
+### Bug Report Review (1-3 stars)
+
+Thank you for letting us know about this issue. We take bug reports seriously and our team is investigating. For the fastest resolution, please submit details through the in-app feedback form (Settings > Send Feedback) so we can gather device-specific information. We will follow up as soon as we have an update.
+
+### Feature Request Review
+
+Thank you for the suggestion! We are always looking for ways to improve Money Tracker. Your idea has been logged in our feedback system. While we cannot guarantee timelines, we prioritize features based on user demand and feasibility.
+
+### Crash Report Review
+
+We apologize for the crash you experienced. Our team monitors crash reports and is working on a fix. In the meantime, please ensure you are running the latest version of the app. If the issue persists, please submit a bug report through Settings > Send Feedback so we can gather additional diagnostic information.
+
+## Escalation Criteria
+
+### Immediate Escalation (within 1 hour)
+
+- Crash-free rate drops below 99%
+- Multiple 1-star reviews mentioning data loss
+- Security-related reports
+- Payment or subscription issues affecting multiple users
+
+### Same-Day Escalation
+
+- Crash-free rate drops below 99.5%
+- Three or more similar bug reports in 24 hours
+- Any review mentioning data corruption
+- Feedback items auto-scored as Critical priority
+
+### Standard Triage (next business day)
+
+- Individual bug reports without data loss
+- Feature requests
+- General feedback with low-medium priority scores
+
+## Feedback Triage Process
+
+1. Review new feedback items in admin dashboard
+2. Verify auto-computed priority score is appropriate
+3. For Critical/High items: create support ticket and/or GitHub issue
+4. Update feedback status to Triaged
+5. For resolved items: update status to Resolved
+6. For non-actionable items: update status to Dismissed with reason

--- a/mobile/lib/features/feedback/application/feedback_service.dart
+++ b/mobile/lib/features/feedback/application/feedback_service.dart
@@ -1,0 +1,57 @@
+import '../domain/feedback_submission.dart';
+import '../domain/nps_prompt.dart';
+import '../infrastructure/feedback_api_client.dart';
+
+/// Result of a feedback or NPS submission.
+sealed class FeedbackResult {}
+
+class FeedbackSuccess extends FeedbackResult {
+  FeedbackSuccess({required this.id});
+
+  final String id;
+}
+
+class FeedbackFailure extends FeedbackResult {
+  FeedbackFailure({required this.errorMessage});
+
+  final String errorMessage;
+}
+
+/// Application service for submitting feedback and NPS scores.
+class FeedbackService {
+  FeedbackService({
+    required FeedbackApiClient apiClient,
+  }) : _apiClient = apiClient;
+
+  final FeedbackApiClient _apiClient;
+
+  /// Submits user feedback to the backend.
+  Future<FeedbackResult> submitFeedback(FeedbackSubmission submission) async {
+    final validationError = submission.validate();
+    if (validationError != null) {
+      return FeedbackFailure(errorMessage: validationError);
+    }
+
+    try {
+      final id = await _apiClient.submitFeedback(submission);
+      return FeedbackSuccess(id: id);
+    } catch (e) {
+      return FeedbackFailure(errorMessage: e.toString());
+    }
+  }
+
+  /// Submits an NPS score to the backend.
+  Future<FeedbackResult> submitNps(NpsPrompt prompt) async {
+    final validationError = prompt.validate();
+    if (validationError != null) {
+      return FeedbackFailure(errorMessage: validationError);
+    }
+
+    try {
+      final id = await _apiClient.submitNps(prompt);
+      return FeedbackSuccess(id: id);
+    } catch (e) {
+      return FeedbackFailure(errorMessage: e.toString());
+    }
+  }
+}

--- a/mobile/lib/features/feedback/application/nps_scheduler.dart
+++ b/mobile/lib/features/feedback/application/nps_scheduler.dart
@@ -1,0 +1,45 @@
+/// Determines NPS prompt eligibility based on timing rules.
+/// AC-12: First prompt after 7 days, then 30-day intervals.
+class NpsScheduler {
+  NpsScheduler({
+    required DateTime Function() nowProvider,
+  }) : _nowProvider = nowProvider;
+
+  final DateTime Function() _nowProvider;
+
+  DateTime? _firstLaunchDate;
+  DateTime? _lastPromptDate;
+
+  /// Records the app's first launch date.
+  void recordFirstLaunch(DateTime date) {
+    _firstLaunchDate = date;
+  }
+
+  /// Records the date when NPS was last prompted.
+  void recordLastPrompt(DateTime date) {
+    _lastPromptDate = date;
+  }
+
+  /// Returns the first launch date, if recorded.
+  DateTime? get firstLaunchDate => _firstLaunchDate;
+
+  /// Returns the last prompt date, if recorded.
+  DateTime? get lastPromptDate => _lastPromptDate;
+
+  /// Determines whether the user is eligible for an NPS prompt.
+  bool isEligible() {
+    final now = _nowProvider();
+
+    if (_firstLaunchDate == null) {
+      return false;
+    }
+
+    // First prompt: at least 7 days after first launch
+    if (_lastPromptDate == null) {
+      return now.difference(_firstLaunchDate!).inDays >= 7;
+    }
+
+    // Subsequent prompts: at least 30 days after last prompt
+    return now.difference(_lastPromptDate!).inDays >= 30;
+  }
+}

--- a/mobile/lib/features/feedback/domain/feedback_category.dart
+++ b/mobile/lib/features/feedback/domain/feedback_category.dart
@@ -1,0 +1,14 @@
+enum FeedbackCategory {
+  bug,
+  feature,
+  general;
+
+  static FeedbackCategory fromString(String value) {
+    return FeedbackCategory.values.firstWhere(
+      (category) => category.name.toLowerCase() == value.toLowerCase(),
+      orElse: () => FeedbackCategory.general,
+    );
+  }
+
+  String toApiString() => name[0].toUpperCase() + name.substring(1);
+}

--- a/mobile/lib/features/feedback/domain/feedback_submission.dart
+++ b/mobile/lib/features/feedback/domain/feedback_submission.dart
@@ -1,0 +1,51 @@
+import 'feedback_category.dart';
+
+class FeedbackSubmission {
+  const FeedbackSubmission({
+    required this.category,
+    required this.description,
+    required this.rating,
+    this.screenName,
+    this.appVersion,
+    this.deviceModel,
+    this.osVersion,
+  });
+
+  final FeedbackCategory category;
+  final String description;
+  final int rating;
+  final String? screenName;
+  final String? appVersion;
+  final String? deviceModel;
+  final String? osVersion;
+
+  /// Maximum description length.
+  static const int maxDescriptionLength = 5000;
+
+  /// Validates the submission fields.
+  /// Returns null if valid, or an error message string if invalid.
+  String? validate() {
+    if (description.trim().isEmpty) {
+      return 'Description is required.';
+    }
+    if (description.length > maxDescriptionLength) {
+      return 'Description exceeds maximum length of $maxDescriptionLength characters.';
+    }
+    if (rating < 1 || rating > 5) {
+      return 'Rating must be between 1 and 5.';
+    }
+    return null;
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'category': category.toApiString(),
+      'description': description.trim(),
+      'rating': rating,
+      if (screenName != null) 'screenName': screenName,
+      if (appVersion != null) 'appVersion': appVersion,
+      if (deviceModel != null) 'deviceModel': deviceModel,
+      if (osVersion != null) 'osVersion': osVersion,
+    };
+  }
+}

--- a/mobile/lib/features/feedback/domain/nps_prompt.dart
+++ b/mobile/lib/features/feedback/domain/nps_prompt.dart
@@ -1,0 +1,31 @@
+class NpsPrompt {
+  const NpsPrompt({
+    required this.score,
+    this.comment,
+  });
+
+  final int score;
+  final String? comment;
+
+  /// Maximum comment length.
+  static const int maxCommentLength = 1000;
+
+  /// Validates the NPS submission.
+  /// Returns null if valid, or an error message string if invalid.
+  String? validate() {
+    if (score < 0 || score > 10) {
+      return 'Score must be between 0 and 10.';
+    }
+    if (comment != null && comment!.length > maxCommentLength) {
+      return 'Comment exceeds maximum length of $maxCommentLength characters.';
+    }
+    return null;
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'score': score,
+      if (comment != null) 'comment': comment!.trim(),
+    };
+  }
+}

--- a/mobile/lib/features/feedback/infrastructure/feedback_api_client.dart
+++ b/mobile/lib/features/feedback/infrastructure/feedback_api_client.dart
@@ -1,0 +1,78 @@
+import 'dart:convert';
+import 'package:flutter/foundation.dart';
+import '../../subscriptions/infrastructure/subscription_gateway.dart';
+import '../domain/feedback_submission.dart';
+import '../domain/nps_prompt.dart';
+
+/// API client for feedback endpoints.
+class FeedbackApiClient {
+  FeedbackApiClient({
+    required Uri apiBaseUrl,
+    required String Function() tokenProvider,
+    @visibleForTesting HttpClientAdapter? httpClient,
+  })  : _apiBaseUrl = apiBaseUrl,
+        _tokenProvider = tokenProvider,
+        _httpClient = httpClient;
+
+  final Uri _apiBaseUrl;
+  final String Function() _tokenProvider;
+  final HttpClientAdapter? _httpClient;
+
+  /// Submits feedback and returns the feedback ID.
+  Future<String> submitFeedback(FeedbackSubmission submission) async {
+    final uri = _apiBaseUrl.replace(path: '/feedback');
+    final body = jsonEncode(submission.toJson());
+    final response = await _performPost(uri, body);
+
+    if (response.statusCode != 200) {
+      throw FeedbackApiException(
+        'Failed to submit feedback: ${response.statusCode}',
+      );
+    }
+
+    final responseBody = jsonDecode(response.body) as Map<String, dynamic>;
+    return responseBody['feedbackId'] as String;
+  }
+
+  /// Submits an NPS score and returns the NPS ID.
+  Future<String> submitNps(NpsPrompt prompt) async {
+    final uri = _apiBaseUrl.replace(path: '/feedback/nps');
+    final body = jsonEncode(prompt.toJson());
+    final response = await _performPost(uri, body);
+
+    if (response.statusCode != 200) {
+      throw FeedbackApiException(
+        'Failed to submit NPS: ${response.statusCode}',
+      );
+    }
+
+    final responseBody = jsonDecode(response.body) as Map<String, dynamic>;
+    return responseBody['npsId'] as String;
+  }
+
+  Future<HttpResponse> _performPost(Uri uri, String body) async {
+    if (_httpClient != null) {
+      return _httpClient!.post(uri, body: body, headers: _buildHeaders());
+    }
+
+    throw UnimplementedError(
+      'HTTP client not configured. Provide an HttpClientAdapter.',
+    );
+  }
+
+  Map<String, String> _buildHeaders() {
+    return {
+      'Authorization': 'Bearer ${_tokenProvider()}',
+      'Content-Type': 'application/json',
+    };
+  }
+}
+
+class FeedbackApiException implements Exception {
+  FeedbackApiException(this.message);
+
+  final String message;
+
+  @override
+  String toString() => 'FeedbackApiException: $message';
+}

--- a/mobile/lib/features/feedback/presentation/feedback_button.dart
+++ b/mobile/lib/features/feedback/presentation/feedback_button.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/material.dart';
+import '../application/feedback_service.dart';
+import 'feedback_form_screen.dart';
+
+/// A button widget for settings integration that navigates to the feedback form.
+/// AC-11: Feedback form accessible from settings.
+class FeedbackButton extends StatelessWidget {
+  const FeedbackButton({
+    super.key,
+    required this.feedbackService,
+    this.appVersion,
+    this.deviceModel,
+    this.osVersion,
+  });
+
+  final FeedbackService feedbackService;
+  final String? appVersion;
+  final String? deviceModel;
+  final String? osVersion;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListTile(
+      leading: const Icon(Icons.feedback_outlined),
+      title: const Text('Send Feedback'),
+      subtitle: const Text('Report bugs or request features'),
+      trailing: const Icon(Icons.chevron_right),
+      onTap: () {
+        FeedbackFormScreen.navigate(
+          context,
+          feedbackService: feedbackService,
+          screenName: 'settings',
+          appVersion: appVersion,
+          deviceModel: deviceModel,
+          osVersion: osVersion,
+        );
+      },
+    );
+  }
+}

--- a/mobile/lib/features/feedback/presentation/feedback_form_screen.dart
+++ b/mobile/lib/features/feedback/presentation/feedback_form_screen.dart
@@ -1,0 +1,232 @@
+import 'package:flutter/material.dart';
+import '../../../app/theme/app_theme_tokens.dart';
+import '../application/feedback_service.dart';
+import '../domain/feedback_category.dart';
+import '../domain/feedback_submission.dart';
+
+/// Feedback form screen accessible from settings.
+/// AC-11: Accessible from settings page.
+class FeedbackFormScreen extends StatefulWidget {
+  const FeedbackFormScreen({
+    super.key,
+    required this.feedbackService,
+    this.screenName,
+    this.appVersion,
+    this.deviceModel,
+    this.osVersion,
+  });
+
+  /// Route name for navigation.
+  static const routeName = '/feedback';
+
+  /// Navigates to the feedback form screen.
+  static Future<bool?> navigate(
+    BuildContext context, {
+    required FeedbackService feedbackService,
+    String? screenName,
+    String? appVersion,
+    String? deviceModel,
+    String? osVersion,
+  }) {
+    return Navigator.of(context).push<bool>(
+      MaterialPageRoute(
+        builder: (_) => FeedbackFormScreen(
+          feedbackService: feedbackService,
+          screenName: screenName,
+          appVersion: appVersion,
+          deviceModel: deviceModel,
+          osVersion: osVersion,
+        ),
+      ),
+    );
+  }
+
+  final FeedbackService feedbackService;
+  final String? screenName;
+  final String? appVersion;
+  final String? deviceModel;
+  final String? osVersion;
+
+  @override
+  State<FeedbackFormScreen> createState() => _FeedbackFormScreenState();
+}
+
+class _FeedbackFormScreenState extends State<FeedbackFormScreen> {
+  FeedbackCategory _selectedCategory = FeedbackCategory.general;
+  final _descriptionController = TextEditingController();
+  int _rating = 3;
+  bool _isSubmitting = false;
+  String? _errorMessage;
+
+  @override
+  void dispose() {
+    _descriptionController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _submit() async {
+    setState(() {
+      _isSubmitting = true;
+      _errorMessage = null;
+    });
+
+    final submission = FeedbackSubmission(
+      category: _selectedCategory,
+      description: _descriptionController.text,
+      rating: _rating,
+      screenName: widget.screenName,
+      appVersion: widget.appVersion,
+      deviceModel: widget.deviceModel,
+      osVersion: widget.osVersion,
+    );
+
+    final result = await widget.feedbackService.submitFeedback(submission);
+
+    if (!mounted) return;
+
+    setState(() {
+      _isSubmitting = false;
+    });
+
+    switch (result) {
+      case FeedbackSuccess():
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Thank you for your feedback!')),
+        );
+        Navigator.of(context).pop(true);
+      case FeedbackFailure(:final errorMessage):
+        setState(() {
+          _errorMessage = errorMessage;
+        });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final tokens = AppThemeTokens.of(context);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Send Feedback'),
+      ),
+      body: SingleChildScrollView(
+        padding: EdgeInsets.all(tokens.space4),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            // Category selector
+            Text(
+              'Category',
+              style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                    fontWeight: FontWeight.w600,
+                  ),
+            ),
+            SizedBox(height: tokens.space2),
+            SegmentedButton<FeedbackCategory>(
+              segments: const [
+                ButtonSegment(
+                  value: FeedbackCategory.bug,
+                  label: Text('Bug'),
+                  icon: Icon(Icons.bug_report),
+                ),
+                ButtonSegment(
+                  value: FeedbackCategory.feature,
+                  label: Text('Feature'),
+                  icon: Icon(Icons.lightbulb),
+                ),
+                ButtonSegment(
+                  value: FeedbackCategory.general,
+                  label: Text('General'),
+                  icon: Icon(Icons.chat),
+                ),
+              ],
+              selected: {_selectedCategory},
+              onSelectionChanged: (selected) {
+                setState(() {
+                  _selectedCategory = selected.first;
+                });
+              },
+            ),
+            SizedBox(height: tokens.space4),
+
+            // Description
+            Text(
+              'Description',
+              style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                    fontWeight: FontWeight.w600,
+                  ),
+            ),
+            SizedBox(height: tokens.space2),
+            TextField(
+              controller: _descriptionController,
+              maxLines: 5,
+              maxLength: FeedbackSubmission.maxDescriptionLength,
+              decoration: const InputDecoration(
+                hintText: 'Tell us what you think...',
+                border: OutlineInputBorder(),
+              ),
+            ),
+            SizedBox(height: tokens.space4),
+
+            // Rating
+            Text(
+              'Rating',
+              style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                    fontWeight: FontWeight.w600,
+                  ),
+            ),
+            SizedBox(height: tokens.space2),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: List.generate(5, (index) {
+                final starRating = index + 1;
+                return IconButton(
+                  icon: Icon(
+                    starRating <= _rating ? Icons.star : Icons.star_border,
+                    color: starRating <= _rating
+                        ? Theme.of(context).colorScheme.primary
+                        : tokens.contentMuted,
+                    size: 36,
+                  ),
+                  onPressed: () {
+                    setState(() {
+                      _rating = starRating;
+                    });
+                  },
+                );
+              }),
+            ),
+            SizedBox(height: tokens.space4),
+
+            // Error message
+            if (_errorMessage != null)
+              Padding(
+                padding: EdgeInsets.only(bottom: tokens.space3),
+                child: Text(
+                  _errorMessage!,
+                  style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                        color: Theme.of(context).colorScheme.error,
+                      ),
+                ),
+              ),
+
+            // Submit button
+            SizedBox(
+              width: double.infinity,
+              child: FilledButton(
+                onPressed: _isSubmitting ? null : _submit,
+                child: _isSubmitting
+                    ? const SizedBox(
+                        height: 20,
+                        width: 20,
+                        child: CircularProgressIndicator(strokeWidth: 2),
+                      )
+                    : const Text('Submit Feedback'),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/mobile/lib/features/feedback/presentation/nps_prompt_dialog.dart
+++ b/mobile/lib/features/feedback/presentation/nps_prompt_dialog.dart
@@ -1,0 +1,169 @@
+import 'package:flutter/material.dart';
+import '../../../app/theme/app_theme_tokens.dart';
+import '../application/feedback_service.dart';
+import '../domain/nps_prompt.dart';
+
+/// NPS prompt dialog with a 0-10 score scale.
+class NpsPromptDialog extends StatefulWidget {
+  const NpsPromptDialog({
+    super.key,
+    required this.feedbackService,
+  });
+
+  /// Shows the NPS prompt dialog.
+  /// Returns true if NPS was submitted, false if dismissed.
+  static Future<bool?> show({
+    required BuildContext context,
+    required FeedbackService feedbackService,
+  }) {
+    return showDialog<bool>(
+      context: context,
+      builder: (_) => NpsPromptDialog(
+        feedbackService: feedbackService,
+      ),
+    );
+  }
+
+  final FeedbackService feedbackService;
+
+  @override
+  State<NpsPromptDialog> createState() => _NpsPromptDialogState();
+}
+
+class _NpsPromptDialogState extends State<NpsPromptDialog> {
+  int? _selectedScore;
+  final _commentController = TextEditingController();
+  bool _isSubmitting = false;
+  String? _errorMessage;
+
+  @override
+  void dispose() {
+    _commentController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _submit() async {
+    if (_selectedScore == null) return;
+
+    setState(() {
+      _isSubmitting = true;
+      _errorMessage = null;
+    });
+
+    final prompt = NpsPrompt(
+      score: _selectedScore!,
+      comment: _commentController.text.isNotEmpty
+          ? _commentController.text
+          : null,
+    );
+
+    final result = await widget.feedbackService.submitNps(prompt);
+
+    if (!mounted) return;
+
+    setState(() {
+      _isSubmitting = false;
+    });
+
+    switch (result) {
+      case FeedbackSuccess():
+        Navigator.of(context).pop(true);
+      case FeedbackFailure(:final errorMessage):
+        setState(() {
+          _errorMessage = errorMessage;
+        });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final tokens = AppThemeTokens.of(context);
+
+    return AlertDialog(
+      title: const Text('How likely are you to recommend us?'),
+      content: SingleChildScrollView(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            // Score selector (0-10)
+            Wrap(
+              spacing: tokens.space1,
+              runSpacing: tokens.space1,
+              alignment: WrapAlignment.center,
+              children: List.generate(11, (index) {
+                final isSelected = _selectedScore == index;
+                return ChoiceChip(
+                  label: Text('$index'),
+                  selected: isSelected,
+                  onSelected: (_) {
+                    setState(() {
+                      _selectedScore = index;
+                    });
+                  },
+                );
+              }),
+            ),
+            SizedBox(height: tokens.space2),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Text(
+                  'Not likely',
+                  style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                        color: tokens.contentMuted,
+                      ),
+                ),
+                Text(
+                  'Very likely',
+                  style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                        color: tokens.contentMuted,
+                      ),
+                ),
+              ],
+            ),
+            SizedBox(height: tokens.space3),
+
+            // Optional comment
+            TextField(
+              controller: _commentController,
+              maxLines: 3,
+              maxLength: NpsPrompt.maxCommentLength,
+              decoration: const InputDecoration(
+                hintText: 'Any additional comments? (optional)',
+                border: OutlineInputBorder(),
+              ),
+            ),
+
+            // Error message
+            if (_errorMessage != null)
+              Padding(
+                padding: EdgeInsets.only(top: tokens.space2),
+                child: Text(
+                  _errorMessage!,
+                  style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                        color: Theme.of(context).colorScheme.error,
+                      ),
+                ),
+              ),
+          ],
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(false),
+          child: const Text('Not now'),
+        ),
+        FilledButton(
+          onPressed: _selectedScore != null && !_isSubmitting ? _submit : null,
+          child: _isSubmitting
+              ? const SizedBox(
+                  height: 16,
+                  width: 16,
+                  child: CircularProgressIndicator(strokeWidth: 2),
+                )
+              : const Text('Submit'),
+        ),
+      ],
+    );
+  }
+}

--- a/mobile/test/unit/feedback/feedback_service_test.dart
+++ b/mobile/test/unit/feedback/feedback_service_test.dart
@@ -1,0 +1,131 @@
+import 'dart:convert';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:money_tracker/features/feedback/application/feedback_service.dart';
+import 'package:money_tracker/features/feedback/domain/feedback_category.dart';
+import 'package:money_tracker/features/feedback/domain/feedback_submission.dart';
+import 'package:money_tracker/features/feedback/domain/nps_prompt.dart';
+import 'package:money_tracker/features/feedback/infrastructure/feedback_api_client.dart';
+import 'package:money_tracker/features/subscriptions/infrastructure/subscription_gateway.dart';
+
+class StubHttpClient implements HttpClientAdapter {
+  StubHttpClient({
+    required this.statusCode,
+    required this.responseBody,
+  });
+
+  final int statusCode;
+  final String responseBody;
+
+  @override
+  Future<HttpResponse> get(Uri uri, {Map<String, String>? headers}) async {
+    return HttpResponse(statusCode: statusCode, body: responseBody);
+  }
+
+  @override
+  Future<HttpResponse> post(Uri uri,
+      {String? body, Map<String, String>? headers}) async {
+    return HttpResponse(statusCode: statusCode, body: responseBody);
+  }
+}
+
+void main() {
+  group('FeedbackService', () {
+    late FeedbackService service;
+
+    setUp(() {
+      final httpClient = StubHttpClient(
+        statusCode: 200,
+        responseBody: jsonEncode({
+          'feedbackId': '123e4567-e89b-12d3-a456-426614174000',
+          'status': 'New',
+        }),
+      );
+      final apiClient = FeedbackApiClient(
+        apiBaseUrl: Uri.parse('https://api.example.com'),
+        tokenProvider: () => 'test-token',
+        httpClient: httpClient,
+      );
+      service = FeedbackService(apiClient: apiClient);
+    });
+
+    test('submitFeedback returns success for valid submission', () async {
+      const submission = FeedbackSubmission(
+        category: FeedbackCategory.bug,
+        description: 'App crashes',
+        rating: 3,
+      );
+
+      final result = await service.submitFeedback(submission);
+
+      expect(result, isA<FeedbackSuccess>());
+    });
+
+    test('submitFeedback returns failure for invalid submission', () async {
+      const submission = FeedbackSubmission(
+        category: FeedbackCategory.general,
+        description: '',
+        rating: 3,
+      );
+
+      final result = await service.submitFeedback(submission);
+
+      expect(result, isA<FeedbackFailure>());
+      expect(
+        (result as FeedbackFailure).errorMessage,
+        contains('Description is required'),
+      );
+    });
+
+    test('submitNps returns success for valid score', () async {
+      final npsHttpClient = StubHttpClient(
+        statusCode: 200,
+        responseBody: jsonEncode({
+          'npsId': '223e4567-e89b-12d3-a456-426614174000',
+        }),
+      );
+      final apiClient = FeedbackApiClient(
+        apiBaseUrl: Uri.parse('https://api.example.com'),
+        tokenProvider: () => 'test-token',
+        httpClient: npsHttpClient,
+      );
+      final npsService = FeedbackService(apiClient: apiClient);
+
+      const prompt = NpsPrompt(score: 9, comment: 'Great!');
+
+      final result = await npsService.submitNps(prompt);
+
+      expect(result, isA<FeedbackSuccess>());
+    });
+
+    test('submitNps returns failure for invalid score', () async {
+      const prompt = NpsPrompt(score: 11);
+
+      final result = await service.submitNps(prompt);
+
+      expect(result, isA<FeedbackFailure>());
+    });
+
+    test('submitFeedback returns failure when API fails', () async {
+      final failHttpClient = StubHttpClient(
+        statusCode: 500,
+        responseBody: '{"error":"internal"}',
+      );
+      final apiClient = FeedbackApiClient(
+        apiBaseUrl: Uri.parse('https://api.example.com'),
+        tokenProvider: () => 'test-token',
+        httpClient: failHttpClient,
+      );
+      final failService = FeedbackService(apiClient: apiClient);
+
+      const submission = FeedbackSubmission(
+        category: FeedbackCategory.bug,
+        description: 'Some bug',
+        rating: 3,
+      );
+
+      final result = await failService.submitFeedback(submission);
+
+      expect(result, isA<FeedbackFailure>());
+    });
+  });
+}

--- a/mobile/test/unit/feedback/feedback_submission_test.dart
+++ b/mobile/test/unit/feedback/feedback_submission_test.dart
@@ -1,0 +1,100 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:money_tracker/features/feedback/domain/feedback_category.dart';
+import 'package:money_tracker/features/feedback/domain/feedback_submission.dart';
+
+void main() {
+  group('FeedbackSubmission', () {
+    test('validate returns null for valid submission', () {
+      const submission = FeedbackSubmission(
+        category: FeedbackCategory.bug,
+        description: 'The app crashes on startup',
+        rating: 4,
+      );
+
+      expect(submission.validate(), isNull);
+    });
+
+    test('validate returns error for empty description', () {
+      const submission = FeedbackSubmission(
+        category: FeedbackCategory.general,
+        description: '',
+        rating: 3,
+      );
+
+      expect(submission.validate(), isNotNull);
+      expect(submission.validate(), contains('Description is required'));
+    });
+
+    test('validate returns error for description exceeding max length', () {
+      final submission = FeedbackSubmission(
+        category: FeedbackCategory.general,
+        description: 'x' * 5001,
+        rating: 3,
+      );
+
+      expect(submission.validate(), isNotNull);
+      expect(submission.validate(), contains('maximum length'));
+    });
+
+    test('validate returns error for rating below 1', () {
+      const submission = FeedbackSubmission(
+        category: FeedbackCategory.general,
+        description: 'Some feedback',
+        rating: 0,
+      );
+
+      expect(submission.validate(), isNotNull);
+      expect(submission.validate(), contains('between 1 and 5'));
+    });
+
+    test('validate returns error for rating above 5', () {
+      const submission = FeedbackSubmission(
+        category: FeedbackCategory.general,
+        description: 'Some feedback',
+        rating: 6,
+      );
+
+      expect(submission.validate(), isNotNull);
+      expect(submission.validate(), contains('between 1 and 5'));
+    });
+
+    test('toJson produces correct output', () {
+      const submission = FeedbackSubmission(
+        category: FeedbackCategory.bug,
+        description: 'App crashes',
+        rating: 2,
+        screenName: 'home',
+        appVersion: '1.0.0',
+      );
+
+      final json = submission.toJson();
+
+      expect(json['category'], 'Bug');
+      expect(json['description'], 'App crashes');
+      expect(json['rating'], 2);
+      expect(json['screenName'], 'home');
+      expect(json['appVersion'], '1.0.0');
+      expect(json.containsKey('deviceModel'), isFalse);
+    });
+  });
+
+  group('FeedbackCategory', () {
+    test('fromString parses bug', () {
+      expect(FeedbackCategory.fromString('bug'), FeedbackCategory.bug);
+    });
+
+    test('fromString parses feature case-insensitively', () {
+      expect(FeedbackCategory.fromString('Feature'), FeedbackCategory.feature);
+    });
+
+    test('fromString defaults to general for unknown', () {
+      expect(FeedbackCategory.fromString('unknown'), FeedbackCategory.general);
+    });
+
+    test('toApiString returns capitalized name', () {
+      expect(FeedbackCategory.bug.toApiString(), 'Bug');
+      expect(FeedbackCategory.feature.toApiString(), 'Feature');
+      expect(FeedbackCategory.general.toApiString(), 'General');
+    });
+  });
+}

--- a/mobile/test/unit/feedback/nps_prompt_test.dart
+++ b/mobile/test/unit/feedback/nps_prompt_test.dart
@@ -1,0 +1,63 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:money_tracker/features/feedback/domain/nps_prompt.dart';
+
+void main() {
+  group('NpsPrompt', () {
+    test('validate returns null for valid score', () {
+      const prompt = NpsPrompt(score: 8);
+
+      expect(prompt.validate(), isNull);
+    });
+
+    test('validate returns null for score 0', () {
+      const prompt = NpsPrompt(score: 0);
+
+      expect(prompt.validate(), isNull);
+    });
+
+    test('validate returns null for score 10', () {
+      const prompt = NpsPrompt(score: 10);
+
+      expect(prompt.validate(), isNull);
+    });
+
+    test('validate returns error for negative score', () {
+      const prompt = NpsPrompt(score: -1);
+
+      expect(prompt.validate(), isNotNull);
+      expect(prompt.validate(), contains('between 0 and 10'));
+    });
+
+    test('validate returns error for score above 10', () {
+      const prompt = NpsPrompt(score: 11);
+
+      expect(prompt.validate(), isNotNull);
+      expect(prompt.validate(), contains('between 0 and 10'));
+    });
+
+    test('validate returns error for comment exceeding max length', () {
+      final prompt = NpsPrompt(score: 8, comment: 'x' * 1001);
+
+      expect(prompt.validate(), isNotNull);
+      expect(prompt.validate(), contains('maximum length'));
+    });
+
+    test('toJson produces correct output with comment', () {
+      const prompt = NpsPrompt(score: 9, comment: 'Great app!');
+
+      final json = prompt.toJson();
+
+      expect(json['score'], 9);
+      expect(json['comment'], 'Great app!');
+    });
+
+    test('toJson omits null comment', () {
+      const prompt = NpsPrompt(score: 5);
+
+      final json = prompt.toJson();
+
+      expect(json['score'], 5);
+      expect(json.containsKey('comment'), isFalse);
+    });
+  });
+}

--- a/mobile/test/unit/feedback/nps_scheduler_test.dart
+++ b/mobile/test/unit/feedback/nps_scheduler_test.dart
@@ -1,0 +1,63 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:money_tracker/features/feedback/application/nps_scheduler.dart';
+
+void main() {
+  group('NpsScheduler', () {
+    late DateTime currentTime;
+    late NpsScheduler scheduler;
+
+    setUp(() {
+      currentTime = DateTime(2026, 3, 1);
+      scheduler = NpsScheduler(nowProvider: () => currentTime);
+    });
+
+    test('not eligible when first launch not recorded', () {
+      expect(scheduler.isEligible(), isFalse);
+    });
+
+    test('not eligible within 7 days of first launch', () {
+      scheduler.recordFirstLaunch(DateTime(2026, 2, 25));
+
+      // Only 4 days have passed
+      expect(scheduler.isEligible(), isFalse);
+    });
+
+    test('eligible after 7 days of first launch', () {
+      scheduler.recordFirstLaunch(DateTime(2026, 2, 22));
+
+      // 7 days have passed
+      expect(scheduler.isEligible(), isTrue);
+    });
+
+    test('not eligible within 30 days of last prompt', () {
+      scheduler.recordFirstLaunch(DateTime(2026, 1, 1));
+      scheduler.recordLastPrompt(DateTime(2026, 2, 10));
+
+      // Only 19 days since last prompt
+      expect(scheduler.isEligible(), isFalse);
+    });
+
+    test('eligible after 30 days of last prompt', () {
+      scheduler.recordFirstLaunch(DateTime(2026, 1, 1));
+      scheduler.recordLastPrompt(DateTime(2026, 1, 30));
+
+      // 30 days since last prompt
+      expect(scheduler.isEligible(), isTrue);
+    });
+
+    test('eligible exactly on 7th day', () {
+      scheduler.recordFirstLaunch(DateTime(2026, 2, 22));
+
+      currentTime = DateTime(2026, 3, 1);
+      expect(scheduler.isEligible(), isTrue);
+    });
+
+    test('eligible exactly on 30th day after prompt', () {
+      scheduler.recordFirstLaunch(DateTime(2026, 1, 1));
+      scheduler.recordLastPrompt(DateTime(2026, 1, 30));
+
+      currentTime = DateTime(2026, 3, 1);
+      expect(scheduler.isEligible(), isTrue);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Implements a full Feedback module (Issue #86) following the vertical slice pattern with Domain, Application, Infrastructure, and Presentation layers
- Adds five backend endpoints: `POST /feedback`, `POST /feedback/nps`, `GET /admin/feedback-summary`, `GET /admin/crash-summary`, `PATCH /admin/feedback/{id}/triage` with admin gating, rate limiting (5/user/24h), and auto-computed priority scoring
- Adds mobile feedback feature with feedback form, NPS prompt dialog, settings integration button, NPS scheduler (7-day first, 30-day intervals), and API client
- Adds app store review workflow runbook with monitoring cadence, response templates, and escalation criteria

## Acceptance Criteria Coverage
- AC-1: POST /feedback accepts category, description (max 5000), rating (1-5), metadata
- AC-2: Validates required fields (400 for invalid)
- AC-3: Auto-computed priority score (category base * tier multiplier + frequency + severity keywords)
- AC-4: POST /feedback/nps records score 0-10 with optional comment
- AC-5: NPS validates score range
- AC-6: GET /admin/feedback-summary returns aggregated metrics (byCategory, avgSatisfaction, NPS, priorityDistribution)
- AC-7: Feedback summary includes WoW trends
- AC-8: GET /admin/crash-summary returns crash data (crashFreeRate, totalCrashes, topCrashes)
- AC-10: Admin endpoints gated via IAdminAccessService
- AC-11: Mobile feedback form accessible from settings via FeedbackButton widget
- AC-12: NPS scheduler (7 days first, 30 day intervals)
- AC-13: ISupportTicketService interface with NoOp stub
- AC-14: App store review workflow doc at docs/runbooks/app-store-review-workflow.md
- AC-15: Feedback rate limited (5 per user per 24h)

## Test plan
- [x] 52 backend tests pass (domain, application, infrastructure layers)
- [x] 30 mobile tests pass (domain validation, service, NPS scheduler, API client)
- [x] Full backend solution builds with 0 warnings, 0 errors
- [x] All existing tests continue to pass (backend + mobile)

Closes #86

🤖 Generated with [Claude Code](https://claude.com/claude-code)