### PR TITLE
Fix: Validate feedback description before submission (#109)

### DIFF
--- a/mobile/lib/features/feedback/domain/feedback_submission.dart
+++ b/mobile/lib/features/feedback/domain/feedback_submission.dart
@@ -19,6 +19,9 @@ class FeedbackSubmission {
   final String? deviceModel;
   final String? osVersion;
 
+  /// Minimum description length.
+  static const int minDescriptionLength = 10;
+
   /// Maximum description length.
   static const int maxDescriptionLength = 5000;
 
@@ -27,6 +30,9 @@ class FeedbackSubmission {
   String? validate() {
     if (description.trim().isEmpty) {
       return 'Description is required.';
+    }
+    if (description.trim().length < minDescriptionLength) {
+      return 'Description must be at least $minDescriptionLength characters.';
     }
     if (description.length > maxDescriptionLength) {
       return 'Description exceeds maximum length of $maxDescriptionLength characters.';

--- a/mobile/lib/features/feedback/presentation/feedback_form_screen.dart
+++ b/mobile/lib/features/feedback/presentation/feedback_form_screen.dart
@@ -52,19 +52,40 @@ class FeedbackFormScreen extends StatefulWidget {
 }
 
 class _FeedbackFormScreenState extends State<FeedbackFormScreen> {
+  final _formKey = GlobalKey<FormState>();
   FeedbackCategory _selectedCategory = FeedbackCategory.general;
   final _descriptionController = TextEditingController();
   int _rating = 3;
   bool _isSubmitting = false;
+  bool _isDescriptionValid = false;
   String? _errorMessage;
 
   @override
+  void initState() {
+    super.initState();
+    _descriptionController.addListener(_onDescriptionChanged);
+  }
+
+  void _onDescriptionChanged() {
+    final valid = _descriptionController.text.trim().length >=
+        FeedbackSubmission.minDescriptionLength;
+    if (valid != _isDescriptionValid) {
+      setState(() {
+        _isDescriptionValid = valid;
+      });
+    }
+  }
+
+  @override
   void dispose() {
+    _descriptionController.removeListener(_onDescriptionChanged);
     _descriptionController.dispose();
     super.dispose();
   }
 
   Future<void> _submit() async {
+    if (!_formKey.currentState!.validate()) return;
+
     setState(() {
       _isSubmitting = true;
       _errorMessage = null;
@@ -111,120 +132,134 @@ class _FeedbackFormScreenState extends State<FeedbackFormScreen> {
       ),
       body: SingleChildScrollView(
         padding: EdgeInsets.all(tokens.space4),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            // Category selector
-            Text(
-              'Category',
-              style: Theme.of(context).textTheme.titleSmall?.copyWith(
-                    fontWeight: FontWeight.w600,
-                  ),
-            ),
-            SizedBox(height: tokens.space2),
-            SegmentedButton<FeedbackCategory>(
-              segments: const [
-                ButtonSegment(
-                  value: FeedbackCategory.bug,
-                  label: Text('Bug'),
-                  icon: Icon(Icons.bug_report),
-                ),
-                ButtonSegment(
-                  value: FeedbackCategory.feature,
-                  label: Text('Feature'),
-                  icon: Icon(Icons.lightbulb),
-                ),
-                ButtonSegment(
-                  value: FeedbackCategory.general,
-                  label: Text('General'),
-                  icon: Icon(Icons.chat),
-                ),
-              ],
-              selected: {_selectedCategory},
-              onSelectionChanged: (selected) {
-                setState(() {
-                  _selectedCategory = selected.first;
-                });
-              },
-            ),
-            SizedBox(height: tokens.space4),
-
-            // Description
-            Text(
-              'Description',
-              style: Theme.of(context).textTheme.titleSmall?.copyWith(
-                    fontWeight: FontWeight.w600,
-                  ),
-            ),
-            SizedBox(height: tokens.space2),
-            TextField(
-              controller: _descriptionController,
-              maxLines: 5,
-              maxLength: FeedbackSubmission.maxDescriptionLength,
-              decoration: const InputDecoration(
-                hintText: 'Tell us what you think...',
-                border: OutlineInputBorder(),
+        child: Form(
+          key: _formKey,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              // Category selector
+              Text(
+                'Category',
+                style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                      fontWeight: FontWeight.w600,
+                    ),
               ),
-            ),
-            SizedBox(height: tokens.space4),
-
-            // Rating
-            Text(
-              'Rating',
-              style: Theme.of(context).textTheme.titleSmall?.copyWith(
-                    fontWeight: FontWeight.w600,
+              SizedBox(height: tokens.space2),
+              SegmentedButton<FeedbackCategory>(
+                segments: const [
+                  ButtonSegment(
+                    value: FeedbackCategory.bug,
+                    label: Text('Bug'),
+                    icon: Icon(Icons.bug_report),
                   ),
-            ),
-            SizedBox(height: tokens.space2),
-            Row(
-              mainAxisAlignment: MainAxisAlignment.center,
-              children: List.generate(5, (index) {
-                final starRating = index + 1;
-                return IconButton(
-                  icon: Icon(
-                    starRating <= _rating ? Icons.star : Icons.star_border,
-                    color: starRating <= _rating
-                        ? Theme.of(context).colorScheme.primary
-                        : tokens.contentMuted,
-                    size: 36,
+                  ButtonSegment(
+                    value: FeedbackCategory.feature,
+                    label: Text('Feature'),
+                    icon: Icon(Icons.lightbulb),
                   ),
-                  onPressed: () {
-                    setState(() {
-                      _rating = starRating;
-                    });
-                  },
-                );
-              }),
-            ),
-            SizedBox(height: tokens.space4),
+                  ButtonSegment(
+                    value: FeedbackCategory.general,
+                    label: Text('General'),
+                    icon: Icon(Icons.chat),
+                  ),
+                ],
+                selected: {_selectedCategory},
+                onSelectionChanged: (selected) {
+                  setState(() {
+                    _selectedCategory = selected.first;
+                  });
+                },
+              ),
+              SizedBox(height: tokens.space4),
 
-            // Error message
-            if (_errorMessage != null)
-              Padding(
-                padding: EdgeInsets.only(bottom: tokens.space3),
-                child: Text(
-                  _errorMessage!,
-                  style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                        color: Theme.of(context).colorScheme.error,
-                      ),
+              // Description
+              Text(
+                'Description',
+                style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                      fontWeight: FontWeight.w600,
+                    ),
+              ),
+              SizedBox(height: tokens.space2),
+              TextFormField(
+                controller: _descriptionController,
+                maxLines: 5,
+                maxLength: FeedbackSubmission.maxDescriptionLength,
+                decoration: const InputDecoration(
+                  hintText: 'Tell us what you think...',
+                  border: OutlineInputBorder(),
+                ),
+                validator: (value) {
+                  if (value == null || value.trim().isEmpty) {
+                    return 'Please enter a description';
+                  }
+                  if (value.trim().length <
+                      FeedbackSubmission.minDescriptionLength) {
+                    return 'Description must be at least ${FeedbackSubmission.minDescriptionLength} characters';
+                  }
+                  return null;
+                },
+              ),
+              SizedBox(height: tokens.space4),
+
+              // Rating
+              Text(
+                'Rating',
+                style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                      fontWeight: FontWeight.w600,
+                    ),
+              ),
+              SizedBox(height: tokens.space2),
+              Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: List.generate(5, (index) {
+                  final starRating = index + 1;
+                  return IconButton(
+                    icon: Icon(
+                      starRating <= _rating ? Icons.star : Icons.star_border,
+                      color: starRating <= _rating
+                          ? Theme.of(context).colorScheme.primary
+                          : tokens.contentMuted,
+                      size: 36,
+                    ),
+                    onPressed: () {
+                      setState(() {
+                        _rating = starRating;
+                      });
+                    },
+                  );
+                }),
+              ),
+              SizedBox(height: tokens.space4),
+
+              // Error message
+              if (_errorMessage != null)
+                Padding(
+                  padding: EdgeInsets.only(bottom: tokens.space3),
+                  child: Text(
+                    _errorMessage!,
+                    style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                          color: Theme.of(context).colorScheme.error,
+                        ),
+                  ),
+                ),
+
+              // Submit button
+              SizedBox(
+                width: double.infinity,
+                child: FilledButton(
+                  onPressed:
+                      _isSubmitting || !_isDescriptionValid ? null : _submit,
+                  child: _isSubmitting
+                      ? const SizedBox(
+                          height: 20,
+                          width: 20,
+                          child: CircularProgressIndicator(strokeWidth: 2),
+                        )
+                      : const Text('Submit Feedback'),
                 ),
               ),
-
-            // Submit button
-            SizedBox(
-              width: double.infinity,
-              child: FilledButton(
-                onPressed: _isSubmitting ? null : _submit,
-                child: _isSubmitting
-                    ? const SizedBox(
-                        height: 20,
-                        width: 20,
-                        child: CircularProgressIndicator(strokeWidth: 2),
-                      )
-                    : const Text('Submit Feedback'),
-              ),
-            ),
-          ],
+            ],
+          ),
         ),
       ),
     );

--- a/mobile/test/unit/feedback/feedback_service_test.dart
+++ b/mobile/test/unit/feedback/feedback_service_test.dart
@@ -119,13 +119,29 @@ void main() {
 
       const submission = FeedbackSubmission(
         category: FeedbackCategory.bug,
-        description: 'Some bug',
+        description: 'Some bug report here',
         rating: 3,
       );
 
       final result = await failService.submitFeedback(submission);
 
       expect(result, isA<FeedbackFailure>());
+    });
+
+    test('submitFeedback returns failure for too-short description', () async {
+      const submission = FeedbackSubmission(
+        category: FeedbackCategory.general,
+        description: 'Short',
+        rating: 3,
+      );
+
+      final result = await service.submitFeedback(submission);
+
+      expect(result, isA<FeedbackFailure>());
+      expect(
+        (result as FeedbackFailure).errorMessage,
+        contains('at least'),
+      );
     });
   });
 }

--- a/mobile/test/unit/feedback/feedback_submission_test.dart
+++ b/mobile/test/unit/feedback/feedback_submission_test.dart
@@ -25,6 +25,42 @@ void main() {
       expect(submission.validate(), contains('Description is required'));
     });
 
+    test('validate returns error for whitespace-only description', () {
+      const submission = FeedbackSubmission(
+        category: FeedbackCategory.general,
+        description: '     ',
+        rating: 3,
+      );
+
+      expect(submission.validate(), isNotNull);
+      expect(submission.validate(), contains('Description is required'));
+    });
+
+    test(
+        'validate returns error for description shorter than minDescriptionLength',
+        () {
+      const submission = FeedbackSubmission(
+        category: FeedbackCategory.general,
+        description: 'Short',
+        rating: 3,
+      );
+
+      expect(submission.validate(), isNotNull);
+      expect(submission.validate(), contains('at least'));
+    });
+
+    test(
+        'validate returns null for description exactly at minDescriptionLength',
+        () {
+      final submission = FeedbackSubmission(
+        category: FeedbackCategory.general,
+        description: 'a' * FeedbackSubmission.minDescriptionLength,
+        rating: 3,
+      );
+
+      expect(submission.validate(), isNull);
+    });
+
     test('validate returns error for description exceeding max length', () {
       final submission = FeedbackSubmission(
         category: FeedbackCategory.general,

--- a/mobile/test/widget/feedback/feedback_form_screen_test.dart
+++ b/mobile/test/widget/feedback/feedback_form_screen_test.dart
@@ -1,0 +1,196 @@
+import 'dart:convert';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:money_tracker/app/theme/money_tracker_theme.dart';
+import 'package:money_tracker/features/feedback/application/feedback_service.dart';
+import 'package:money_tracker/features/feedback/infrastructure/feedback_api_client.dart';
+import 'package:money_tracker/features/feedback/presentation/feedback_form_screen.dart';
+import 'package:money_tracker/features/subscriptions/infrastructure/subscription_gateway.dart';
+
+class StubHttpClient implements HttpClientAdapter {
+  StubHttpClient({
+    required this.statusCode,
+    required this.responseBody,
+  });
+
+  final int statusCode;
+  final String responseBody;
+
+  @override
+  Future<HttpResponse> get(Uri uri, {Map<String, String>? headers}) async {
+    return HttpResponse(statusCode: statusCode, body: responseBody);
+  }
+
+  @override
+  Future<HttpResponse> post(Uri uri,
+      {String? body, Map<String, String>? headers}) async {
+    return HttpResponse(statusCode: statusCode, body: responseBody);
+  }
+}
+
+FeedbackService _createService({int statusCode = 200}) {
+  final httpClient = StubHttpClient(
+    statusCode: statusCode,
+    responseBody: jsonEncode({
+      'feedbackId': '123e4567-e89b-12d3-a456-426614174000',
+      'status': 'New',
+    }),
+  );
+  final apiClient = FeedbackApiClient(
+    apiBaseUrl: Uri.parse('https://api.example.com'),
+    tokenProvider: () => 'test-token',
+    httpClient: httpClient,
+  );
+  return FeedbackService(apiClient: apiClient);
+}
+
+Widget _buildTestApp({required FeedbackService feedbackService}) {
+  return MaterialApp(
+    theme: MoneyTrackerTheme.light(),
+    home: FeedbackFormScreen(feedbackService: feedbackService),
+  );
+}
+
+void main() {
+  group('FeedbackFormScreen validation', () {
+    testWidgets('submit button is disabled when description is empty',
+        (tester) async {
+      final service = _createService();
+
+      await tester.pumpWidget(_buildTestApp(feedbackService: service));
+      await tester.pumpAndSettle();
+
+      // Submit button should be disabled when description is empty.
+      final submitButton = tester.widget<FilledButton>(
+        find.byType(FilledButton),
+      );
+      expect(submitButton.onPressed, isNull);
+
+      // No error text should be visible initially.
+      expect(find.text('Please enter a description'), findsNothing);
+    });
+
+    testWidgets(
+        'submit button is disabled when description is too short',
+        (tester) async {
+      final service = _createService();
+
+      await tester.pumpWidget(_buildTestApp(feedbackService: service));
+      await tester.pumpAndSettle();
+
+      // Enter a short description (less than 10 chars).
+      await tester.enterText(find.byType(TextFormField), 'Short');
+      await tester.pumpAndSettle();
+
+      // Button should still be disabled (5 chars < 10 min).
+      final submitButton = tester.widget<FilledButton>(
+        find.byType(FilledButton),
+      );
+      expect(submitButton.onPressed, isNull);
+    });
+
+    testWidgets(
+        'submit button is enabled when description meets minimum length',
+        (tester) async {
+      final service = _createService();
+
+      await tester.pumpWidget(_buildTestApp(feedbackService: service));
+      await tester.pumpAndSettle();
+
+      // Enter a valid description (>= 10 chars).
+      await tester.enterText(
+        find.byType(TextFormField),
+        'This is valid feedback text',
+      );
+      await tester.pumpAndSettle();
+
+      final submitButton = tester.widget<FilledButton>(
+        find.byType(FilledButton),
+      );
+      expect(submitButton.onPressed, isNotNull);
+    });
+
+    testWidgets(
+        'submit button transitions from disabled to enabled as user types',
+        (tester) async {
+      final service = _createService();
+
+      await tester.pumpWidget(_buildTestApp(feedbackService: service));
+      await tester.pumpAndSettle();
+
+      // Initially disabled.
+      var submitButton = tester.widget<FilledButton>(
+        find.byType(FilledButton),
+      );
+      expect(submitButton.onPressed, isNull);
+
+      // Type 9 characters -- still disabled.
+      await tester.enterText(find.byType(TextFormField), '123456789');
+      await tester.pumpAndSettle();
+
+      submitButton = tester.widget<FilledButton>(
+        find.byType(FilledButton),
+      );
+      expect(submitButton.onPressed, isNull);
+
+      // Type 10 characters -- now enabled.
+      await tester.enterText(find.byType(TextFormField), '1234567890');
+      await tester.pumpAndSettle();
+
+      submitButton = tester.widget<FilledButton>(
+        find.byType(FilledButton),
+      );
+      expect(submitButton.onPressed, isNotNull);
+    });
+
+    testWidgets('successful submission pops the screen and shows snackbar',
+        (tester) async {
+      final service = _createService();
+
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: MoneyTrackerTheme.light(),
+          home: Builder(
+            builder: (context) => Scaffold(
+              body: ElevatedButton(
+                onPressed: () {
+                  Navigator.of(context).push(
+                    MaterialPageRoute(
+                      builder: (_) =>
+                          FeedbackFormScreen(feedbackService: service),
+                    ),
+                  );
+                },
+                child: const Text('Open Feedback'),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // Navigate to the feedback form.
+      await tester.tap(find.text('Open Feedback'));
+      await tester.pumpAndSettle();
+
+      // Enter a valid description.
+      await tester.enterText(
+        find.byType(TextFormField),
+        'This is valid feedback text for testing',
+      );
+      await tester.pumpAndSettle();
+
+      // Tap the submit button.
+      await tester.tap(find.byType(FilledButton));
+      await tester.pumpAndSettle();
+
+      // Should show a snackbar with success message.
+      expect(find.text('Thank you for your feedback!'), findsOneWidget);
+
+      // Should have popped back to the previous screen.
+      expect(find.text('Open Feedback'), findsOneWidget);
+      expect(find.byType(FeedbackFormScreen), findsNothing);
+    });
+  });
+}
+


### PR DESCRIPTION
## Summary
- Adds client-side form validation to the feedback form, preventing submission of empty or too-short descriptions (minimum 10 characters)
- Submit button is reactively disabled until the description meets the minimum length requirement
- Adds `minDescriptionLength` constant and validation check to the domain model (`FeedbackSubmission`) as defense-in-depth

## Changes

### Domain layer (`feedback_submission.dart`)
- Added `static const int minDescriptionLength = 10`
- Updated `validate()` to reject descriptions shorter than `minDescriptionLength` (after trimming)

### Presentation layer (`feedback_form_screen.dart`)
- Added `GlobalKey<FormState> _formKey` and wrapped form content in a `Form` widget
- Replaced `TextField` with `TextFormField` including inline `validator` callback
- Added `_onDescriptionChanged` listener to reactively enable/disable submit button
- Gated `_submit()` behind `_formKey.currentState!.validate()`
- Submit button is now disabled when `_isDescriptionValid` is false

### Tests
- **`feedback_submission_test.dart`**: Added 3 new tests (whitespace-only, below min length, exactly at min length)
- **`feedback_service_test.dart`**: Added test for too-short description rejection; fixed existing test with description that was under new minimum
- **`feedback_form_screen_test.dart`** (new): 5 widget tests covering button disabled/enabled states, transition behavior, and successful submission flow

## Test plan
- [x] `flutter analyze` passes (no new issues)
- [x] All 39 feedback-related tests pass (unit + widget)
- [x] Existing tests unaffected

Closes #109

🤖 Generated with [Claude Code](https://claude.com/claude-code)