### PR TITLE
Fix: Replace hardcoded colors with theme tokens in insights widgets (#104)

### DIFF
--- a/mobile/lib/features/insights/presentation/widgets/budget_health_card.dart
+++ b/mobile/lib/features/insights/presentation/widgets/budget_health_card.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+import '../../../../app/theme/app_theme_tokens.dart';
 import '../../domain/budget_health.dart';
 
 /// Displays the composite budget health score as a colored ring gauge
@@ -12,16 +13,17 @@ class BudgetHealthCard extends StatelessWidget {
 
   final BudgetHealth health;
 
-  Color _scoreColor(int score) {
-    if (score >= 80) return Colors.green;
-    if (score >= 50) return Colors.orange;
-    return Colors.red;
+  Color _scoreColor(int score, AppThemeTokens tokens) {
+    if (score >= 80) return tokens.stateSuccess;
+    if (score >= 50) return tokens.stateWarning;
+    return tokens.stateDanger;
   }
 
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final scoreColor = _scoreColor(health.overallScore);
+    final tokens = AppThemeTokens.of(context);
+    final scoreColor = _scoreColor(health.overallScore, tokens);
 
     return Card(
       child: Padding(
@@ -151,7 +153,7 @@ class _BreakdownRow extends StatelessWidget {
         SizedBox(
           width: 36,
           child: Text(
-            '${score.toStringAsFixed(0)}',
+            score.toStringAsFixed(0),
             style: theme.textTheme.labelSmall?.copyWith(
               fontWeight: FontWeight.w600,
             ),
@@ -168,16 +170,16 @@ class _CategoryStatusRow extends StatelessWidget {
 
   final CategoryHealth category;
 
-  Color _statusColor(String status) {
+  Color _statusColor(String status, AppThemeTokens tokens) {
     switch (status) {
       case 'OnTrack':
-        return Colors.green;
+        return tokens.stateSuccess;
       case 'AtRisk':
-        return Colors.orange;
+        return tokens.stateWarning;
       case 'OverBudget':
-        return Colors.red;
+        return tokens.stateDanger;
       default:
-        return Colors.grey;
+        return tokens.contentMuted;
     }
   }
 
@@ -197,7 +199,8 @@ class _CategoryStatusRow extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final color = _statusColor(category.status);
+    final tokens = AppThemeTokens.of(context);
+    final color = _statusColor(category.status, tokens);
 
     return Padding(
       padding: const EdgeInsets.only(bottom: 6),

--- a/mobile/lib/features/insights/presentation/widgets/spending_trend_chart.dart
+++ b/mobile/lib/features/insights/presentation/widgets/spending_trend_chart.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+import '../../../../app/theme/app_theme_tokens.dart';
 import '../../domain/spending_analysis.dart';
 
 /// Displays a bar chart comparing current vs previous period spending
@@ -122,7 +123,9 @@ class _CategoryBar extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final currentFraction = maxValue > 0 ? category.currentSpent / maxValue : 0.0;
+    final tokens = AppThemeTokens.of(context);
+    final currentFraction =
+        maxValue > 0 ? category.currentSpent / maxValue : 0.0;
     final previousFraction =
         maxValue > 0 ? category.previousSpent / maxValue : 0.0;
 
@@ -134,7 +137,7 @@ class _CategoryBar extends StatelessWidget {
         ? theme.colorScheme.error
         : category.changePercent > 0
             ? theme.colorScheme.tertiary
-            : Colors.green;
+            : tokens.stateSuccess;
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -167,7 +170,9 @@ class _CategoryBar extends StatelessWidget {
               children: [
                 FractionallySizedBox(
                   widthFactor: previousFraction,
-                  child: Container(color: theme.colorScheme.outline.withValues(alpha: 0.4)),
+                  child: Container(
+                    color: theme.colorScheme.outline.withValues(alpha: 0.4),
+                  ),
                 ),
                 FractionallySizedBox(
                   widthFactor: currentFraction,

--- a/mobile/test/component/insights/budget_health_card_test.dart
+++ b/mobile/test/component/insights/budget_health_card_test.dart
@@ -1,11 +1,22 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:money_tracker/app/theme/app_theme_tokens.dart';
 import 'package:money_tracker/features/insights/domain/budget_health.dart';
 import 'package:money_tracker/features/insights/presentation/widgets/budget_health_card.dart';
 
 void main() {
-  Widget buildTestWidget(BudgetHealth health) {
+  Widget buildTestWidget(
+    BudgetHealth health, {
+    Brightness brightness = Brightness.light,
+  }) {
+    final theme = ThemeData(brightness: brightness).copyWith(
+      extensions: <ThemeExtension<dynamic>>[
+        AppThemeTokens.fromBrightness(brightness),
+      ],
+    );
+
     return MaterialApp(
+      theme: theme,
       home: Scaffold(
         body: SingleChildScrollView(
           child: BudgetHealthCard(health: health),
@@ -103,5 +114,177 @@ void main() {
       expect(find.text('Dining'), findsOneWidget);
       expect(find.text('Over budget'), findsOneWidget);
     });
+  });
+
+  group('BudgetHealthCard score colors', () {
+    for (final brightness in Brightness.values) {
+      final modeName = brightness == Brightness.light ? 'light' : 'dark';
+      final tokens = AppThemeTokens.fromBrightness(brightness);
+
+      testWidgets(
+        'uses stateSuccess color for score >= 80 ($modeName mode)',
+        (tester) async {
+          final health = BudgetHealth(
+            householdId: 'test',
+            periodStartUtc: '2026-03-01T00:00:00Z',
+            periodEndUtc: '2026-04-01T00:00:00Z',
+            overallScore: 95,
+            scoreBreakdown: const ScoreBreakdown(
+              adherenceScore: 90,
+              adherenceWeight: 0.40,
+              velocityScore: 95,
+              velocityWeight: 0.35,
+              billPaymentScore: 100,
+              billPaymentWeight: 0.25,
+            ),
+            categoryHealth: const [],
+          );
+
+          await tester
+              .pumpWidget(buildTestWidget(health, brightness: brightness));
+
+          final indicator = tester.widget<CircularProgressIndicator>(
+            find.byType(CircularProgressIndicator),
+          );
+          final animation =
+              indicator.valueColor! as AlwaysStoppedAnimation<Color>;
+          expect(animation.value, equals(tokens.stateSuccess));
+        },
+      );
+
+      testWidgets(
+        'uses stateWarning color for score >= 50 and < 80 ($modeName mode)',
+        (tester) async {
+          final health = BudgetHealth(
+            householdId: 'test',
+            periodStartUtc: '2026-03-01T00:00:00Z',
+            periodEndUtc: '2026-04-01T00:00:00Z',
+            overallScore: 65,
+            scoreBreakdown: const ScoreBreakdown(
+              adherenceScore: 60,
+              adherenceWeight: 0.40,
+              velocityScore: 70,
+              velocityWeight: 0.35,
+              billPaymentScore: 65,
+              billPaymentWeight: 0.25,
+            ),
+            categoryHealth: const [],
+          );
+
+          await tester
+              .pumpWidget(buildTestWidget(health, brightness: brightness));
+
+          final indicator = tester.widget<CircularProgressIndicator>(
+            find.byType(CircularProgressIndicator),
+          );
+          final animation =
+              indicator.valueColor! as AlwaysStoppedAnimation<Color>;
+          expect(animation.value, equals(tokens.stateWarning));
+        },
+      );
+
+      testWidgets(
+        'uses stateDanger color for score < 50 ($modeName mode)',
+        (tester) async {
+          final health = BudgetHealth(
+            householdId: 'test',
+            periodStartUtc: '2026-03-01T00:00:00Z',
+            periodEndUtc: '2026-04-01T00:00:00Z',
+            overallScore: 30,
+            scoreBreakdown: const ScoreBreakdown(
+              adherenceScore: 30,
+              adherenceWeight: 0.40,
+              velocityScore: 25,
+              velocityWeight: 0.35,
+              billPaymentScore: 35,
+              billPaymentWeight: 0.25,
+            ),
+            categoryHealth: const [],
+          );
+
+          await tester
+              .pumpWidget(buildTestWidget(health, brightness: brightness));
+
+          final indicator = tester.widget<CircularProgressIndicator>(
+            find.byType(CircularProgressIndicator),
+          );
+          final animation =
+              indicator.valueColor! as AlwaysStoppedAnimation<Color>;
+          expect(animation.value, equals(tokens.stateDanger));
+        },
+      );
+    }
+  });
+
+  group('BudgetHealthCard category status colors', () {
+    for (final brightness in Brightness.values) {
+      final modeName = brightness == Brightness.light ? 'light' : 'dark';
+      final tokens = AppThemeTokens.fromBrightness(brightness);
+
+      testWidgets(
+        'uses correct token colors for each category status ($modeName mode)',
+        (tester) async {
+          final health = BudgetHealth(
+            householdId: 'test',
+            periodStartUtc: '2026-03-01T00:00:00Z',
+            periodEndUtc: '2026-04-01T00:00:00Z',
+            overallScore: 72,
+            scoreBreakdown: const ScoreBreakdown(
+              adherenceScore: 75,
+              adherenceWeight: 0.40,
+              velocityScore: 65,
+              velocityWeight: 0.35,
+              billPaymentScore: 80,
+              billPaymentWeight: 0.25,
+            ),
+            categoryHealth: const [
+              CategoryHealth(
+                categoryId: 'cat-1',
+                categoryName: 'Groceries',
+                allocated: 900,
+                spent: 700,
+                status: 'OnTrack',
+              ),
+              CategoryHealth(
+                categoryId: 'cat-2',
+                categoryName: 'Entertainment',
+                allocated: 300,
+                spent: 280,
+                status: 'AtRisk',
+              ),
+              CategoryHealth(
+                categoryId: 'cat-3',
+                categoryName: 'Dining',
+                allocated: 400,
+                spent: 450,
+                status: 'OverBudget',
+              ),
+            ],
+          );
+
+          await tester
+              .pumpWidget(buildTestWidget(health, brightness: brightness));
+
+          // Find all status dot containers (8x8 circles)
+          final dotFinder = find.byWidgetPredicate(
+            (widget) =>
+                widget is Container &&
+                widget.constraints?.maxWidth == 8 &&
+                widget.constraints?.maxHeight == 8,
+          );
+          final dots = tester.widgetList<Container>(dotFinder).toList();
+          expect(dots.length, equals(3));
+
+          final dotColors = dots.map((dot) {
+            final decoration = dot.decoration! as BoxDecoration;
+            return decoration.color;
+          }).toList();
+
+          expect(dotColors[0], equals(tokens.stateSuccess));
+          expect(dotColors[1], equals(tokens.stateWarning));
+          expect(dotColors[2], equals(tokens.stateDanger));
+        },
+      );
+    }
   });
 }

--- a/mobile/test/component/insights/insights_dashboard_screen_test.dart
+++ b/mobile/test/component/insights/insights_dashboard_screen_test.dart
@@ -1,11 +1,19 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:money_tracker/app/theme/app_theme_tokens.dart';
 import 'package:money_tracker/features/insights/application/insights_controller.dart';
 import 'package:money_tracker/features/insights/presentation/insights_dashboard_screen.dart';
 
 void main() {
   Widget buildTestWidget(InsightsController controller) {
+    final theme = ThemeData.light().copyWith(
+      extensions: <ThemeExtension<dynamic>>[
+        AppThemeTokens.fromBrightness(Brightness.light),
+      ],
+    );
+
     return MaterialApp(
+      theme: theme,
       home: Scaffold(
         body: InsightsDashboardScreen(controller: controller),
       ),

--- a/mobile/test/component/insights/spending_trend_chart_test.dart
+++ b/mobile/test/component/insights/spending_trend_chart_test.dart
@@ -1,11 +1,23 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:money_tracker/app/theme/app_theme_tokens.dart';
 import 'package:money_tracker/features/insights/domain/spending_analysis.dart';
 import 'package:money_tracker/features/insights/presentation/widgets/spending_trend_chart.dart';
 
 void main() {
-  Widget buildTestWidget(List<CategorySpending> categories, String period) {
+  Widget buildTestWidget(
+    List<CategorySpending> categories,
+    String period, {
+    Brightness brightness = Brightness.light,
+  }) {
+    final theme = ThemeData(brightness: brightness).copyWith(
+      extensions: <ThemeExtension<dynamic>>[
+        AppThemeTokens.fromBrightness(brightness),
+      ],
+    );
+
     return MaterialApp(
+      theme: theme,
       home: Scaffold(
         body: SingleChildScrollView(
           child: SpendingTrendChart(
@@ -80,5 +92,38 @@ void main() {
       expect(find.text('Current'), findsOneWidget);
       expect(find.text('Previous'), findsOneWidget);
     });
+  });
+
+  group('SpendingTrendChart change-percent colors', () {
+    for (final brightness in Brightness.values) {
+      final modeName = brightness == Brightness.light ? 'light' : 'dark';
+      final tokens = AppThemeTokens.fromBrightness(brightness);
+
+      testWidgets(
+        'uses stateSuccess for negative change percent ($modeName mode)',
+        (tester) async {
+          const categories = [
+            CategorySpending(
+              categoryId: 'cat-1',
+              categoryName: 'Groceries',
+              currentSpent: 400,
+              previousSpent: 500,
+              changePercent: -20.0,
+            ),
+          ];
+
+          await tester.pumpWidget(
+            buildTestWidget(categories, '30d', brightness: brightness),
+          );
+
+          // Find the change-percent text widget
+          final changeTextFinder = find.text('-20.0%');
+          expect(changeTextFinder, findsOneWidget);
+
+          final textWidget = tester.widget<Text>(changeTextFinder);
+          expect(textWidget.style?.color, equals(tokens.stateSuccess));
+        },
+      );
+    }
   });
 }


### PR DESCRIPTION
## Summary
- Replace all hardcoded `Colors.green`, `Colors.orange`, `Colors.red`, and `Colors.grey` in `BudgetHealthCard` with `AppThemeTokens` semantic colors (`stateSuccess`, `stateWarning`, `stateDanger`, `contentMuted`).
- Replace `Colors.green` in `SpendingTrendChart._CategoryBar` with `tokens.stateSuccess`.
- Update test helpers in all three insights test files to register `AppThemeTokens` as a theme extension, and add color-assertion tests verifying correct token usage for each score bracket and category status in both light and dark mode.

Closes #104

## Files changed
| File | Change |
|------|--------|
| `budget_health_card.dart` | `_scoreColor` and `_statusColor` now accept `AppThemeTokens` parameter; `build()` resolves tokens via `AppThemeTokens.of(context)` |
| `spending_trend_chart.dart` | `_CategoryBar.build()` resolves tokens and uses `tokens.stateSuccess` for negative change percent |
| `budget_health_card_test.dart` | Updated `buildTestWidget` with theme extension; added 6 score-color tests + 2 category-status-color tests (light & dark) |
| `spending_trend_chart_test.dart` | Updated `buildTestWidget` with theme extension; added 2 change-percent color tests (light & dark) |
| `insights_dashboard_screen_test.dart` | Updated `buildTestWidget` to register `AppThemeTokens` so the integration test passes with the new token-dependent widgets |

## Test plan
- [x] `flutter analyze` passes with zero new issues
- [x] All 24 insights tests pass (`flutter test test/component/insights/`)
- [x] New color-assertion tests verify correct token for each score bracket (>=80, >=50, <50) in both light and dark mode
- [x] New tests verify correct token for each category status (OnTrack, AtRisk, OverBudget) in both light and dark mode
- [x] New tests verify `stateSuccess` is used for negative change percent in SpendingTrendChart in both light and dark mode
- [x] No hardcoded `Colors.green/orange/red/grey` remain in either widget file

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Replace hardcoded insight widget colors with theme tokens and ensure they respect light and dark mode.

Enhancements:
- Use AppThemeTokens semantic colors for budget health scores, category statuses, and spending trend change indicators instead of hardcoded Material colors.
- Resolve AppThemeTokens from context in insights widgets to align visuals with the global app theme across brightness modes.

Tests:
- Extend insights widget tests to register AppThemeTokens in themes and verify correct token-based colors for scores, category statuses, and change percentages in both light and dark mode.