### PR TITLE
Fix: Replace hardcoded 'Wednesday plan' with dynamic day title (#102)

### DIFF
--- a/mobile/lib/app/shell/money_tracker_shell.dart
+++ b/mobile/lib/app/shell/money_tracker_shell.dart
@@ -12,6 +12,20 @@ import '../theme/app_theme_controller.dart';
 import '../theme/app_theme_mode.dart';
 import '../theme/app_theme_tokens.dart';
 
+String _todayPlanTitle([DateTime? now]) {
+  const dayNames = [
+    'Monday',
+    'Tuesday',
+    'Wednesday',
+    'Thursday',
+    'Friday',
+    'Saturday',
+    'Sunday',
+  ];
+  final day = (now ?? DateTime.now()).weekday; // 1=Monday, 7=Sunday
+  return '${dayNames[day - 1]} plan';
+}
+
 const double _shellExpandedBreakpoint = 980.0;
 const double _dashboardSplitBreakpoint = 900.0;
 const double _summaryCompactBreakpoint = 560.0;
@@ -83,7 +97,7 @@ class _MoneyTrackerShellState extends State<MoneyTrackerShell> {
           appBar: AppBar(
             title: Text(
               _selectedIndex == 0
-                  ? 'Wednesday plan'
+                  ? _todayPlanTitle()
                   : _destinations[_selectedIndex].label,
             ),
             actions: [
@@ -396,7 +410,7 @@ class _TopSummaryCard extends StatelessWidget {
                 ),
                 SizedBox(height: tokens.space1),
                 Text(
-                  'Wednesday plan',
+                  _todayPlanTitle(),
                   style: Theme.of(context).textTheme.headlineSmall,
                 ),
               ],

--- a/mobile/lib/app/shell/money_tracker_shell.dart
+++ b/mobile/lib/app/shell/money_tracker_shell.dart
@@ -12,7 +12,8 @@ import '../theme/app_theme_controller.dart';
 import '../theme/app_theme_mode.dart';
 import '../theme/app_theme_tokens.dart';
 
-String _todayPlanTitle([DateTime? now]) {
+@visibleForTesting
+String todayPlanTitle([DateTime? now]) {
   const dayNames = [
     'Monday',
     'Tuesday',
@@ -97,7 +98,7 @@ class _MoneyTrackerShellState extends State<MoneyTrackerShell> {
           appBar: AppBar(
             title: Text(
               _selectedIndex == 0
-                  ? _todayPlanTitle()
+                  ? todayPlanTitle()
                   : _destinations[_selectedIndex].label,
             ),
             actions: [
@@ -410,7 +411,7 @@ class _TopSummaryCard extends StatelessWidget {
                 ),
                 SizedBox(height: tokens.space1),
                 Text(
-                  _todayPlanTitle(),
+                  todayPlanTitle(),
                   style: Theme.of(context).textTheme.headlineSmall,
                 ),
               ],

--- a/mobile/test/widget_test.dart
+++ b/mobile/test/widget_test.dart
@@ -3,6 +3,20 @@ import 'package:flutter_test/flutter_test.dart';
 
 import 'package:money_tracker/app/app.dart';
 
+String _expectedPlanTitle() {
+  const dayNames = [
+    'Monday',
+    'Tuesday',
+    'Wednesday',
+    'Thursday',
+    'Friday',
+    'Saturday',
+    'Sunday',
+  ];
+  final day = DateTime.now().weekday; // 1=Monday, 7=Sunday
+  return '${dayNames[day - 1]} plan';
+}
+
 void main() {
   testWidgets('renders app shell with compact navigation', (
     WidgetTester tester,
@@ -12,13 +26,15 @@ void main() {
     addTearDown(tester.view.resetPhysicalSize);
     addTearDown(tester.view.resetDevicePixelRatio);
 
+    final expectedTitle = _expectedPlanTitle();
+
     await tester.pumpWidget(const MoneyTrackerApp(themeMode: ThemeMode.light));
     await tester.pumpAndSettle();
 
     expect(
       find.descendant(
         of: find.byType(AppBar),
-        matching: find.text('Wednesday plan'),
+        matching: find.text(expectedTitle),
       ),
       findsOneWidget,
     );

--- a/mobile/test/widget_test.dart
+++ b/mobile/test/widget_test.dart
@@ -2,20 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:money_tracker/app/app.dart';
-
-String _expectedPlanTitle() {
-  const dayNames = [
-    'Monday',
-    'Tuesday',
-    'Wednesday',
-    'Thursday',
-    'Friday',
-    'Saturday',
-    'Sunday',
-  ];
-  final day = DateTime.now().weekday; // 1=Monday, 7=Sunday
-  return '${dayNames[day - 1]} plan';
-}
+import 'package:money_tracker/app/shell/money_tracker_shell.dart';
 
 void main() {
   testWidgets('renders app shell with compact navigation', (
@@ -26,7 +13,7 @@ void main() {
     addTearDown(tester.view.resetPhysicalSize);
     addTearDown(tester.view.resetDevicePixelRatio);
 
-    final expectedTitle = _expectedPlanTitle();
+    final expectedTitle = todayPlanTitle();
 
     await tester.pumpWidget(const MoneyTrackerApp(themeMode: ThemeMode.light));
     await tester.pumpAndSettle();
@@ -41,5 +28,24 @@ void main() {
     expect(find.text('Shared dashboard'), findsOneWidget);
     expect(find.byType(NavigationBar), findsOneWidget);
     expect(find.byType(NavigationRail), findsNothing);
+  });
+
+  group('todayPlanTitle', () {
+    test('returns correct day name for each weekday', () {
+      // 2026-03-09 is a Monday, 2026-03-15 is a Sunday
+      const expected = [
+        'Monday plan',
+        'Tuesday plan',
+        'Wednesday plan',
+        'Thursday plan',
+        'Friday plan',
+        'Saturday plan',
+        'Sunday plan',
+      ];
+      for (var i = 0; i < 7; i++) {
+        final date = DateTime(2026, 3, 9 + i);
+        expect(todayPlanTitle(date), expected[i]);
+      }
+    });
   });
 }


### PR DESCRIPTION
## Summary
- Added a file-scoped `_todayPlanTitle([DateTime? now])` helper in `money_tracker_shell.dart` that derives the weekday name from `DateTime.now()` (with an optional override for test determinism)
- Replaced both hardcoded `'Wednesday plan'` occurrences (AppBar title and `_TopSummaryCard` heading) with calls to `_todayPlanTitle()`
- Updated `widget_test.dart` to compute the expected title dynamically at test runtime instead of asserting against a hardcoded string

## Test plan
- [x] `flutter analyze` passes (all 22 issues are pre-existing, none related to this change)
- [x] `flutter test` passes -- all 201 tests pass
- [x] Verified `_todayPlanTitle()` returns correct `"<Weekday> plan"` format using `DateTime.weekday` (1=Monday through 7=Sunday)
- [x] No new package dependencies introduced

Closes #102

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Make the plan title dynamic based on the current weekday across the app shell and summary card, and align tests with the new behavior.

Bug Fixes:
- Replace hardcoded "Wednesday plan" labels with a weekday-based title derived from the current date to ensure correct labeling on any day.

Tests:
- Update widget test expectations to compute the plan title dynamically at runtime instead of asserting a fixed string.