### PR TITLE
Fix: Clean up all 22 flutter analyze warnings (#110)

### DIFF
--- a/mobile/lib/features/experiments/infrastructure/experiment_api_client.dart
+++ b/mobile/lib/features/experiments/infrastructure/experiment_api_client.dart
@@ -72,7 +72,7 @@ class ExperimentApiClient {
 
   Future<HttpResponse> _performGet(Uri uri) async {
     if (_httpClient != null) {
-      return _httpClient!.get(uri, headers: _buildHeaders());
+      return _httpClient.get(uri, headers: _buildHeaders());
     }
 
     throw UnimplementedError(
@@ -82,7 +82,7 @@ class ExperimentApiClient {
 
   Future<HttpResponse> _performPost(Uri uri, String body) async {
     if (_httpClient != null) {
-      return _httpClient!.post(uri, body: body, headers: _buildHeaders());
+      return _httpClient.post(uri, body: body, headers: _buildHeaders());
     }
 
     throw UnimplementedError(

--- a/mobile/lib/features/feedback/infrastructure/feedback_api_client.dart
+++ b/mobile/lib/features/feedback/infrastructure/feedback_api_client.dart
@@ -52,7 +52,7 @@ class FeedbackApiClient {
 
   Future<HttpResponse> _performPost(Uri uri, String body) async {
     if (_httpClient != null) {
-      return _httpClient!.post(uri, body: body, headers: _buildHeaders());
+      return _httpClient.post(uri, body: body, headers: _buildHeaders());
     }
 
     throw UnimplementedError(

--- a/mobile/lib/features/insights/presentation/widgets/budget_health_card.dart
+++ b/mobile/lib/features/insights/presentation/widgets/budget_health_card.dart
@@ -151,7 +151,7 @@ class _BreakdownRow extends StatelessWidget {
         SizedBox(
           width: 36,
           child: Text(
-            '${score.toStringAsFixed(0)}',
+            score.toStringAsFixed(0),
             style: theme.textTheme.labelSmall?.copyWith(
               fontWeight: FontWeight.w600,
             ),

--- a/mobile/lib/features/subscriptions/application/restore_purchases_controller.dart
+++ b/mobile/lib/features/subscriptions/application/restore_purchases_controller.dart
@@ -1,4 +1,3 @@
-import 'dart:convert';
 import 'package:flutter/foundation.dart';
 import '../infrastructure/revenuecat_sdk_adapter.dart';
 import '../infrastructure/subscription_gateway.dart';

--- a/mobile/lib/features/subscriptions/application/subscription_state_recovery.dart
+++ b/mobile/lib/features/subscriptions/application/subscription_state_recovery.dart
@@ -2,7 +2,6 @@ import 'package:flutter/foundation.dart';
 import '../infrastructure/revenuecat_sdk_adapter.dart';
 import '../infrastructure/subscription_gateway.dart';
 import 'entitlement_provider.dart';
-import 'restore_purchases_controller.dart';
 
 /// Handles subscription state recovery on app launch.
 /// AC-12: Reconciles local state with RevenueCat on app launch.

--- a/mobile/lib/features/subscriptions/infrastructure/revenuecat_sdk_adapter.dart
+++ b/mobile/lib/features/subscriptions/infrastructure/revenuecat_sdk_adapter.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/foundation.dart';
 import '../domain/offering.dart';
 import '../domain/purchase_result.dart';
 

--- a/mobile/lib/features/subscriptions/infrastructure/subscription_gateway.dart
+++ b/mobile/lib/features/subscriptions/infrastructure/subscription_gateway.dart
@@ -85,7 +85,7 @@ class SubscriptionGateway {
 
   Future<HttpResponse> _performGet(Uri uri) async {
     if (_httpClient != null) {
-      return _httpClient!.get(uri, headers: _buildHeaders());
+      return _httpClient.get(uri, headers: _buildHeaders());
     }
 
     // Default implementation would use dart:io HttpClient
@@ -97,7 +97,7 @@ class SubscriptionGateway {
 
   Future<HttpResponse> _performPost(Uri uri, String body) async {
     if (_httpClient != null) {
-      return _httpClient!.post(uri, body: body, headers: _buildHeaders());
+      return _httpClient.post(uri, body: body, headers: _buildHeaders());
     }
 
     throw UnimplementedError(

--- a/mobile/lib/features/subscriptions/presentation/paywall_screen.dart
+++ b/mobile/lib/features/subscriptions/presentation/paywall_screen.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import '../../../app/theme/app_theme_tokens.dart';
-import '../domain/offering.dart';
 import '../domain/purchase_result.dart';
 import 'paywall_controller.dart';
 import 'plan_card.dart';

--- a/mobile/lib/features/subscriptions/presentation/purchase_success_screen.dart
+++ b/mobile/lib/features/subscriptions/presentation/purchase_success_screen.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import '../../../app/theme/app_theme_tokens.dart';
-import '../domain/feature_key.dart';
 
 /// Post-purchase confirmation screen.
 /// AC-5: Shows purchase success screen after successful purchase.

--- a/mobile/lib/shared_kernel/analytics/activation_tracker.dart
+++ b/mobile/lib/shared_kernel/analytics/activation_tracker.dart
@@ -31,7 +31,7 @@ class ActivationTracker {
   Future<void> restore() async {
     if (_loader == null) return;
     try {
-      final loaded = await _loader!();
+      final loaded = await _loader();
       _recorded.addAll(loaded);
       _restored = true;
     } catch (_) {
@@ -76,7 +76,7 @@ class ActivationTracker {
   Future<void> _save() async {
     if (_saver == null) return;
     try {
-      await _saver!(Set.from(_recorded));
+      await _saver(Set.from(_recorded));
     } catch (_) {
       // Save failure is tolerated.
     }

--- a/mobile/lib/shared_kernel/analytics/analytics_queue.dart
+++ b/mobile/lib/shared_kernel/analytics/analytics_queue.dart
@@ -46,7 +46,7 @@ class AnalyticsQueue {
   Future<void> restore() async {
     if (_loader == null) return;
     try {
-      final events = await _loader!();
+      final events = await _loader();
       _queue.addAll(events);
     } catch (_) {
       // Restore failure is tolerated; events may be lost.
@@ -117,7 +117,7 @@ class AnalyticsQueue {
   Future<void> _persist() async {
     if (_persister == null) return;
     try {
-      await _persister!(_queue.toList());
+      await _persister(_queue.toList());
     } catch (_) {
       // Persist failure is tolerated.
     }

--- a/mobile/test/unit/analytics/activation_tracker_test.dart
+++ b/mobile/test/unit/analytics/activation_tracker_test.dart
@@ -6,7 +6,7 @@ import 'package:money_tracker/shared_kernel/analytics/analytics_service.dart';
 
 void main() {
   group('ActivationTracker', () {
-    QueuedAnalyticsService _makeService(List<List<AnalyticsEvent>> sent) {
+    QueuedAnalyticsService makeService(List<List<AnalyticsEvent>> sent) {
       final queue = AnalyticsQueue(
         sender: (batch) async {
           sent.add(List.of(batch));
@@ -23,7 +23,7 @@ void main() {
     test('trackIfNew tracks first occurrence and returns true', () async {
       final sent = <List<AnalyticsEvent>>[];
       final tracker = ActivationTracker(
-        analyticsService: _makeService(sent),
+        analyticsService: makeService(sent),
       );
 
       final result = await tracker.trackIfNew('signup_completed');
@@ -36,7 +36,7 @@ void main() {
     test('trackIfNew returns false for duplicate milestone', () async {
       final sent = <List<AnalyticsEvent>>[];
       final tracker = ActivationTracker(
-        analyticsService: _makeService(sent),
+        analyticsService: makeService(sent),
       );
 
       await tracker.trackIfNew('signup_completed');
@@ -49,7 +49,7 @@ void main() {
     test('trackIfNew tracks different milestones independently', () async {
       final sent = <List<AnalyticsEvent>>[];
       final tracker = ActivationTracker(
-        analyticsService: _makeService(sent),
+        analyticsService: makeService(sent),
       );
 
       final r1 = await tracker.trackIfNew('signup_completed');
@@ -63,7 +63,7 @@ void main() {
     test('trackIfNew passes householdId and metadata through', () async {
       final sent = <List<AnalyticsEvent>>[];
       final tracker = ActivationTracker(
-        analyticsService: _makeService(sent),
+        analyticsService: makeService(sent),
       );
 
       await tracker.trackIfNew(
@@ -79,7 +79,7 @@ void main() {
     test('restore loads previously recorded milestones', () async {
       final sent = <List<AnalyticsEvent>>[];
       final tracker = ActivationTracker(
-        analyticsService: _makeService(sent),
+        analyticsService: makeService(sent),
         loader: () async => {'signup_completed'},
       );
 
@@ -94,7 +94,7 @@ void main() {
     test('restore tolerates loader failure', () async {
       final sent = <List<AnalyticsEvent>>[];
       final tracker = ActivationTracker(
-        analyticsService: _makeService(sent),
+        analyticsService: makeService(sent),
         loader: () async => throw Exception('storage error'),
       );
 
@@ -121,7 +121,7 @@ void main() {
     test('reset clears recorded milestones', () async {
       final sent = <List<AnalyticsEvent>>[];
       final tracker = ActivationTracker(
-        analyticsService: _makeService(sent),
+        analyticsService: makeService(sent),
       );
 
       await tracker.trackIfNew('signup_completed');
@@ -139,7 +139,7 @@ void main() {
     test('auto-restores on first trackIfNew if loader is set', () async {
       final sent = <List<AnalyticsEvent>>[];
       final tracker = ActivationTracker(
-        analyticsService: _makeService(sent),
+        analyticsService: makeService(sent),
         loader: () async => {'signup_completed'},
       );
 

--- a/mobile/test/unit/analytics/analytics_queue_test.dart
+++ b/mobile/test/unit/analytics/analytics_queue_test.dart
@@ -4,7 +4,7 @@ import 'package:money_tracker/shared_kernel/analytics/analytics_queue.dart';
 
 void main() {
   group('AnalyticsQueue', () {
-    AnalyticsEvent _makeEvent(String milestone) => AnalyticsEvent(
+    AnalyticsEvent makeEvent(String milestone) => AnalyticsEvent(
           milestone: milestone,
           occurredAtUtc: DateTime.utc(2026, 3, 7, 12, 0, 0),
         );
@@ -19,10 +19,10 @@ void main() {
         batchSize: 2,
       );
 
-      await queue.enqueue(_makeEvent('signup_completed'));
+      await queue.enqueue(makeEvent('signup_completed'));
       expect(sent.length, 0); // Not yet at batch size.
 
-      await queue.enqueue(_makeEvent('household_created'));
+      await queue.enqueue(makeEvent('household_created'));
       expect(sent.length, 1);
       expect(sent.first.length, 2);
       expect(sent.first[0].milestone, 'signup_completed');
@@ -39,8 +39,8 @@ void main() {
         batchSize: 100, // Large batch size to prevent auto-flush.
       );
 
-      await queue.enqueue(_makeEvent('signup_completed'));
-      await queue.enqueue(_makeEvent('household_created'));
+      await queue.enqueue(makeEvent('signup_completed'));
+      await queue.enqueue(makeEvent('household_created'));
       expect(sent.length, 0);
 
       await queue.flush();
@@ -61,7 +61,7 @@ void main() {
         batchSize: 100,
       );
 
-      await queue.enqueue(_makeEvent('signup_completed'));
+      await queue.enqueue(makeEvent('signup_completed'));
       await queue.flush(); // First attempt fails.
       expect(queue.length, 1); // Event retained.
       expect(sent.length, 0);
@@ -77,7 +77,7 @@ void main() {
         batchSize: 100,
       );
 
-      await queue.enqueue(_makeEvent('signup_completed'));
+      await queue.enqueue(makeEvent('signup_completed'));
       await queue.flush(); // Should not throw.
       expect(queue.length, 1); // Event retained.
     });
@@ -104,7 +104,7 @@ void main() {
         batchSize: 100,
       );
 
-      await queue.enqueue(_makeEvent('signup_completed'));
+      await queue.enqueue(makeEvent('signup_completed'));
       expect(persisted.length, 1);
       expect(persisted.last.length, 1);
 
@@ -116,7 +116,7 @@ void main() {
     test('restore loads events from loader', () async {
       final queue = AnalyticsQueue(
         sender: (_) async => true,
-        loader: () async => [_makeEvent('signup_completed')],
+        loader: () async => [makeEvent('signup_completed')],
         batchSize: 100,
       );
 

--- a/mobile/test/unit/entitlement_provider_test.dart
+++ b/mobile/test/unit/entitlement_provider_test.dart
@@ -48,12 +48,6 @@ void main() {
     'currentPeriodEndUtc': '2026-04-01T00:00:00Z',
   });
 
-  final freeResponse = jsonEncode({
-    'tier': 'Free',
-    'featureKeys': <String>[],
-    'trialExpiresAtUtc': null,
-    'currentPeriodEndUtc': null,
-  });
 
   setUp(() {
     httpClient = StubHttpClient(

--- a/mobile/test/unit/offerings_provider_test.dart
+++ b/mobile/test/unit/offerings_provider_test.dart
@@ -1,7 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:money_tracker/features/subscriptions/application/offerings_provider.dart';
 import 'package:money_tracker/features/subscriptions/domain/offering.dart';
-import 'package:money_tracker/features/subscriptions/domain/purchase_result.dart';
 import 'package:money_tracker/features/subscriptions/infrastructure/revenuecat_sdk_adapter.dart';
 
 Offering _buildDefaultOffering() {

--- a/mobile/test/unit/restore_purchases_controller_test.dart
+++ b/mobile/test/unit/restore_purchases_controller_test.dart
@@ -2,7 +2,6 @@ import 'dart:convert';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:money_tracker/features/subscriptions/application/entitlement_provider.dart';
 import 'package:money_tracker/features/subscriptions/application/restore_purchases_controller.dart';
-import 'package:money_tracker/features/subscriptions/domain/subscription_tier.dart';
 import 'package:money_tracker/features/subscriptions/infrastructure/revenuecat_sdk_adapter.dart';
 import 'package:money_tracker/features/subscriptions/infrastructure/subscription_gateway.dart';
 
@@ -68,12 +67,6 @@ void main() {
     'currentPeriodEndUtc': '2026-04-01T00:00:00Z',
   });
 
-  final restoreNoneResponse = jsonEncode({
-    'status': 'None',
-    'tier': 'Free',
-    'featureKeys': <String>[],
-    'currentPeriodEndUtc': null,
-  });
 
   setUp(() {
     sdkAdapter = InMemoryRevenueCatSdkAdapter(

--- a/mobile/test/widget/paywall_screen_test.dart
+++ b/mobile/test/widget/paywall_screen_test.dart
@@ -6,7 +6,6 @@ import 'package:money_tracker/features/subscriptions/application/entitlement_pro
 import 'package:money_tracker/features/subscriptions/application/offerings_provider.dart';
 import 'package:money_tracker/features/subscriptions/application/purchase_controller.dart';
 import 'package:money_tracker/features/subscriptions/domain/offering.dart';
-import 'package:money_tracker/features/subscriptions/domain/purchase_result.dart';
 import 'package:money_tracker/features/subscriptions/infrastructure/revenuecat_sdk_adapter.dart';
 import 'package:money_tracker/features/subscriptions/infrastructure/subscription_gateway.dart';
 import 'package:money_tracker/features/subscriptions/presentation/paywall_controller.dart';


### PR DESCRIPTION
## Summary
- Removes 9 unnecessary non-null assertion operators (`!`) in null-guarded blocks where Dart type promotion already narrows the type
- Removes 8 unused imports across production and test files
- Removes 2 unused local variables (`freeResponse`, `restoreNoneResponse`) in test setup
- Fixes 1 unnecessary string interpolation wrapping `score.toStringAsFixed(0)`
- Renames 2 local test helpers (`_makeService` -> `makeService`, `_makeEvent` -> `makeEvent`) to comply with `no_leading_underscores_for_local_identifiers`

## Verification
- `flutter analyze` reports **0 issues** (was 22)
- `flutter test` passes all **201 tests** with 0 failures
- No behavioral changes -- all fixes are purely cosmetic/hygienic

## Files changed (17)
| Category | Files |
|----------|-------|
| Unnecessary `!` (9) | `experiment_api_client.dart`, `feedback_api_client.dart`, `subscription_gateway.dart`, `activation_tracker.dart`, `analytics_queue.dart` |
| Unused imports (8) | `restore_purchases_controller.dart`, `subscription_state_recovery.dart`, `revenuecat_sdk_adapter.dart`, `paywall_screen.dart`, `purchase_success_screen.dart`, `offerings_provider_test.dart`, `restore_purchases_controller_test.dart`, `paywall_screen_test.dart` |
| Unused variables (2) | `entitlement_provider_test.dart`, `restore_purchases_controller_test.dart` |
| String interpolation (1) | `budget_health_card.dart` |
| Leading underscores (2) | `activation_tracker_test.dart`, `analytics_queue_test.dart` |

Closes #110

## Test plan
- [x] `flutter analyze` -- 0 issues
- [x] `flutter test` -- 201 tests pass, 0 failures
- [x] No production logic changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Resolve static analysis warnings across production and test code to achieve a clean `flutter analyze` run without changing runtime behavior.

Bug Fixes:
- Remove unnecessary non-null assertion operators in HTTP client and analytics helpers where null checks already guarantee non-null values.
- Remove unused local variables from subscription-related tests to eliminate dead code paths.
- Simplify a string interpolation in the budget health UI widget to avoid redundant formatting.

Enhancements:
- Clean up unused imports across subscription, feedback, and paywall modules and associated tests.
- Align local test helper naming in analytics tests with lint rules by removing leading underscores from non-private identifiers.

Tests:
- Keep all existing tests passing while updating test helpers and removing unused test data to satisfy analyzer lints without altering test coverage.