### PR TITLE
Fix: Guard reminder sample data behind debug assert (#101)

### DIFF
--- a/mobile/lib/app/shell/money_tracker_shell.dart
+++ b/mobile/lib/app/shell/money_tracker_shell.dart
@@ -46,12 +46,13 @@ class _MoneyTrackerShellState extends State<MoneyTrackerShell> {
     super.initState();
     _dashboardController = DashboardController();
     _insightsController = InsightsController();
+    _remindersController = RemindersController();
     assert(() {
       _dashboardController.seedSample();
       _insightsController.seedSample();
+      _remindersController.seedSample();
       return true;
     }());
-    _remindersController = RemindersController()..seedSample();
   }
 
   @override

--- a/mobile/test/unit/reminders_controller_test.dart
+++ b/mobile/test/unit/reminders_controller_test.dart
@@ -36,19 +36,19 @@ void main() {
     final controller = RemindersController();
     addTearDown(controller.dispose);
 
-    final now = DateTime.now();
+    final baseline = DateTime(2026, 1, 1);
     final laterReminder = ReminderEntry(
       id: 'r1',
       title: 'Later',
       amount: 10.0,
-      dueDate: now.add(const Duration(days: 30)),
+      dueDate: baseline.add(const Duration(days: 30)),
       cadence: 'Monthly',
     );
     final earlierReminder = ReminderEntry(
       id: 'r2',
       title: 'Earlier',
       amount: 20.0,
-      dueDate: now.add(const Duration(days: 5)),
+      dueDate: baseline.add(const Duration(days: 5)),
       cadence: 'Weekly',
     );
 

--- a/mobile/test/unit/reminders_controller_test.dart
+++ b/mobile/test/unit/reminders_controller_test.dart
@@ -1,0 +1,79 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:money_tracker/features/reminders/reminders_controller.dart';
+
+void main() {
+  test('reminders list is empty on construction', () {
+    final controller = RemindersController();
+    addTearDown(controller.dispose);
+
+    expect(controller.reminders, isEmpty);
+  });
+
+  test('seedSample populates two sample reminders', () {
+    final controller = RemindersController();
+    addTearDown(controller.dispose);
+
+    controller.seedSample();
+
+    expect(controller.reminders, hasLength(2));
+    expect(controller.reminders[0].title, 'Phone bill');
+    expect(controller.reminders[0].amount, 82.0);
+    expect(controller.reminders[1].title, 'Gym membership');
+    expect(controller.reminders[1].amount, 35.0);
+  });
+
+  test('seedSample is idempotent when called twice', () {
+    final controller = RemindersController();
+    addTearDown(controller.dispose);
+
+    controller.seedSample();
+    controller.seedSample();
+
+    expect(controller.reminders, hasLength(2));
+  });
+
+  test('addReminder inserts and maintains sort order by dueDate', () {
+    final controller = RemindersController();
+    addTearDown(controller.dispose);
+
+    final now = DateTime.now();
+    final laterReminder = ReminderEntry(
+      id: 'r1',
+      title: 'Later',
+      amount: 10.0,
+      dueDate: now.add(const Duration(days: 30)),
+      cadence: 'Monthly',
+    );
+    final earlierReminder = ReminderEntry(
+      id: 'r2',
+      title: 'Earlier',
+      amount: 20.0,
+      dueDate: now.add(const Duration(days: 5)),
+      cadence: 'Weekly',
+    );
+
+    controller.addReminder(laterReminder);
+    controller.addReminder(earlierReminder);
+
+    expect(controller.reminders, hasLength(2));
+    expect(controller.reminders[0].title, 'Earlier');
+    expect(controller.reminders[1].title, 'Later');
+  });
+
+  test('toggleNotifications updates flag and notifies listeners', () {
+    final controller = RemindersController();
+    addTearDown(controller.dispose);
+
+    expect(controller.notificationsEnabled, isTrue);
+
+    var notified = false;
+    controller.addListener(() {
+      notified = true;
+    });
+
+    controller.toggleNotifications(false);
+
+    expect(controller.notificationsEnabled, isFalse);
+    expect(notified, isTrue);
+  });
+}


### PR DESCRIPTION
## Summary

- Moves `_remindersController.seedSample()` inside the existing `assert()` block in `MoneyTrackerShell.initState()`, so hard-coded sample reminders ("Phone bill $82", "Gym membership $35") are no longer seeded in release builds.
- Instantiates `_remindersController` before the `assert()` block to ensure the variable is assigned before the closure references it.
- Adds 5 unit tests for `RemindersController` covering empty construction, `seedSample()` content, idempotency, sort order, and notification toggle.

Closes #101

## Test plan

- [x] `flutter analyze` passes with no new issues
- [x] `flutter test test/unit/reminders_controller_test.dart` -- all 5 tests pass
- [x] Full `flutter test` suite -- no regressions (4 pre-existing failures in insights widget tests remain unchanged)
- [ ] Manual: `flutter run` (debug) shows sample reminders on Bill Reminders screen
- [ ] Manual: `flutter build ios --release` shows empty reminders list

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Guard reminder sample data seeding to only occur in debug builds and add unit coverage for RemindersController behavior.

Bug Fixes:
- Prevent hard-coded sample reminders from being seeded in release builds by limiting seeding to debug-only assertions.

Tests:
- Add unit tests for RemindersController covering initial empty state, seedSample behavior and idempotency, reminder sort order, and notification toggle notifications.