### PR TITLE
Fix: Show both period bars in spending trend chart (#103)

### DIFF
--- a/mobile/lib/features/insights/presentation/widgets/spending_trend_chart.dart
+++ b/mobile/lib/features/insights/presentation/widgets/spending_trend_chart.dart
@@ -159,23 +159,32 @@ class _CategoryBar extends StatelessWidget {
           ],
         ),
         const SizedBox(height: 4),
-        ClipRRect(
-          borderRadius: BorderRadius.circular(4),
-          child: SizedBox(
-            height: 8,
-            child: Stack(
-              children: [
-                FractionallySizedBox(
-                  widthFactor: previousFraction,
-                  child: Container(color: theme.colorScheme.outline.withValues(alpha: 0.4)),
-                ),
-                FractionallySizedBox(
+        Column(
+          children: [
+            ClipRRect(
+              borderRadius: BorderRadius.circular(4),
+              child: SizedBox(
+                height: 4,
+                child: FractionallySizedBox(
+                  alignment: Alignment.centerLeft,
                   widthFactor: currentFraction,
                   child: Container(color: theme.colorScheme.primary),
                 ),
-              ],
+              ),
             ),
-          ),
+            const SizedBox(height: 2),
+            ClipRRect(
+              borderRadius: BorderRadius.circular(4),
+              child: SizedBox(
+                height: 4,
+                child: FractionallySizedBox(
+                  alignment: Alignment.centerLeft,
+                  widthFactor: previousFraction,
+                  child: Container(color: theme.colorScheme.outline.withValues(alpha: 0.4)),
+                ),
+              ),
+            ),
+          ],
         ),
         const SizedBox(height: 2),
         Text(


### PR DESCRIPTION
## Summary

- **Bug**: In the spending trend chart, the current-period bar was rendered on top of the previous-period bar inside a `Stack`, causing the previous bar to be completely hidden whenever current spending exceeded previous spending.
- **Fix**: Replaced the `Stack` layout in `_CategoryBar` with a `Column` containing two separate `ClipRRect`-wrapped bars (4px each), so both the current-period and previous-period bars are always visible regardless of relative magnitude.
- All 201 existing tests pass. No new warnings introduced by this change.

## Test plan

- [x] `flutter analyze` passes (no new issues)
- [x] `flutter test` passes (201/201 tests, including `spending_trend_chart_test.dart`)
- [ ] Manual verification: confirm both bars visible when current > previous
- [ ] Manual verification: confirm both bars visible when previous > current

Closes #103

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Prevent the previous-period bar in the spending trend chart from being fully obscured when the current-period spending exceeds it by rendering the two bars as separate horizontal rows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced the spending trend chart to display current and previous spending periods as two separate stacked bars for improved period-over-period comparison.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->