### PR TITLE
Fix: Show 'coming soon' snackbar for Explore roadmap button (#106)

### DIFF
--- a/mobile/lib/app/shell/money_tracker_shell.dart
+++ b/mobile/lib/app/shell/money_tracker_shell.dart
@@ -201,7 +201,15 @@ class _ShellBody extends StatelessWidget {
               ),
               const Spacer(),
               TextButton.icon(
-                onPressed: () {},
+                onPressed: () {
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    const SnackBar(
+                      content: Text('Roadmap coming soon'),
+                      behavior: SnackBarBehavior.floating,
+                      duration: Duration(seconds: 2),
+                    ),
+                  );
+                },
                 icon: const Icon(Icons.open_in_new),
                 label: const Text('Explore roadmap'),
               ),

--- a/mobile/test/widget/stub_screen_explore_button_test.dart
+++ b/mobile/test/widget/stub_screen_explore_button_test.dart
@@ -1,0 +1,69 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:money_tracker/app/app.dart';
+
+void main() {
+  Future<void> _pumpAppAndNavigateTo(
+    WidgetTester tester,
+    String destinationLabel,
+  ) async {
+    tester.view.physicalSize = const Size(390, 844);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    await tester.pumpWidget(const MoneyTrackerApp(themeMode: ThemeMode.light));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text(destinationLabel));
+    await tester.pumpAndSettle();
+  }
+
+  group('Explore roadmap button on stub screens', () {
+    testWidgets('shows SnackBar when tapped on Budgets stub', (
+      WidgetTester tester,
+    ) async {
+      await _pumpAppAndNavigateTo(tester, 'Budgets');
+
+      await tester.tap(find.text('Explore roadmap'));
+      await tester.pump();
+
+      expect(find.text('Roadmap coming soon'), findsOneWidget);
+    });
+
+    testWidgets('shows SnackBar when tapped on Activity stub', (
+      WidgetTester tester,
+    ) async {
+      await _pumpAppAndNavigateTo(tester, 'Activity');
+
+      await tester.tap(find.text('Explore roadmap'));
+      await tester.pump();
+
+      expect(find.text('Roadmap coming soon'), findsOneWidget);
+    });
+
+    testWidgets('shows SnackBar when tapped on Household stub', (
+      WidgetTester tester,
+    ) async {
+      await _pumpAppAndNavigateTo(tester, 'Household');
+
+      await tester.tap(find.text('Explore roadmap'));
+      await tester.pump();
+
+      expect(find.text('Roadmap coming soon'), findsOneWidget);
+    });
+
+    testWidgets('SnackBar uses floating behavior', (
+      WidgetTester tester,
+    ) async {
+      await _pumpAppAndNavigateTo(tester, 'Budgets');
+
+      await tester.tap(find.text('Explore roadmap'));
+      await tester.pump();
+
+      final snackBar = tester.widget<SnackBar>(find.byType(SnackBar));
+      expect(snackBar.behavior, SnackBarBehavior.floating);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Replaces the empty `onPressed: () {}` closure on the "Explore roadmap" `TextButton.icon` in stub screens (Budgets, Activity, Household) with a `ScaffoldMessenger.showSnackBar` call that displays a floating SnackBar with the message "Roadmap coming soon" for 2 seconds.
- Eliminates the dead-click UX anti-pattern on three of the five primary navigation destinations.

Closes #106

## Test plan
- [x] `flutter analyze` -- no new warnings (22 pre-existing warnings, none in changed file)
- [x] `flutter test` -- all 201 tests pass
- [ ] Manual: tap "Explore roadmap" on Budgets, Activity, and Household stubs and verify the floating SnackBar appears and auto-dismisses after 2 seconds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

New Features:
- Display a floating SnackBar saying "Roadmap coming soon" for 2 seconds when the Explore roadmap button is pressed on relevant stub screens.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a notification that displays when the roadmap button is clicked, informing users that the feature is coming soon.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->